### PR TITLE
03 16 add report slash command for easier reporting

### DIFF
--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -3,6 +3,9 @@ from discord.ext import commands
 from loguru import logger
 from modals import CubeDraftSelectionView, StakedCubeDraftSelectionView
 
+from session import DraftSession, MatchResult
+from views import MatchResultSelect
+
 class DraftCommands(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -24,6 +27,72 @@ class DraftCommands(commands.Cog):
         logger.info("Received stakedraft command")
         view = StakedCubeDraftSelectionView()
         await ctx.response.send_message("Select a cube for the staked draft:", view=view, ephemeral=True)
+
+    @discord.slash_command(
+        name='report', 
+        description='Report the result of your last unreported match',
+        guild_ids=None
+    )
+    async def report_match(self, ctx):
+        """Report the result of your latest unreported match"""
+        logger.info(f"Received report command from user {ctx.author.id}")
+        await ctx.response.defer(ephemeral=True)
+        
+        user_id = str(ctx.author.id)
+        channel_id = str(ctx.channel_id)
+        
+        # Get draft session by channel
+        draft_session = await DraftSession.get_by_channel_id(channel_id)
+        if not draft_session:
+            await ctx.followup.send("This command can only be used in active draft channels.", ephemeral=True)
+            return
+        
+        # Check if user is participating
+        if not draft_session.is_user_participating(user_id):
+            await ctx.followup.send("You are not a participant in this draft.", ephemeral=True)
+            return
+        
+        # Find unreported match for user
+        match = await MatchResult.find_unreported_for_user(draft_session.session_id, user_id)
+        if not match:
+            await ctx.followup.send("You don't have any unreported matches in this draft.", ephemeral=True)
+            return
+        
+        # Create match result UI
+        await self._send_match_result_selector(ctx, match, draft_session.session_id)
+
+    async def _send_match_result_selector(self, ctx, match, session_id):
+        """Create and send the match result selection UI."""
+        # Get player names
+        player1 = ctx.guild.get_member(int(match.player1_id))
+        player2 = ctx.guild.get_member(int(match.player2_id))
+        
+        if not player1 or not player2:
+            await ctx.followup.send("Could not find one or both players for this match.", ephemeral=True)
+            return
+            
+        player1_name = player1.display_name
+        player2_name = player2.display_name
+        
+        # Create the select menu
+        select_menu = MatchResultSelect(
+            bot=self.bot,
+            match_number=match.match_number,
+            session_id=session_id,
+            player1_name=player1_name,
+            player2_name=player2_name
+        )
+        
+        # Create a view and add the select menu
+        view = discord.ui.View()
+        view.add_item(select_menu)
+        
+        # Send the response with the select menu
+        await ctx.followup.send(
+            f"Report result for Match {match.match_number}: {player1_name} vs {player2_name}", 
+            view=view,
+            ephemeral=True
+        )
 
 def setup(bot):
     bot.add_cog(DraftCommands(bot))


### PR DESCRIPTION
## Overview
This PR adds a new `/report` command that allows users to report match results directly from draft channels. It also introduces a significant improvement to our database access patterns by implementing a context manager and adding model-based query methods.

## Changes

### 1. New `/report` Command
- Added a slash command that lets users report their match results from any draft channel
- Command automatically finds the user's earliest unreported match
- Uses the existing `MatchResultSelect` UI component for consistent user experience

### 2. Database Access Improvements
- Added `db_session()` context manager to handle session lifecycle and transaction management
- Implemented model-based query methods:
  - `DraftSession.get_by_channel_id()`
  - `DraftSession.get_by_session_id()`
  - `DraftSession.is_user_participating()`
  - `MatchResult.find_unreported_for_user()`

### 3. Code Organization
- Refactored database operations to follow the Active Record pattern
- Reduced code duplication and boilerplate in database access
- Improved command structure with clearer separation of concerns

## Benefits
- **User Experience**: Players can now report match results directly from their team channels
- **Code Quality**: Database operations are now more consistent and have less boilerplate
- **Maintainability**: Database queries are centralized in model classes
- **Error Handling**: Improved transaction management with automatic commits/rollbacks

## Testing
The `/report` command needs to be tested with:
- Multiple users in a draft
- Non-draft channels
- Users not participating in drafts