### PR TITLE
add button to change cube

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,0 +1,16 @@
+
+# Define a mapping of cube names to thumbnail URLs
+# This is used for consistent cube thumbnails across the app
+CUBE_THUMBNAILS = {
+    "LSVCube": "https://cdn.discordapp.com/attachments/1239255966818635796/1348496824956354641/LSVCube.png?ex=67cfad08&is=67ce5b88&hm=16d3350410a3a4c87404c5e6fa1c8ce0408db78a6e841a9133fd69886a1a0db8&",
+    "LSVRetro": "https://cdn.discordapp.com/attachments/1239255966818635796/1348496825417470012/LSVRetro.png?ex=67cfad09&is=67ce5b89&hm=8d4d755e1e47993910f06f886f131b2f7930a8fff022db7651ca3e976d1582ce&",
+    "AlphaFrog": "https://cdn.discordapp.com/attachments/1097030242507444226/1348723563481530378/585x620-Gavin-Thompson-Exner-2022-Profile-removebg-preview.png?ex=67d08033&is=67cf2eb3&hm=2962b1159ffafce373de1a69e527ffceec86f085453695f3348ee518e3954674&",
+    "PowerMack": "https://cdn.discordapp.com/attachments/1097030242507444226/1348717924978004102/mac.png?ex=67d07af3&is=67cf2973&hm=c750d1ce62a06cc0aa0b224119b4d8a04e3c35e2933cb834f819a8a11061e4f8&"
+}
+
+# Default thumbnail for cubes that don't have a specific image
+DEFAULT_THUMBNAIL = "https://cdn.discordapp.com/attachments/1186757246936424558/1217295353972527176/131.png"
+
+def get_cube_thumbnail_url(cube_name):
+    """Get the thumbnail URL for a given cube name."""
+    return CUBE_THUMBNAILS.get(cube_name, DEFAULT_THUMBNAIL)

--- a/sessions/base_session.py
+++ b/sessions/base_session.py
@@ -2,6 +2,7 @@ from database.message_management import make_message_sticky
 from models.session_details import SessionDetails
 from session import DraftSession, AsyncSessionLocal
 from datetime import datetime, timedelta
+from helpers.utils import get_cube_thumbnail_url
 from views import PersistentView
 import discord
 from services.draft_setup_manager import DraftSetupManager
@@ -88,8 +89,12 @@ class BaseSession:
         # Add common Sign-Ups field
         embed.add_field(name="Sign-Ups", value="No players yet.", inline=False)
         
+        # Add a dedicated Cube field (easier to update in views.py)
+        cube_field_value = f"[{self.session_details.cube_choice}](https://cubecobra.com/cube/list/{self.session_details.cube_choice})"
+        embed.add_field(name="Cube:", value=cube_field_value, inline=True)
+        
         # Add thumbnail
-        embed.set_thumbnail(url=self.get_thumbnail_url())
+        embed.set_thumbnail(url=get_cube_thumbnail_url(self.session_details.cube_choice))
         
         return embed
 
@@ -115,26 +120,10 @@ class BaseSession:
                 await session.commit()
 
     def get_common_description(self):
-        """Generate common description parts for cube choice and draftmancer link."""
+        """Generate common description parts for draftmancer link."""
         return (
-            f"\n\n**Chosen Cube: [{self.session_details.cube_choice}]"
-            f"(https://cubecobra.com/cube/list/{self.session_details.cube_choice})**\n"
-            # Note: We don't include a generic draft link here anymore
+            "\n\n"  # Add some spacing for formatting
+            # Note: Cube information is now in a separate field
             # Each user will get their own personalized link when they sign up
-            f"**Draftmancer Link**: Click your username below to open your personalized link."
+            "**Draftmancer Link**: Click your username below to open your personalized link."
         )
-
-    def get_thumbnail_url(self):
-        """Get thumbnail URL based on cube choice."""
-        cube_choice = self.session_details.cube_choice
-        if cube_choice == "LSVCube":
-            return "https://cdn.discordapp.com/attachments/1239255966818635796/1348496824956354641/LSVCube.png?ex=67cfad08&is=67ce5b88&hm=16d3350410a3a4c87404c5e6fa1c8ce0408db78a6e841a9133fd69886a1a0db8&"
-        elif cube_choice == "LSVRetro":
-            return "https://cdn.discordapp.com/attachments/1239255966818635796/1348496825417470012/LSVRetro.png?ex=67cfad09&is=67ce5b89&hm=8d4d755e1e47993910f06f886f131b2f7930a8fff022db7651ca3e976d1582ce&"
-        elif cube_choice == "AlphaFrog":
-            return "https://cdn.discordapp.com/attachments/1097030242507444226/1348723563481530378/585x620-Gavin-Thompson-Exner-2022-Profile-removebg-preview.png?ex=67d08033&is=67cf2eb3&hm=2962b1159ffafce373de1a69e527ffceec86f085453695f3348ee518e3954674&"
-        elif cube_choice == "PowerMack":
-            return "https://cdn.discordapp.com/attachments/1097030242507444226/1348717924978004102/mac.png?ex=67d07af3&is=67cf2973&hm=c750d1ce62a06cc0aa0b224119b4d8a04e3c35e2933cb834f819a8a11061e4f8&"
-        else:
-            return "https://cdn.discordapp.com/attachments/1186757246936424558/1217295353972527176/131.png"
-

--- a/sessions/premade_session.py
+++ b/sessions/premade_session.py
@@ -3,36 +3,9 @@ import discord
 
 
 class PremadeSession(BaseSession):
-    def create_embed(self):
-        """Create an embed message for a premade draft session."""
-        session_details = self.session_details
-        title = f"{session_details.cube_choice} Premade Team Draft Queue - Started <t:{session_details.draft_start_time}:R>"
-        description = (
-            "\n**How to use bot**:\n"
-            "1. Click Team A or Team B to join that team. Enter the Draftmancer link. Draftmancer host still has to update settings and import from CubeCobra.\n"
-            "2. When all teams are joined, push Ready Check. Once everyone is ready, push Generate Seating Order.\n"
-            "3. Draftmancer host needs to adjust the table to match seating order. **TURN OFF RANDOM SEATING IN DRAFTMANCER**.\n"
-            "4. After the draft, come back to this message (it'll be in pins) and push Create Rooms and Post Pairings.\n"
-            "5. You will now have a private team chat with just your team and a shared draft chat that has pairings and match results. You can select the Match Results buttons to report results.\n"
-            "6. Chat channels will automatically close around five hours after the /startdraft command was used."
-            f"{self.get_common_description()}"
-        )
-        color = discord.Color.blue()
-        embed = discord.Embed(title=title, description=description, color=color)
-
-        embed.set_thumbnail(url=self.get_thumbnail_url())
-        
-        embed.add_field(
-            name=session_details.team_a_name or "Team A",
-            value="No players yet.",
-            inline=True,
-        )
-        embed.add_field(
-            name=session_details.team_b_name or "Team B",
-            value="No players yet.",
-            inline=True,
-        )
-        return embed
+    # Remove this method since it overrides the BaseSession.create_embed method
+    # Instead, just use the _create_embed_content method with the base class create_embed
+    # This method is redundant and causes confusion with initialization
 
     def get_session_type(self):
         """Return session type for premade sessions."""
@@ -51,7 +24,8 @@ class PremadeSession(BaseSession):
     def _create_embed_content(self):
         """Create an embed message for a premade draft session."""
         session_details = self.session_details
-        title = f"{session_details.cube_choice} Premade Team Draft Queue - Started <t:{session_details.draft_start_time}:R>"
+        # Remove the cube from the title since it's now in its own field
+        title = f"Premade Team Draft Queue - Started <t:{session_details.draft_start_time}:R>"
         description = (
             "\n**How to use bot**:\n"
             "1. Click Team A or Team B to join that team. Enter the Draftmancer link. Draftmancer host still has to update settings and import from CubeCobra.\n"

--- a/sessions/random_session.py
+++ b/sessions/random_session.py
@@ -3,7 +3,8 @@ from discord import Embed, Color
 
 class RandomSession(BaseSession):
     def _create_embed_content(self):
-        title = f"Looking for Players! {self.session_details.cube_choice} Random Team Draft - Queue Opened <t:{self.session_details.draft_start_time}:R>"
+        # Remove the cube from the title since it's now in its own field
+        title = f"Looking for Players! Random Team Draft - Queue Opened <t:{self.session_details.draft_start_time}:R>"
         description = (
             "**How to use bot**:\n"
             "1. Click sign up and click the draftmancer link.\n"

--- a/sessions/staked_session.py
+++ b/sessions/staked_session.py
@@ -12,7 +12,8 @@ class StakedSession(RandomSession):
         
     def _create_embed_content(self):
         """Create an embed message for a staked draft session."""
-        title = f"{self.session_details.cube_choice} Dynamic Money Draft! Minimum Bet: {self.session_details.min_stake} tix  "
+        # Remove the cube from the title since it's now in its own field
+        title = f"Dynamic Money Draft! Minimum Bet: {self.session_details.min_stake} tix"
         description = (
             f"Queue Opened <t:{self.session_details.draft_start_time}:R>\n\n"
             "**Dynamic Money Draft Queue**\n"

--- a/sessions/swiss_session.py
+++ b/sessions/swiss_session.py
@@ -5,7 +5,8 @@ class SwissSession(BaseSession):
     def _create_embed_content(self):
         """Create an embed message for a Swiss draft session."""
         session_details = self.session_details
-        title = f"AlphaFrog Prelims: Looking for Players! Queue Opened <t:{session_details.draft_start_time}:R>"
+        # Remove hardcoded cube reference in title
+        title = f"Swiss Draft: Looking for Players! Queue Opened <t:{session_details.draft_start_time}:R>"
         description = (
             "Swiss 8 player draft. Draftmancer host must still update the draftmancer session with the chosen cube."
             f"{self.get_common_description()}"


### PR DESCRIPTION
# Add Button to Change Cube

## Overview
This PR adds the ability to change the cube during an active draft session through a new "Update Cube" button. This feature allows draft organizers to switch cubes without having to restart the entire draft session.

## Key Changes
- Added a new "Update Cube" button to the draft interface
- Created a cube selection dropdown with predefined cube options
- Implemented cube thumbnail management through a new `helpers/utils.py` module
- Added cube update functionality to `DraftSetupManager`
- Improved embed message structure to better display cube information
- Added global manager registry to track active draft sessions

## Technical Details
- Created `CUBE_THUMBNAILS` mapping for consistent cube thumbnails
- Added `update_cube` method to `DraftSetupManager` for handling cube changes
- Implemented `CubeUpdateSelectionView` for cube selection UI
- Improved embed field management with helper functions
- Added proper error handling and user feedback for cube updates

## Testing
- [x] Verify cube selection dropdown works for different session types
- [x] Test cube update functionality during active drafts
- [x] Confirm thumbnail updates correctly
- [x] Verify database updates properly

## Notes
- The cube update feature maintains the draft state while changing the cube
- Thumbnails are now managed centrally through the `helpers/utils.py` module
- The UI has been improved to better display cube information in a dedicated field