### PR TITLE
display personalized draft links

### DIFF
--- a/league.py
+++ b/league.py
@@ -1070,7 +1070,7 @@ class ChallengeView(View):
                         embed_title = f"AlphaFrog Prelims: Scheduled Queue Opened <t:{int(draft_start_time)}:R>"
                         embed = discord.Embed(title=embed_title,
                             description="Swiss 8 player draft. Draftmancer host must still update the draftmanacer session with the chosen cube. Turn off randomized seating." +
-                            f"\n\n**Weekly Cube: [{challenge.cube}](https://cubecobra.com/cube/list/{challenge.cube})** \n**Draftmancer Session**: **[Join Here]({draft_link})**",
+                            f"\n\n**Weekly Cube: [{challenge.cube}](https://cubecobra.com/cube/list/{challenge.cube})**\n*Click 'Sign Up' to get your personalized draft link*",
                             color=discord.Color.dark_gold()
                             )
                         sign_up_count = len(new_draft_session.sign_ups)

--- a/sessions/base_session.py
+++ b/sessions/base_session.py
@@ -119,6 +119,8 @@ class BaseSession:
         return (
             f"\n\n**Chosen Cube: [{self.session_details.cube_choice}]"
             f"(https://cubecobra.com/cube/list/{self.session_details.cube_choice})**\n\n"
+            # Note: We don't include a generic draft link here anymore
+            # Each user will get their own personalized link when they sign up
         )
 
     def get_thumbnail_url(self):

--- a/utils.py
+++ b/utils.py
@@ -767,9 +767,14 @@ async def send_channel_reminders(bot, session_id):
             stmt = select(DraftSession).where(DraftSession.session_id == session_id)
             result = await db_session.execute(stmt)
             session = result.scalars().first()
-    # Format the mention string and construct the reminder message
-    mentions = " ".join([f"<@{user_id}>" for user_id in session.sign_ups])
-    reminder_message = f"{mentions}\nReminder: Your scheduled draft starts in 15 minutes! Join here: {session.draft_link}"
+    # Format personalized reminders for each user
+    user_reminders = []
+    for user_id, display_name in session.sign_ups.items():
+        user_link = session.get_draft_link_for_user(display_name)
+        user_reminders.append(f"<@{user_id}> - [Your personalized draft link]({user_link})")
+    
+    # Create the reminder message with personalized links
+    reminder_message = "Reminder: Your scheduled draft starts in 15 minutes!\n" + "\n".join(user_reminders)
 
     # Fetch the channel and send the reminder
     guild = bot.get_guild(int(session.guild_id))


### PR DESCRIPTION
# Enhance Draft Link Personalization

## Changes
- Removed generic draft links from initial session embeds
- Added personalized draft links for each user in various UI components
- Updated reminder system to send personalized draft links
- Enhanced ready check system with personalized links

## Technical Details
- Modified `BaseSession` to remove generic draft link from common description
- Updated `generate_ready_check_embed` to support personalized links
- Enhanced channel embeds to display personalized links for each user
- Updated reminder system in `utils.py` to send individual links
- Modified league challenge view to use personalized links

## UI Improvements
- Added "Your Personalized Draft Links" field in ready check embeds
- Updated team announcement embeds with personalized links
- Enhanced reminder messages with clickable personalized links
- Improved Swiss draft queue messaging

## Benefits
- Better user experience with personalized draft links
- Clearer communication of draft access
- More organized presentation of draft links
- Reduced confusion about which link to use

## Testing
- Verify personalized links work in all session types
- Confirm reminder system sends correct personalized links
- Check ready check system displays personalized links correctly
- Ensure all embeds show personalized links appropriately
