### PR TITLE
Add msg that updates when users join leave session

### DIFF
--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -53,6 +53,7 @@ class DraftSession(Base):
     should_ping = Column(Boolean, default=False)
     pack_first_picks = Column(JSON)
     draftmancer_role_users = Column(JSON)
+    status_message_id = Column(String, nullable=True)
     
     # Relationships
     match_results = relationship("MatchResult", back_populates="draft_session", 

--- a/update_schema.py
+++ b/update_schema.py
@@ -11,67 +11,52 @@ logger = logging.getLogger(__name__)
 # Database URL - should match your existing configuration
 DATABASE_URL = "sqlite+aiosqlite:///drafts.db"
 
-async def add_timeframe_columns():
-    """Add columns for timeframe view message IDs and timeframe settings to the leaderboard_messages table"""
+async def add_status_message_id_column():
+    """Add status_message_id column to the draft_sessions table"""
     engine = create_async_engine(DATABASE_URL, echo=True)
     
     try:
         async with engine.begin() as conn:
             # Check if the table exists
             result = await conn.execute(text(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='leaderboard_messages'"
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='draft_sessions'"
             ))
             
             table_exists = result.scalar() is not None
             
             if not table_exists:
-                logger.error("leaderboard_messages table does not exist. Please run create_leaderboard_messages_table first.")
+                logger.error("draft_sessions table does not exist. Make sure the database is properly initialized.")
                 return
             
             # Get current columns in the table
             result = await conn.execute(text(
-                "PRAGMA table_info(leaderboard_messages)"
+                "PRAGMA table_info(draft_sessions)"
             ))
             columns = {row[1] for row in result.fetchall()}
             
-            # Define new columns to add
-            new_columns = [
-                # View message ID columns
-                ('draft_record_view_message_id', String(64)),
-                ('match_win_view_message_id', String(64)),
-                ('drafts_played_view_message_id', String(64)),
-                ('time_vault_and_key_view_message_id', String(64)),
-                
-                # Timeframe setting columns
-                ('draft_record_timeframe', String(20)),
-                ('match_win_timeframe', String(20)),
-                ('drafts_played_timeframe', String(20)),
-                ('time_vault_and_key_timeframe', String(20))
-            ]
-            
-            # Add each column if it doesn't exist
-            for column_name, column_type in new_columns:
-                if column_name not in columns:
-                    logger.info(f"Adding column: {column_name}")
-                    await conn.execute(text(
-                        f"ALTER TABLE leaderboard_messages ADD COLUMN {column_name} {column_type}"
-                    ))
-                else:
-                    logger.info(f"Column {column_name} already exists")
+            # Add status_message_id column if it doesn't exist
+            if 'status_message_id' not in columns:
+                logger.info("Adding column: status_message_id")
+                await conn.execute(text(
+                    "ALTER TABLE draft_sessions ADD COLUMN status_message_id VARCHAR"
+                ))
+                logger.info("Successfully added status_message_id column to draft_sessions table")
+            else:
+                logger.info("Column status_message_id already exists")
                 
     except Exception as e:
-        logger.error(f"Error adding columns to leaderboard_messages table: {e}")
+        logger.error(f"Error adding status_message_id column to draft_sessions table: {e}")
         raise
     finally:
         await engine.dispose()
 
 async def migrate_database():
     """Execute all migration steps"""
-    logger.info("Starting database migration to add timeframe columns")
+    logger.info("Starting database migration to add status_message_id column")
     
     try:
-        # Add the new columns
-        await add_timeframe_columns()
+        # Add the new column
+        await add_status_message_id_column()
         
         logger.info("Database migration completed successfully")
     except Exception as e:


### PR DESCRIPTION
### TL;DR

Added Discord status message tracking for Draftmancer sessions to provide real-time updates on player presence.

### What changed?

- Added `status_message_id` column to the `DraftSession` model to store the ID of the status message
- Implemented status message functionality in `DraftSetupManager` that shows:
  - Players present in the Draftmancer session
  - Players who are missing
  - Any unexpected users who joined
  - Instructions for the draft process
- Added automatic status message updates when users join or leave the session
- Enhanced seating order logic to only proceed when all expected users are present
- Added more detailed error messages when ready checks or seating orders fail
- Created database migration script to add the new column


### Why make this change?

This change improves the user experience by providing clear, real-time feedback about who has joined the Draftmancer session. Previously, there was no easy way for players to know if everyone had joined or who was still missing, leading to confusion and delays. The status message also provides clear instructions on next steps, making the draft process more intuitive for users.