### PR TITLE
bug fix for deleting stale sessions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -796,11 +796,11 @@ async def cleanup_sessions_task(bot):
                         draft_channel = bot.get_channel(int(session.draft_channel_id))
                         if draft_channel:
                             try:
-                                # Send cancellation notification
-                                await draft_channel.send(f"Queue for Draft-{session.draft_id} has been cancelled due to inactivity (no new signups for 90 minutes).")
-                                
                                 # Delete the original message
                                 msg = await draft_channel.fetch_message(int(session.message_id))
+                                if msg:
+                                    # Send cancellation notification
+                                    await draft_channel.send(f"Queue for Draft-{session.draft_id} has been cancelled due to inactivity (no new signups for 90 minutes).")
                                 await msg.delete()
                                 logger.info(f"Cancelled inactive queue for session {session.session_id} (Draft-{session.draft_id})")
                             except discord.NotFound:


### PR DESCRIPTION
### TL;DR

Fixed a bug in the queue cancellation process to prevent sending notifications when the original message can't be found.

### What changed?

Modified the `cleanup_sessions_task` function to check if the original message exists before sending a cancellation notification. Now the notification is only sent if the message is successfully fetched, preventing potential errors when the original message has already been deleted.

### How to test?

1. Create a draft queue and let it become inactive (90 minutes without new signups)
2. Manually delete the original queue message before the cleanup task runs
3. Verify that no cancellation notification is sent when the original message is missing
4. Create another draft queue, let it become inactive, and verify that the cancellation notification works correctly when the message exists

### Why make this change?

This change prevents unnecessary error messages and improves the robustness of the cleanup process. Previously, the bot would attempt to send a cancellation notification before confirming the original message exists, which could lead to confusing behavior if the message had already been deleted.