### PR TITLE
refactor base draftmancer url

### DIFF
--- a/datacollections.py
+++ b/datacollections.py
@@ -12,6 +12,7 @@ from sqlalchemy.future import select
 from aiobotocore.session import get_session
 from session import AsyncSessionLocal, DraftSession
 from loguru import logger
+from config import get_draftmancer_base_url, get_draftmancer_websocket_url
 
 load_dotenv()
 
@@ -49,8 +50,9 @@ class DraftLogManager:
             self.first_connection = False
         while keep_running:
             try:
+                websocket_url = get_draftmancer_websocket_url(self.draft_id)
                 await self.sio.connect(
-                    f'wss://draftmancer.com?userID=DraftBot&sessionID=DB{self.draft_id}&userName=DraftBot',
+                    websocket_url,
                     transports='websocket',
                     wait_timeout=10)
                 
@@ -85,7 +87,8 @@ class DraftLogManager:
                 await asyncio.sleep(120)
 
     async def fetch_draft_log_data(self):
-        url = f"https://draftmancer.com/getDraftLog/DB{self.draft_id}"
+        base_url = get_draftmancer_base_url()
+        url = f"{base_url}/getDraftLog/DB{self.draft_id}"
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.get(url) as response:

--- a/league.py
+++ b/league.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from session import AsyncSessionLocal, Team, DraftSession, Match, Challenge, TeamRegistration, SwissChallenge
 from sqlalchemy import select, update, func
 import random
+from config import get_draftmancer_base_url, get_draftmancer_session_url
 
 
 class InitialRangeView(View):
@@ -490,7 +491,7 @@ class ChallengeTimeModal(Modal):
             draft_start_time = datetime.now().timestamp()
             session_id = f"{interaction.user.id}-{int(draft_start_time)}"
             draft_id = ''.join(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') for _ in range(8))
-            draft_link = f"https://draftmancer.com/?session=DB{draft_id}"
+            draft_link = f"{get_draftmancer_session_url(draft_id)}"
             async with AsyncSessionLocal() as session:
                 async with session.begin():
                     new_draft_session = DraftSession(
@@ -1047,7 +1048,7 @@ class ChallengeView(View):
                         draft_start_time = datetime.now().timestamp()
                         session_id = f"{interaction.user.id}-{int(draft_start_time)}"
                         draft_id = ''.join(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') for _ in range(8))
-                        draft_link = f"https://draftmancer.com/?session=DB{draft_id}"
+                        draft_link = get_draftmancer_session_url(draft_id)
 
                         new_draft_session = DraftSession(
                                             session_id=session_id,

--- a/models/session_details.py
+++ b/models/session_details.py
@@ -2,13 +2,14 @@ from datetime import datetime
 import random
 import discord
 from loguru import logger
+from config import get_draftmancer_session_url
 
 class SessionDetails:
     def __init__(self, interaction: discord.Interaction, draft_start_time=None):
         self.draft_start_time = draft_start_time or int(datetime.now().timestamp())
         self.session_id = f"{interaction.user.id}-{self.draft_start_time}"
         self.draft_id = ''.join(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') for _ in range(8))
-        self.draft_link = f"https://draftmancer.com/?session=DB{self.draft_id}"
+        self.draft_link = get_draftmancer_session_url(self.draft_id)
         self.guild_id = str(interaction.guild_id)
         self.cube_choice = None
         self.team_a_name = None

--- a/reconnect_drafts.py
+++ b/reconnect_drafts.py
@@ -5,6 +5,7 @@ from session import AsyncSessionLocal, DraftSession
 from datacollections import DraftLogManager
 from services.draft_setup_manager import DraftSetupManager
 from loguru import logger
+from config import get_draftmancer_draft_url
 
 async def reconnect_draft_setup_sessions(discord_client):
     """
@@ -114,7 +115,7 @@ async def reconnect_recent_draft_sessions(discord_client):
             logger.info(f"Session {session.session_id} (type: {session.session_type}) started {hours_since_start:.1f} hours ago")
             
             # Create draft link for reference
-            draft_link = f"https://draftmancer.com/draft/DB{session.draft_id}"
+            draft_link = get_draftmancer_draft_url(session.draft_id)
             
             try:
                 # Create a new DraftLogManager for this session

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -3,6 +3,7 @@ import socketio
 from loguru import logger
 from functools import wraps
 import random
+from config import get_draftmancer_websocket_url
 
 def exponential_backoff(max_retries=10, base_delay=1):
     def decorator(func):
@@ -141,9 +142,11 @@ class DraftSetupManager:
     async def keep_connection_alive(self):
         self.logger.info(f"Starting connection task for draft_id: DB{self.draft_id}")
         try:
+            websocket_url = get_draftmancer_websocket_url(self.draft_id)
+            
             # Connect to the websocket
             await self.sio.connect(
-                f'wss://draftmancer.com?userID=DraftBot&sessionID=DB{self.draft_id}&userName=DraftBot',
+                websocket_url,
                 transports='websocket',
                 wait_timeout=10
             )


### PR DESCRIPTION
# Refactor Draftmancer URL Configuration

## Changes
- Centralized Draftmancer URL configuration by introducing a base URL constant
- Added helper functions for generating different types of Draftmancer URLs
- Updated all hardcoded Draftmancer URLs to use the new configuration system
- Set default environment to beta.draftmancer.com

## Technical Details
- Added `DRAFTMANCER_BASE_URL` constant in `config.py`
- Created new helper functions:
  - `get_draftmancer_base_url()`
  - `get_draftmancer_session_url()`
  - `get_draftmancer_draft_url()`
  - `get_draftmancer_websocket_url()`
- Updated URL references across multiple files:
  - `datacollections.py`
  - `league.py`
  - `models/session_details.py`
  - `reconnect_drafts.py`
  - `services/draft_setup_manager.py`

## Benefits
- Easier environment switching (prod/beta/dev)
- Reduced code duplication
- More maintainable URL management
- Consistent URL generation across the application

## Testing
- Verify all draft links are generated correctly
- Ensure websocket connections work properly
- Confirm draft log fetching functions as expected