### PR TITLE
fix mocs name for random sessions

### DIFF
--- a/modals.py
+++ b/modals.py
@@ -82,7 +82,7 @@ class CubeDraftSelectionView(discord.ui.View):
                 options=[
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="APR25", value="APR25"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerMack", value="PowerMack"),
                 discord.SelectOption(label="Custom Cube...", value="custom")
@@ -142,7 +142,7 @@ class StakedCubeDraftSelectionView(discord.ui.View):
             options=[
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="MOCS Vintage Cube", value="APR25"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerMack", value="PowerMack"),
                 discord.SelectOption(label="Custom Cube...", value="custom")


### PR DESCRIPTION
### TL;DR

Updated the display name for the APR25 cube option in dropdown menus.

### What changed?

Changed the label for the APR25 cube option from "APR25" to "2025 MOCS Vintage Cube" in one location and from "MOCS Vintage Cube" to "2025 MOCS Vintage Cube" in another location. The value remains "APR25" in both instances.

### Why make this change?

This change provides a more descriptive and consistent label for the APR25 cube across the application, making it clearer to users what this cube option represents. The standardized naming improves user experience by using the official cube name rather than an internal code.