### PR TITLE
adjustment to bet logic for proportional approach

### DIFF
--- a/draft_organization/stake_calculator.py
+++ b/draft_organization/stake_calculator.py
@@ -1113,24 +1113,19 @@ class OptimizedStakeCalculator:
             else:
                 above_min_players.append((player_id, max_stake))
         
-        # Step 2: For above_min_players, cap bets based on theoretical maximum allocation
+        # Step 2: For above_min_players, cap bets based on highest bet on min team
         if above_min_players and min_team:
-            # Calculate the theoretical max a single player could be allocated
-            min_team_count = len(min_team)
-            min_team_total_stakes = sum(stake for _, stake in min_team)
+            # Find the highest bet on the min team
+            highest_min_team_bet = max(stake for _, stake in min_team) if min_team else min_stake
             
-            # Formula: Min team total - ((min_team_count - 1) * min_stake)
-            theoretical_max = min_team_total_stakes - ((min_team_count - 1) * min_stake)
-            theoretical_max = max(theoretical_max, min_stake)  # Ensure at least min_stake
+            stake_logger.info(f"Highest min team bet: {highest_min_team_bet}")
             
-            stake_logger.info(f"Theoretical max bet: {theoretical_max} (min team total: {min_team_total_stakes}, players: {min_team_count})")
-            
-            # Iterate through above_min_players and cap any whose bet exceeds theoretical_max
+            # Iterate through above_min_players and cap any whose bet exceeds highest_min_team_bet
             for i in range(len(above_min_players)):
                 player_id, max_stake = above_min_players[i]
-                if max_stake > theoretical_max:
-                    above_min_players[i] = (player_id, theoretical_max)
-                    stake_logger.info(f"Capped bettor {player_id} from {max_stake} to {theoretical_max}")
+                if max_stake > highest_min_team_bet:
+                    above_min_players[i] = (player_id, highest_min_team_bet)
+                    stake_logger.info(f"Capped bettor {player_id} from {max_stake} to {highest_min_team_bet}")
         
         # Step 3: Calculate total allocated to min stake players
         min_stake_allocation = sum(min(stake, min_stake) for _, stake in min_stake_players)


### PR DESCRIPTION
### TL;DR

Changed the stake capping algorithm to use the highest bet on the minimum team instead of a theoretical maximum calculation.

### What changed?

- Modified the stake capping algorithm in `calculate_stakes()` to use the highest bet on the minimum team as the cap for maximum team bets
- Previously, we calculated a "theoretical maximum" based on the formula: `min_team_total - ((min_team_count - 1) * min_stake)`
- Now, we simply find the highest bet on the minimum team and use that as the cap
- Updated the explanation generation in `views.py` to reflect this new approach in the UI

### How to test?

1. Create a draft with uneven betting between teams
2. Verify that maximum team bets are capped at the highest minimum team bet
3. Check that the explanation text correctly describes the new capping approach
4. Confirm that the proportional allocation still works correctly with the new capping method

### Why make this change?

The previous "theoretical maximum" calculation could produce unintuitive results in certain scenarios. Using the highest minimum team bet as the cap is more straightforward and fair, as it ensures no player on the maximum team can bet more than the highest bettor on the minimum team. This creates a more balanced betting environment while still allowing for proportional allocation of stakes.