### PR TITLE
Add Scrap Command and fix timeout timers

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -228,7 +228,7 @@ class DraftSetupManager:
             await self.update_draft_session_field('ready_check_message_id', str(message.id))
             
             # Start timeout timer
-            self.ready_check_timer = asyncio.create_task(self.ready_check_timeout(30, bot))
+            self.ready_check_timer = asyncio.create_task(self.ready_check_timeout(60, bot))
             
             # Emit ready check to Draftmancer
             await self.sio.emit('readyCheck')


### PR DESCRIPTION
# Add Draft Cancellation Vote Feature

### TL;DR

Added a `/scrap` command that allows draft participants to vote on canceling a paused draft, and improved the time display in ready checks.

### What changed?

- Added a new `/scrap` slash command that initiates a vote to cancel an ongoing draft
- Created a `ScrapVoteView` class to handle the voting UI and logic
- Improved time display in ready checks to use Discord's relative timestamp format (`<t:timestamp:R>`)
- Changed time tracking from `asyncio.get_event_loop().time()` to `datetime.now()`
- Extended the ready check timeout from 30 to 60 seconds
- Updated the pause command message to inform users about the `/scrap` option

### How to test?

1. Start a draft and use `/pause` to pause it
2. Use `/scrap` to initiate a cancellation vote
3. Have participants vote using the Yes/No buttons
4. Verify the vote passes if more than half vote yes
5. Verify the draft is canceled if the vote passes
6. Verify the improved timestamp display in ready checks

### Why make this change?

This feature allows draft participants to democratically decide whether to cancel a draft that may have stalled or encountered issues, rather than having to manually restart. The improved time display also makes it clearer when ready checks and votes will expire.