### PR TITLE
remove timeout for Discord ready check

### DIFF
--- a/views.py
+++ b/views.py
@@ -769,24 +769,24 @@ class PersistentView(discord.ui.View):
         # Send the mention message as a follow-up to ensure it gets sent after the embed
         await interaction.followup.send(mention_message, ephemeral=False)
 
-        asyncio.create_task(self.cleanup_ready_check(self.draft_session_id))
+        # asyncio.create_task(self.cleanup_ready_check(self.draft_session_id))
 
     async def remove_cooldown(self, draft_session_id):
         await asyncio.sleep(60)  # Wait for 60 seconds
         if draft_session_id in READY_CHECK_COOLDOWNS:
             del READY_CHECK_COOLDOWNS[draft_session_id]
 
-    async def cleanup_ready_check(self, draft_session_id):
-        await asyncio.sleep(1800)  # Wait for 30 minutes
-        try:
-            if draft_session_id in sessions:
-                logger.warning(f"⚠️ Removing session {draft_session_id} from sessions dictionary due to timeout")
-                del sessions[draft_session_id]  # Clean up the session data
-                logger.debug(f"Sessions dictionary after cleanup: {list(sessions.keys())}")
-            else:
-                logger.info(f"Session {draft_session_id} already removed from sessions dictionary")
-        except Exception as e:
-            logger.error(f"Failed during ready check cleanup: {e}")
+    # async def cleanup_ready_check(self, draft_session_id):
+    #     await asyncio.sleep(1800)  # Wait for 30 minutes
+    #     try:
+    #         if draft_session_id in sessions:
+    #             logger.warning(f"⚠️ Removing session {draft_session_id} from sessions dictionary due to timeout")
+    #             del sessions[draft_session_id]  # Clean up the session data
+    #             logger.debug(f"Sessions dictionary after cleanup: {list(sessions.keys())}")
+    #         else:
+    #             logger.info(f"Session {draft_session_id} already removed from sessions dictionary")
+    #     except Exception as e:
+    #         logger.error(f"Failed during ready check cleanup: {e}")
 
     async def randomize_teams_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         bot = interaction.client
@@ -859,6 +859,11 @@ class PersistentView(discord.ui.View):
                     # Re-fetch session to get updated teams
                     updated_session = await get_draft_session(self.draft_session_id)
                     
+                    if session_id in sessions:
+                        logger.info(f"✅ Teams created - removing ready check data for session {session_id}")
+                        del sessions[session_id]
+                        logger.debug(f"Sessions dictionary after cleanup: {list(sessions.keys())}")
+
                     # Now that teams exist, calculate stakes for staked drafts
                     stake_pairs = []
                     stake_info_by_player = {}


### PR DESCRIPTION
# Disable Automatic Session Cleanup and Implement Manual Cleanup After Team Creation

### TL;DR

Disabled automatic session cleanup after 30 minutes and moved cleanup logic to execute after teams are successfully created.

### What changed?

- Commented out the call to `cleanup_ready_check` in the `ready_check_callback` method
- Commented out the entire `cleanup_ready_check` method that was previously set to clean up sessions after 30 minutes
- Added explicit session cleanup code in the `randomize_teams_callback` method that removes the session data immediately after teams are successfully created

### How to test?

1. Initiate a draft session and complete the ready check
2. Verify that the session remains active indefinitely until teams are created
3. Create teams using the randomize teams function
4. Confirm that the session data is properly cleaned up after team creation
5. Check logs for the message "✅ Teams created - removing ready check data for session {session_id}"

### Why make this change?

The previous implementation automatically cleaned up sessions after 30 minutes regardless of whether teams were created. This could lead to data loss if users took longer than 30 minutes to create teams. The new approach only cleans up session data after teams are successfully created, ensuring that no active sessions are prematurely removed while still maintaining proper cleanup.