### PR TITLE
refactor for cleanliness

### DIFF
--- a/cube_views/CubeSelectionView.py
+++ b/cube_views/CubeSelectionView.py
@@ -1,0 +1,36 @@
+import discord
+
+class CubeUpdateSelectionView(discord.ui.View):
+    """Selection view for updating cubes, to avoid circular imports with modals.py"""
+    def __init__(self, session_type: str):
+        super().__init__()
+        self.session_type = session_type
+        
+        # Define cube options by type
+        cube_options = {
+            "winston": [
+                discord.SelectOption(label="LSVWinston", value="LSVWinston"),
+                discord.SelectOption(label="ChillWinston", value="ChillWinston"),
+                discord.SelectOption(label="WinstonDeluxe", value="WinstonDeluxe"),
+                discord.SelectOption(label="data", value="data")
+            ],
+            "default": [
+                discord.SelectOption(label="LSVCube", value="LSVCube"),
+                discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
+                discord.SelectOption(label="LSVRetro", value="LSVRetro"),
+                discord.SelectOption(label="PowerMack", value="PowerMack")
+            ]
+        }
+        
+        # Get the appropriate options for this session type
+        options = cube_options.get(session_type, cube_options["default"])
+        
+        # Create the select dropdown with those options
+        self.cube_select = discord.ui.Select(
+            placeholder="Select a Cube",
+            options=options
+        )
+        
+        # We'll set the callback later in the update_cube_callback method
+        self.add_item(self.cube_select)

--- a/views.py
+++ b/views.py
@@ -12,46 +12,13 @@ from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
 from helpers.utils import get_cube_thumbnail_url
 from utils import calculate_pairings, get_formatted_stake_pairs, generate_draft_summary_embed ,post_pairings, generate_seating_order, fetch_match_details, split_into_teams, update_draft_summary_message, check_and_post_victory_or_draw, update_player_stats_and_elo, check_weekly_limits, update_player_stats_for_draft
+from cube_views.CubeSelectionView import CubeUpdateSelectionView
 from loguru import logger
 
 READY_CHECK_COOLDOWNS = {}
 PROCESSING_ROOMS_PAIRINGS = {}
 sessions = {}
 
-class CubeUpdateSelectionView(discord.ui.View):
-    """Selection view for updating cubes, to avoid circular imports with modals.py"""
-    def __init__(self, session_type: str):
-        super().__init__()
-        self.session_type = session_type
-        
-        # Define cube options by type
-        cube_options = {
-            "winston": [
-                discord.SelectOption(label="LSVWinston", value="LSVWinston"),
-                discord.SelectOption(label="ChillWinston", value="ChillWinston"),
-                discord.SelectOption(label="WinstonDeluxe", value="WinstonDeluxe"),
-                discord.SelectOption(label="data", value="data")
-            ],
-            "default": [
-                discord.SelectOption(label="LSVCube", value="LSVCube"),
-                discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
-                discord.SelectOption(label="LSVRetro", value="LSVRetro"),
-                discord.SelectOption(label="PowerMack", value="PowerMack")
-            ]
-        }
-        
-        # Get the appropriate options for this session type
-        options = cube_options.get(session_type, cube_options["default"])
-        
-        # Create the select dropdown with those options
-        self.cube_select = discord.ui.Select(
-            placeholder="Select a Cube",
-            options=options
-        )
-        
-        # We'll set the callback later in the update_cube_callback method
-        self.add_item(self.cube_select)
 
 class PersistentView(discord.ui.View):
 


### PR DESCRIPTION
# Refactor Cube Selection View for Better Code Organization

## Changes
- Moved `CubeUpdateSelectionView` class from `views.py` to a new dedicated module `cube_views/CubeSelectionView.py`
- Created an empty `__init__.py` in the `cube_views` directory to make it a proper Python package
- Updated imports in `views.py` to reference the new location of `CubeUpdateSelectionView`

## Why
This refactoring improves code organization by:
- Separating cube-related view logic into its own module
- Reducing the size of `views.py` which was becoming quite large
- Making the codebase more modular and easier to maintain
- Following the principle of separation of concerns

## Testing
- The functionality remains exactly the same, just moved to a new location
- All existing cube selection features should continue to work as before