### PR TITLE
fix for drafting variable on scrap success

### DIFF
--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -482,15 +482,20 @@ class DraftControlCog(commands.Cog):
                 if passed:
                     # Vote passed, cancel the draft
                     final_message = await ctx.channel.send("⚠️ **Vote passed!** Canceling draft in 5 seconds...")
+                    manager.drafting = False
                     await asyncio.sleep(5)
                     
                     # Send stopDraft command to Draftmancer
                     await manager.sio.emit('stopDraft')
                     
-                    await final_message.edit(content="🛑 **Draft canceled!** Use `/ready` to beging ready check for a new draft.")
+                    await final_message.edit(content=
+                                             "🛑 **Draft canceled!** \n" \
+                                            "Use `/ready` to begin a ready check for a new draft.\n" \
+                                            "Use `/mutiny` to remove the bot and take control of the session."
+                    )
                 else:
                     # Vote didn't pass
-                    await ctx.channel.send("🛑 **Vote to cancel draft did not pass.** Use `/unpause` to continue the draft.")
+                    await ctx.channel.send("🛑 **Vote to cancel draft did not pass.**\n Use `/unpause` to continue the draft.")
                 
                 # Clean up
                 if draft_session.session_id in ACTIVE_SCRAP_VOTES:


### PR DESCRIPTION
### TL;DR

Improved draft cancellation UX with clearer messaging and added `/mutiny` command reference.

### What changed?

- Set `manager.drafting = False` when a scrap vote passes
- Enhanced the draft cancellation message to include information about the `/mutiny` command
- Improved formatting of messages with line breaks for better readability
- Updated the failed vote message formatting

### How to test?

1. Start a draft session
2. Run the `/scrap` command to initiate a vote to cancel the draft
3. Verify that when the vote passes:
   - The draft is properly canceled
   - The final message includes information about both `/ready` and `/mutiny` commands
4. Verify that when the vote fails:
   - The message correctly instructs to use `/unpause` to continue

### Why make this change?

This change improves user experience by setting the drafting state correctly and providing clearer instructions to users after a draft is canceled. The addition of the `/mutiny` command reference gives users an alternative option to regain control of the session, making the system more flexible and user-friendly.