### PR TITLE
change to draftmancer production

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ SPECIAL_GUILD_ID = "336345350535118849"
 
 # Base URL for Draftmancer service
 # Change this to switch between environments (prod, beta, dev)
-DRAFTMANCER_BASE_URL = "https://beta.draftmancer.com"
+DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
 class Config:
     def __init__(self):


### PR DESCRIPTION
### TL;DR

Updated the Draftmancer base URL from beta to production.

### What changed?

Changed `DRAFTMANCER_BASE_URL` from `https://beta.draftmancer.com` to `https://draftmancer.com`, switching the application from using the beta environment to the production environment.

### How to test?

1. Run the application with the updated configuration
2. Verify that API calls are correctly routing to the production environment
3. Confirm that all functionality works as expected with the production endpoint

### Why make this change?

The beta testing phase has concluded, and the application is now ready to use the production environment. This change ensures users interact with the stable production API rather than the beta testing environment.