### PR TITLE
remove queues due to inactivity

### DIFF
--- a/sessions/base_session.py
+++ b/sessions/base_session.py
@@ -69,7 +69,7 @@ class BaseSession:
             draft_link=self.session_details.draft_link,
             draft_id=self.session_details.draft_id,
             draft_start_time=datetime.fromtimestamp(self.session_details.draft_start_time),
-            deletion_time=datetime.fromtimestamp(self.session_details.draft_start_time) + timedelta(days=3),
+            deletion_time=datetime.now() + timedelta(minutes=90),
             session_type=self.get_session_type(),
             premade_match_id=self.get_premade_match_id(),
             team_a_name=self.session_details.team_a_name,

--- a/views.py
+++ b/views.py
@@ -310,7 +310,11 @@ class PersistentView(discord.ui.View):
                     }
                     if should_ping:
                         values_to_update["should_ping"] = True
-                        
+
+                    # Reset the inactivity timer when a user signs up (if still in initial queue)
+                    if not draft_session.session_stage:
+                        values_to_update["deletion_time"] = datetime.now() + timedelta(minutes=90)
+
                     # Update the draft session in the database
                     await session.execute(
                         update(DraftSession).
@@ -2546,7 +2550,11 @@ class StakeOptionsSelect(discord.ui.Select):
                 }
                 if should_ping:
                     values_to_update["should_ping"] = True
-                
+
+                # Reset the inactivity timer when a user signs up (if still in initial queue)
+                if not draft_session.session_stage:
+                    values_to_update["deletion_time"] = datetime.now() + timedelta(minutes=90)
+
                 await session.execute(
                     update(DraftSession).
                     where(DraftSession.session_id == self.draft_session_id).


### PR DESCRIPTION
# Auto-cancel inactive draft queues after 90 minutes

### TL;DR
Adds functionality to automatically cancel draft queues that have been inactive for 90 minutes.

### What changed?
- Changed the deletion time for new draft sessions from 3 days after start to 90 minutes from creation
- Added logic to reset the deletion timer whenever a user signs up for a draft
- Implemented cleanup logic to cancel and remove inactive draft queues
- Increased the frequency of the cleanup task from hourly to every 10 minutes

### How to test?
1. Create a new draft queue
2. Verify that no users sign up for 90 minutes
3. Confirm the queue is automatically cancelled with a message indicating inactivity
4. Create another queue and have a user sign up after 80 minutes
5. Verify the queue remains active for another 90 minutes

### Why make this change?
This change prevents stale draft queues from lingering in channels when there's insufficient interest. By automatically cancelling inactive queues, we keep channels cleaner and make it easier for users to focus on active drafts.