### PR TITLE
refactor winston draft command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,11 @@ async def main():
 
     @bot.event
     async def on_ready():
-        await bot.sync_commands()
+        try:
+            await bot.sync_commands()
+            logger.info("Successfully synced commands")
+        except Exception as e:
+            logger.error(f"Failed to sync commands: {e}")
         
         bot.loop.create_task(cleanup_sessions_task(bot))
         bot.loop.create_task(check_inactive_players_task(bot))

--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -10,15 +10,30 @@ class DraftCommands(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @discord.slash_command(name='startdraft', description='Start a team draft with random teams', guild_id=None)
+    # @commands.Cog.listener()
+    # async def on_application_command_error(self, ctx, error):
+    #     logger.error(f"Command error: {error}", exc_info=True)
+        
+    # # Add this to debug interaction handling
+    # @commands.Cog.listener()
+    # async def on_interaction(self, interaction):
+    #     logger.info(f"Received interaction: {interaction.data}")
+
+    @discord.slash_command(name='start_draft', description='Start a team draft with random teams', guild_ids=None)
     async def start_draft(self, ctx):
-        logger.info("Received startdraft command")
+        logger.info("Received start_draft command")
         view = CubeDraftSelectionView(session_type="random")
         await ctx.response.send_message("Select a cube:", view=view, ephemeral=True)
 
-    @discord.slash_command(name='premadedraft', description='Start a team draft with premade teams', guild_id=None)
+    @discord.slash_command(name='winston_draft', description='Start a winston draft', guild_ids=None)
+    async def winston_draft(self, ctx):
+        logger.info("Received winston_draft command")
+        view = CubeDraftSelectionView(session_type="winston")
+        await ctx.response.send_message("Select a cube:", view=view, ephemeral=True)
+
+    @discord.slash_command(name='premade_draft', description='Start a team draft with premade teams', guild_ids=None)
     async def premade_draft(self, ctx):
-        logger.info("Received premadedraft command")
+        logger.info("Received premade_draft command")
         view = CubeDraftSelectionView(session_type="premade")
         await ctx.response.send_message("Select a cube:", view=view, ephemeral=True)
         

--- a/commands.py
+++ b/commands.py
@@ -286,17 +286,6 @@ async def league_commands(bot):
 
     #         await interaction.response.send_message(embed=embed)
 
-    @bot.slash_command(name='winston_draft', description='Lists all available slash commands')
-    async def winstondraft(interaction: discord.Interaction):
-        from config import is_special_guild, get_config
-    
-        # Only allow this command in your guild
-        if not is_special_guild(interaction.guild_id):
-            await interaction.response.send_message("Winston draft is not available on this server.", ephemeral=True)
-            return
-        from utils import create_winston_draft
-        await create_winston_draft(bot, interaction)
-        await interaction.response.send_message("Queue posted in #winston-draft. Good luck!", ephemeral=True)
     # @bot.slash_command(name='commands', description='Lists all available slash commands')
     # async def list_commands(ctx):
     #     # Manually creating a list of commands and descriptions

--- a/modals.py
+++ b/modals.py
@@ -7,6 +7,7 @@ from models.session_details import SessionDetails
 
 from sessions import RandomSession, PremadeSession, SwissSession, BaseSession
 from sessions.staked_session import StakedSession
+from sessions.winston_session import WinstonSession
 
 class CubeDraftModal(discord.ui.Modal):
     @classmethod
@@ -64,10 +65,21 @@ class CubeDraftSelectionView(discord.ui.View):
     def __init__(self, session_type: str):
         super().__init__()
         self.session_type = session_type
-        
-        self.cube_select = discord.ui.Select(
-            placeholder="Select a Cube",
-            options=[
+        if session_type == "winston":
+            self.cube_select = discord.ui.Select(
+                placeholder="Select a Cube",
+                options=[
+                    discord.SelectOption(label="LSVWinston", value="LSVWinston"),
+                    discord.SelectOption(label="ChillWinston", value="ChillWinston"),
+                    discord.SelectOption(label="WinstonDeluxe", value="WinstonDeluxe"),
+                    discord.SelectOption(label="data", value="data"),
+                    discord.SelectOption(label="Custom Cube...", value="custom")
+                ]
+            )
+        else:
+            self.cube_select = discord.ui.Select(
+                placeholder="Select a Cube",
+                options=[
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
                 discord.SelectOption(label="modovintage", value="modovintage"),
@@ -96,6 +108,7 @@ def create_session_instance(session_type: str, session_details: SessionDetails) 
         "premade": PremadeSession,
         "swiss": SwissSession,
         'random': RandomSession,
+        "winston": WinstonSession
     }.get(session_type, BaseSession)
 
     return session_class(session_details)

--- a/sessions/winston_session.py
+++ b/sessions/winston_session.py
@@ -1,0 +1,21 @@
+from .base_session import BaseSession
+from discord import Embed, Color
+
+class WinstonSession(BaseSession):
+    def create_embed(self):
+        title = f"Looking for Players - Winston Draft <t:{self.session_details.draft_start_time}:R>"
+        description = (
+            "**How to use bot**:\n"
+            "1. Click sign up and join the draftmancer link (make sure you set up as a Winston Draft).\n"
+            "2. You will be notified after someone joins.\n"
+            f"{self.get_common_description()}"
+        )
+        embed = Embed(title=title, description=description, color=Color.brand_red())
+        embed.add_field(name="Sign-Ups", value="No players yet.", inline=False)
+
+        embed.set_thumbnail(url=self.get_thumbnail_url())
+  
+        return embed
+
+    def get_session_type(self):
+        return "winston"

--- a/utils.py
+++ b/utils.py
@@ -1337,48 +1337,6 @@ async def calculate_player_standings(limit=None):
             return embeds
         
 
-async def create_winston_draft(bot, interaction):
-    cubes = ["LSVWinston", "ChillWinston", "WinstonDeluxe"]
-    cube_name = random.choice(cubes)
-    draft_start_time = datetime.now().timestamp()
-    session_id = f"{interaction.user.id}-{int(draft_start_time)}"
-    guild = bot.get_guild(interaction.guild_id)
-    channel = discord.utils.get(guild.text_channels, name="winston-draft")
-    draft_id = ''.join(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') for _ in range(8))
-    draft_link = f"https://draftmancer.com/?session=DB{draft_id}"
-    embed_title = f"Looking for Players - Winston Draft"
-    embed_description = f"Click sign up below and join the draftmancer (make sure you set up as a Winston Draft). You will be notified after someone joins.\n\n**Chosen Cube: [{cube_name}](https://cubecobra.com/cube/list/{cube_name})** \n**Draftmancer Session**: **[Join Here]({draft_link})**"
-    embed = discord.Embed(title=embed_title, description=embed_description, color=discord.Color.brand_red())
-    embed.add_field(name="Sign-Ups", value="No players yet.", inline=False)
-    from views import PersistentView
-    view = PersistentView(
-            bot=bot,
-            draft_session_id=session_id,
-            session_type="winston"
-        )
-    message = await channel.send(embed=embed, view=view)
-    
-    async with AsyncSessionLocal() as db_session:
-        async with db_session.begin():
-            new_draft_session = DraftSession(
-                session_id=session_id,
-                guild_id=str(interaction.guild_id),
-                draft_link=draft_link,
-                draft_id=draft_id,
-                draft_start_time=datetime.now(),
-                deletion_time=datetime.now() + timedelta(hours=3),
-                session_type="winston",
-                premade_match_id=None,
-                team_a_name=None,
-                team_b_name=None,
-                tracked_draft=True,
-                cube=cube_name,
-                message_id=str(message.id),
-                draft_channel_id=message.channel.id
-            )
-            db_session.add(new_draft_session)
-
-
 async def validate_stakes(session_id, min_stake=10):
     """
     Validate that all players in a staked draft have entered stake information.

--- a/views.py
+++ b/views.py
@@ -9,7 +9,7 @@ from draft_organization.stake_calculator import calculate_stakes_with_strategy
 from session import StakeInfo, AsyncSessionLocal, get_draft_session, DraftSession, MatchResult
 from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
-from utils import calculate_pairings, create_winston_draft, generate_draft_summary_embed ,post_pairings, generate_seating_order, fetch_match_details, update_draft_summary_message, check_and_post_victory_or_draw, update_player_stats_and_elo, check_weekly_limits, update_player_stats_for_draft
+from utils import calculate_pairings, generate_draft_summary_embed ,post_pairings, generate_seating_order, fetch_match_details, update_draft_summary_message, check_and_post_victory_or_draw, update_player_stats_and_elo, check_weekly_limits, update_player_stats_for_draft
 from loguru import logger
 
 PROCESSING_ROOMS_PAIRINGS = {}
@@ -256,7 +256,6 @@ class PersistentView(discord.ui.View):
                     guild = self.bot.get_guild(int(interaction.guild_id))
                     channel = discord.utils.get(guild.text_channels, name="winston-draft")
                     await channel.send(f"Winston Draft Ready. Good luck in your match! {sign_up_tags}")
-                    await create_winston_draft(self.bot, interaction)
                 else:
                     guild = interaction.guild
                     message_link = f"https://discord.com/channels/{draft_session_updated.guild_id}/{draft_session_updated.draft_channel_id}/{draft_session_updated.message_id}"


### PR DESCRIPTION
# Add Winston Draft Command

## Changes
- Removed old inconsistent `winstondraft` command
- Added new `/winston_draft` command to align with other command naming conventions
- Updated cube selection list for Winston drafts to include:
  - LSVWinston
  - ChillWinston
  - WinstonDeluxe
  - data

## Implementation Details
- Updated command registration in `DraftCommands` cog
- Added Winston-specific cube options to `CubeDraftSelectionView`
- Ensured proper session type handling in session creation flow
- Maintained consistent error handling with other draft commands

## Testing
- Verified command registration and visibility in Discord
- Tested cube selection menu population
- Confirmed Winston draft session creation
- Validated session type handling

## Related
- Fixes inconsistent command naming
- Improves user experience with curated Winston cube list