### PR TITLE
more logging for session stage

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -259,7 +259,7 @@ class DraftSetupManager:
                  self.users_count >= self.expected_user_count and
                  self.expected_user_count > 0)):
                 
-                self.logger.info(f"Reached expected user count or need to reset seating! Attempting seating order")
+                self.logger.info(f"Reached expected user count or need to reset seating! Attempting seating order. on_session_users")
                 await self.check_session_stage_and_organize()
                 return
             
@@ -269,6 +269,7 @@ class DraftSetupManager:
                 (current_time - self.last_db_check_time).total_seconds() > self.db_check_cooldown):
                 
                 self.last_db_check_time = current_time
+                self.logger.info("check session stage from on_session_users")
                 await self.check_session_stage_and_organize()
 
         @self.sio.on('storedSessionSettings')
@@ -1888,6 +1889,7 @@ class DraftSetupManager:
                                 (current_time - self.last_db_check_time).total_seconds() > self.db_check_cooldown):
                                 
                                 self.last_db_check_time = current_time
+                                self.logger("check session stage from keep connection alive for user count >= expected user count")
                                 await self.check_session_stage_and_organize()
                                     
                         # Try to emit getUsers regularly for accurate counts
@@ -2289,7 +2291,7 @@ class DraftSetupManager:
                     
                 # If we now have all expected users, check seating order
                 if not missing_users and self.users_count >= self.expected_user_count:
-                    self.logger.info("All expected users are now present, checking seating order")
+                    self.logger.info("All expected users are now present, checking seating order. checking session stage from update_status_message_after_user_change")
                     await self.check_session_stage_and_organize()
                     
             except Exception as e:

--- a/views.py
+++ b/views.py
@@ -1101,6 +1101,7 @@ class PersistentView(discord.ui.View):
                             logger.info(f"Set bot instance on manager to ensure Discord messaging works")
                             
                             # Manager exists, force a check of session stage
+                            logger.info("Check Session Stage from randomize teams callback for staked draft")
                             await manager.check_session_stage_and_organize()
                             
                             # Also force a refresh of users to ensure accurate count
@@ -1152,6 +1153,7 @@ class PersistentView(discord.ui.View):
                 logger.info(f"TEAMS CREATED: Manager state - Seating set: {manager.seating_order_set}, "
                         f"Users count: {manager.users_count}, Expected count: {manager.expected_user_count}")
                 # Manager exists, force a check of session stage
+                logger.info("Check session from randomize teams normal draft")
                 await manager.check_session_stage_and_organize()
                 
                 # Also force a refresh of users to ensure accurate count


### PR DESCRIPTION
### TL;DR

Added detailed logging for session stage checks to improve debugging of draft seating issues.

### What changed?

Enhanced logging in the draft setup manager by adding more specific log messages when `check_session_stage_and_organize()` is called from different locations:

- Added context to the log message in `on_session_users` when reaching expected user count
- Added a new log message when checking session stage from `on_session_users` during cooldown checks
- Added a log message in `keep_connection_alive` when checking session stage
- Added more context to the log in `update_status_message_after_user_change`
- Added logging in `views.py` for both staked and normal draft scenarios in the `randomize_teams_callback`

### How to test?

1. Create a draft session and observe the logs
2. Test different scenarios that trigger session stage checks:
   - When users join and reach expected count
   - During the keep-alive cycle
   - When randomizing teams
   - After user changes
3. Verify the logs show the specific context of where each check was triggered from

### Why make this change?

This change improves debugging capabilities by providing more context about when and where session stage checks are being triggered. This will help identify the source of potential issues with draft seating and organization, making it easier to diagnose problems in the draft setup process.