### PR TITLE
fix to custom cube input  in normal servers

### DIFF
--- a/modals.py
+++ b/modals.py
@@ -49,10 +49,10 @@ class CubeDraftModal(discord.ui.Modal):
         details: SessionDetails = SessionDetails(interaction)
         
         # If custom cube, get name from input, otherwise use preset choice
-        if hasattr(self, 'cube_choice'):
-            details.cube_choice = self.cube_choice
-        else:
+        if self.cube_choice == "custom":
             details.cube_choice = self.children[0].value
+        else:
+            details.cube_choice = self.cube_choice
 
         if self.session_type == "premade":
             input_offset = 0 if hasattr(self, 'cube_choice') else 1


### PR DESCRIPTION
### TL;DR

Fixed a bug in the session configuration logic for custom cube selection.

### What changed?

Updated the cube choice logic in `configure_session_details` to properly handle custom cube selections. Instead of checking if the `cube_choice` attribute exists, the code now explicitly checks if the cube choice is "custom" to determine whether to use the input value or the preset choice.

### How to test?

1. Create a session with a custom cube and verify the cube name is correctly saved
2. Create a session with a preset cube and verify the preset name is correctly saved
3. Test both premade and custom session types to ensure the cube selection works in both scenarios

### Why make this change?

The previous implementation had a logic error where it was checking for the existence of an attribute rather than the actual value of the selection. This could lead to incorrect cube choices being saved when users selected custom cubes, potentially causing confusion or errors in session creation.