### PR TITLE
fix to db crashes on log collection

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1865,7 +1865,7 @@ class DraftSetupManager:
             
             # Continue with log collection as before
             if not self.logs_collection_attempted and not self.logs_collection_in_progress:
-                asyncio.create_task(self.schedule_log_collection(5))
+                asyncio.create_task(self.schedule_log_collection(60))
             
             return True
         except Exception as e:


### PR DESCRIPTION
### TL;DR

Increased the delay before log collection from 5 to 60 seconds.

### What changed?

Modified the `schedule_log_collection` delay parameter in the `on_draft_log_response` method from 5 seconds to 60 seconds, giving the system more time before attempting to collect logs.

### How to test?

1. Trigger a draft log response scenario
2. Verify that log collection now starts after a 60-second delay instead of 5 seconds
3. Confirm that the logs are still collected correctly despite the longer delay

### Why make this change?

The increased delay likely provides more time for all relevant logs to be generated and stabilized before collection begins. This could improve the completeness of collected logs and reduce the chance of missing important information that might appear shortly after the initial response.