### PR TITLE
update pick timer to 60 based on feedback from LSV and others

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -95,6 +95,7 @@ class DraftSetupManager:
             await self.sio.emit('setDraftLogRecipients', "delayed")
             await self.sio.emit('setPersonalLogs', True)
             await self.sio.emit('teamDraft', True)  # Added teamDraft setting
+            await self.sio.emit('setPickTimer', 60)
             
             return True
             


### PR DESCRIPTION
Feedback from users indicated that they would prefer the default draft timer to be 60s instead of 75s. This change reflects that.