### PR TITLE
initial endDraft listener

### DIFF
--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -482,7 +482,10 @@ class DraftControlCog(commands.Cog):
                 if passed:
                     # Vote passed, cancel the draft
                     final_message = await ctx.channel.send("⚠️ **Vote passed!** Canceling draft in 5 seconds...")
+                        # Mark as cancelled BEFORE stopping the draft
+                    await manager.mark_draft_cancelled()
                     manager.drafting = False
+                    
                     await asyncio.sleep(5)
                     
                     # Send stopDraft command to Draftmancer


### PR DESCRIPTION
### TL;DR

Fixed draft cancellation logic and reduced pick timer to 1 second.

### What changed?

- Added a `draft_cancelled` flag to track when drafts are manually cancelled
- Added a handler for the `endDraft` event to properly detect when drafts end
- Modified the scrap command to mark drafts as cancelled before stopping them
- Added a `mark_draft_cancelled()` method to the DraftSetupManager
- Reduced the pick timer from 60 seconds to 1 second

### How to test?

1. Start a draft and use the scrap command to cancel it
2. Verify that the cancellation is properly handled without duplicate messages
3. Start a new draft and verify the pick timer is set to 1 second (TESTING ONLY)
4. Let a draft complete naturally and verify it's properly detected as completed

### Why make this change?

The previous implementation didn't properly distinguish between drafts that were manually cancelled and those that completed naturally.