### PR TITLE
04 09 remove obsolete buttons

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -183,7 +183,7 @@ class DraftSetupManager:
                     self.logger.error(f"Failed to set seating order after {self.seating_attempts} attempts")
                     await self.notify_seating_failure(missing_users)
 
-    @exponential_backoff(max_retries=1, base_delay=1)
+    @exponential_backoff(max_retries=10, base_delay=1)
     async def set_seating_order(self, desired_username_order):
         """
         Sets the seating order for the draft based on usernames.

--- a/sessions/swiss_session.py
+++ b/sessions/swiss_session.py
@@ -22,10 +22,6 @@ class SwissSession(BaseSession):
         """Provide a specific premade match ID for Swiss sessions."""
         return 9000
     
-    def get_session_buttons(self, view):
-        """Add Swiss-specific buttons."""
-        view.add_item(view.create_button("Generate Seating Order", "blurple", f"randomize_teams_{view.draft_session_id}", view.randomize_teams_callback))
-    
     async def create_draft_session(self, interaction, bot):
         """Use base class method to handle the creation of the draft session."""
         await super().create_draft_session(interaction, bot)

--- a/sessions/winston_session.py
+++ b/sessions/winston_session.py
@@ -15,10 +15,3 @@ class WinstonSession(BaseSession):
 
     def get_session_type(self):
         return "winston"
-        
-    def get_base_buttons(self, view):
-        """Override base buttons for winston drafts."""
-        view.add_item(view.create_button("Sign Up", "green", f"sign_up_{view.draft_session_id}", view.sign_up_callback))
-        view.add_item(view.create_button("Cancel Sign Up", "red", f"cancel_sign_up_{view.draft_session_id}", view.cancel_sign_up_callback))
-        view.add_item(view.create_button("Cancel Draft", "grey", f"cancel_draft_{view.draft_session_id}", view.cancel_draft_callback))
-        view.add_item(view.create_button("Remove User", "grey", f"remove_user_{view.draft_session_id}", view.remove_user_button_callback))


### PR DESCRIPTION
# DraftBot Improvements: Winston Draft Support and Connection Management

## Changes Overview
This PR introduces several improvements to the DraftBot system, focusing on Winston draft support and enhanced connection management.

### Major Changes
1. **Winston Draft Support**
   - Added a "Start Draft" button for Winston drafts
   - Implemented team formation and seating order management
   - Created personalized draft links for participants
   - Added visual team assignments (Red vs Blue teams)

2. **Connection Management Improvements**
   - Modified DraftBot to connect as a spectator instead of a player
   - Added connection state tracking with proper locking mechanisms
   - Improved user counting to exclude bot from player counts
   - Enhanced seating order management with retry logic

3. **Code Cleanup**
   - Removed obsolete buttons from Swiss and Winston session classes
   - Improved error handling and logging throughout the connection process
   - Added proper cleanup on disconnection

### Technical Details
- Added connection state tracking with `_connection_lock` and `_seating_lock`
- Implemented exponential backoff for seating order attempts
- Enhanced logging for better debugging and monitoring
- Added proper cleanup procedures for disconnection

### Testing Notes
- Winston drafts now require exactly 2 players
- DraftBot connects as a spectator and doesn't interfere with player seating
- Seating order is managed more reliably with proper locking
- Connection cleanup is more robust

### Breaking Changes
- Winston draft sessions now have a different button layout
- DraftBot no longer counts as a player in user counts
- Seating order management has been updated to handle spectator mode
