### PR TITLE
bug fix for logger

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1889,7 +1889,7 @@ class DraftSetupManager:
                                 (current_time - self.last_db_check_time).total_seconds() > self.db_check_cooldown):
                                 
                                 self.last_db_check_time = current_time
-                                self.logger("check session stage from keep connection alive for user count >= expected user count")
+                                self.logger.info("check session stage from keep connection alive for user count >= expected user count")
                                 await self.check_session_stage_and_organize()
                                     
                         # Try to emit getUsers regularly for accurate counts


### PR DESCRIPTION
### TL;DR

Updated logger call from string to proper info method in the keep_connection_alive function.

### What changed?

Changed a direct string assignment to the logger (`self.logger("check session stage...")`) to use the proper logging method (`self.logger.info("check session stage...")`). This ensures that log messages are properly formatted and categorized with the correct log level.

### How to test?

1. Run the application and observe the logs when the keep_connection_alive function executes
2. Verify that log messages appear correctly with the proper INFO level
3. Check that the message "check session stage from keep connection alive for user count >= expected user count" appears in logs when the condition is met

### Why make this change?

This fixes an incorrect logger usage pattern. The previous code was treating the logger as a function rather than an object with logging methods. Using the proper `.info()` method ensures consistent logging behavior, proper log level assignment, and compatibility with log filtering and formatting.