### PR TITLE
Add seating order verifiction or reset before ready check

### DIFF
--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -554,7 +554,7 @@ class DraftControlCog(commands.Cog):
             await ctx.followup.send(f"Transferring control to {requester_name} and disconnecting...", ephemeral=True)
             
             # Public message
-            await ctx.channel.send(f"🔄 **Mutiny!** {ctx.author.mention} is taking control of the draft. Bot disconnecting...")
+            await ctx.channel.send(f"https://tenor.com/view/mutiny-jack-sparrow-pirates-pirates-of-the-caribbean-i-wish-to-report-a-mutiny-gif-26531174 \n\n🔄 **Mutiny!** {ctx.author.mention} is taking control of the draft. Bot disconnecting...")
             
             # Set owner as player (required before transfer)
             await manager.sio.emit('setOwnerIsPlayer', True)


### PR DESCRIPTION
### TL;DR

Added a GIF to the mutiny command and implemented seating verification before ready checks.

### What changed?

- Added a Tenor GIF link to the mutiny command message for a more engaging user experience
- Implemented a new `verify_seating_order` method that runs before ready checks to ensure players are seated correctly
- The seating verification process:
  - Fetches the desired seating order from the database if not already stored
  - Checks if all expected users are present in the session
  - Forces a reset of the seating order to ensure correctness
  - Provides detailed error messages if verification fails

### How to test?

1. Test the mutiny command to see the Jack Sparrow GIF appear with the mutiny message
2. Test the ready check process with:
   - A complete set of players to verify seating works correctly
   - Missing players to see the appropriate error message
   - Incorrect seating order to confirm it gets reset properly

### Why make this change?

- The GIF adds personality and humor to the mutiny command
- The seating verification addresses a common issue where players would be seated incorrectly, causing draft problems
- By proactively checking and fixing seating before the ready check, we prevent drafts from starting with incorrect player order
- Detailed error messages help users understand what's wrong and how to fix it