### PR TITLE
adding a script to cleanup merged branches

### DIFF
--- a/scripts/cleanup_merged_branches.sh
+++ b/scripts/cleanup_merged_branches.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Ensure we're up to date with the remote
+echo "Fetching latest changes from remote..."
+git fetch origin
+
+# Try to automatically determine the main remote and branch
+main_remote=""
+main_branch=""
+
+# Check if upstream exists
+if git remote | grep -q "^upstream$"; then
+    # Check if upstream has a main branch
+    if git ls-remote --heads upstream main >/dev/null; then
+        main_remote="upstream"
+        main_branch="main"
+    elif git ls-remote --heads upstream master >/dev/null; then
+        main_remote="upstream"
+        main_branch="master"
+    fi
+fi
+
+# If we couldn't find upstream with main/master, prompt user
+if [ -z "$main_remote" ]; then
+    echo "Please enter the name of the remote for the main repository (e.g., origin or upstream):"
+    read main_remote
+fi
+
+if [ -z "$main_branch" ]; then
+    echo "Please enter the name of the main branch (e.g., main or master):"
+    read main_branch
+fi
+
+# Update local reference to remote main branch
+echo "Using $main_remote/$main_branch as the reference branch"
+git fetch $main_remote $main_branch
+
+# Get all local branches
+branches=$(git branch | grep -v "^\*" | sed 's/^[[:space:]]*//')
+
+# Counter for deleted branches
+deleted=0
+
+echo "Checking branches that can be safely deleted..."
+
+for branch in $branches; do
+    # Skip the main branch itself
+    if [ "$branch" = "$main_branch" ]; then
+        continue
+    fi
+    
+    # Check if all commits in this branch are contained in the main branch
+    if git merge-base --is-ancestor "$branch" "$main_remote/$main_branch"; then
+        echo "Branch '$branch' is fully merged into $main_remote/$main_branch"
+        read -p "Delete this branch? (y/n): " confirm
+        if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+            git branch -D "$branch"
+            ((deleted++))
+            echo "Deleted branch: $branch"
+        else
+            echo "Skipped branch: $branch"
+        fi
+    fi
+done
+
+echo "Cleanup complete. Deleted $deleted branches."


### PR DESCRIPTION
# Add Branch Cleanup Script

## Description
This PR adds a new shell script `cleanup_merged_branches.sh` that helps maintain a clean git repository by identifying and removing branches that have been fully merged into the main branch.

## Features
- Automatically detects the main remote and branch (supports both `main` and `master` naming conventions)
- Falls back to user input if automatic detection fails
- Safely identifies branches that are fully merged into the main branch
- Interactive confirmation before deleting each branch
- Provides a summary of deleted branches at the end

## Usage
1. Make the script executable: `chmod +x scripts/cleanup_merged_branches.sh`
2. Run the script: `./scripts/cleanup_merged_branches.sh`
3. Follow the interactive prompts to confirm branch deletions

## Benefits
- Helps maintain a clean repository by removing unnecessary branches
- Prevents accidental deletion of unmerged branches
- Reduces repository clutter and improves organization
- Interactive confirmation ensures safe operation

## Technical Details
- Uses `git merge-base --is-ancestor` to safely determine if branches are fully merged
- Supports both `upstream` and `origin` as potential main remotes
- Compatible with both `main` and `master` branch naming conventions