### PR TITLE
second fix for cleanup logic

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -801,8 +801,8 @@ async def cleanup_sessions_task(bot):
                                 if msg:
                                     # Send cancellation notification
                                     await draft_channel.send(f"Queue for Draft-{session.draft_id} has been cancelled due to inactivity (no new signups for 90 minutes).")
-                                await msg.delete()
-                                logger.info(f"Cancelled inactive queue for session {session.session_id} (Draft-{session.draft_id})")
+                                    await msg.delete()
+                                    logger.info(f"Cancelled inactive queue for session {session.session_id} (Draft-{session.draft_id})")
                             except discord.NotFound:
                                 # If the message is not found, silently continue
                                 pass


### PR DESCRIPTION
### TL;DR

Fixed a bug in the queue cancellation notification logic by properly indenting code blocks.

### What changed?

Fixed an indentation issue in the `cleanup_sessions_task` function where the `msg.delete()` and `logger.info()` calls were incorrectly indented. These operations are now properly nested inside the `if msg:` condition, ensuring they only execute when a message exists.


### Why make this change?

The previous indentation caused the code to attempt to delete messages and log information even when no message existed (`msg` was None), potentially leading to errors. This fix ensures these operations only run when a valid message is available, preventing potential exceptions.