### PR TITLE
add exception reporting to edit draft msg to team msg

### DIFF
--- a/views.py
+++ b/views.py
@@ -846,7 +846,10 @@ class PersistentView(discord.ui.View):
                         stake_view.add_item(StakeCalculationButton(session.session_id))
                         
                         # Use the new view instead of self
-                        await interaction.response.edit_message(embed=embed, view=stake_view)
+                        try:
+                            await interaction.response.edit_message(embed=embed, view=stake_view)
+                        except Exception as e:
+                            logger.error(f"Failed to update draft message: {e}")
                         
                         # Send the channel announcement after responding to the interaction
                         await interaction.channel.send(embed=channel_embed)
@@ -912,7 +915,10 @@ class PersistentView(discord.ui.View):
                     await db_session.commit()
         
             # Respond with the embed and updated view
-            await interaction.response.edit_message(embed=embed, view=self)
+            try:
+                 await interaction.response.edit_message(embed=embed, view=self)
+            except Exception as e:
+                logger.error(f"Failed to update draft message: {e}")
             
             # Send the channel announcement after responding to the interaction
             await interaction.channel.send(embed=channel_embed)


### PR DESCRIPTION
### TL;DR

Added error handling for Discord message update failures in team randomization.

### What changed?

Added try-except blocks around `interaction.response.edit_message()` calls in the `randomize_teams_callback` function to catch and log any exceptions that occur when updating Discord messages. This prevents the application from crashing when message updates fail.

### Why make this change?

Discord interactions can sometimes fail due to network issues, permission changes, or message deletion. This change improves application resilience by gracefully handling these failures instead of crashing, while also providing useful error logs for troubleshooting.