### PR TITLE
fix to check user count

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1883,7 +1883,7 @@ class DraftSetupManager:
                             
                         # If we already have enough users, check session stage
                         # This is a fallback in case any event updates were missed
-                        if self.users_count >= self.expected_user_count:
+                        if self.users_count >= self.expected_user_count and self.expected_user_count != 0:
                             current_time = datetime.now()
                             if (self.last_db_check_time is None or 
                                 (current_time - self.last_db_check_time).total_seconds() > self.db_check_cooldown):


### PR DESCRIPTION
### TL;DR

Added a check to prevent session stage verification when expected user count is zero.

### What changed?

Modified the condition in `keep_connection_alive` method to only check session stage when both:
1. We have enough users (`self.users_count >= self.expected_user_count`)
2. The expected user count is not zero (`self.expected_user_count != 0`)

### How to test?

1. Create a draft session with expected user count set to 0
2. Monitor the connection alive functionality
3. Verify that the session stage verification is skipped when expected user count is 0
4. Test with non-zero expected user counts to ensure normal behavior is maintained

### Why make this change?

This fixes a logical issue where the system would attempt to verify session stages when the expected user count is zero, which could lead to unnecessary database checks or incorrect session state transitions. The change ensures that session stage verification only happens when there's a valid expected user count.