### PR TITLE
fix for race condition on log collection and posting victory message

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -585,15 +585,6 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
 
                 draft_session.deletion_time = datetime.now() + timedelta(hours=2)
 
-                if draft_manager:
-                    logger.info(f"Victory/draw determined - unlocking logs for session {draft_session_id}")
-                    await draft_manager.manually_unlock_draft_logs()
-                    
-                    # Small delay to allow logs to process
-                    await asyncio.sleep(2)
-                else:
-                    logger.warning(f"No active manager found for session {draft_session_id} - logs may remain locked")
-
                 embed = await generate_draft_summary_embed(bot, draft_session_id)
                 three_zero_drafters = await calculate_three_zero_drafters(session, draft_session_id, guild)
                 embed.add_field(name="3-0 Drafters", value=three_zero_drafters or "None", inline=False)
@@ -622,7 +613,16 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
                 else:
                     print(f"Results channel '{results_channel_name}' not found.")
 
-                
+                # Unlock logs for posting
+                if draft_manager:
+                    logger.info(f"Victory/draw determined - unlocking logs for session {draft_session_id}")
+                    await draft_manager.manually_unlock_draft_logs()
+                    
+                    # Small delay to allow logs to process
+                    await asyncio.sleep(2)
+                else:
+                    logger.warning(f"No active manager found for session {draft_session_id} - logs may remain locked")
+
                 # Check if we have a leaderboard message for this guild
                 stmt = select(LeaderboardMessage).where(LeaderboardMessage.guild_id == draft_session.guild_id)
                 result = await session.execute(stmt)


### PR DESCRIPTION
### TL;DR

Improved draft log collection reliability and fixed Discord bot integration issues.

### What changed?

- Modified the draft log collection process to use a delayed schedule (60 seconds) to ensure all data is available
- Fixed Discord bot integration by using the global bot instance instead of relying on the client property
- Changed the pick timer setting from 60 seconds to 1 second for faster drafts
- Reordered the log unlocking process to happen after posting victory/draw messages to ensure proper sequence

### How to test?

1. Run a draft and verify logs are collected properly after completion
2. Check that Discord embeds are sent to the appropriate channels
3. Verify that the pick timer is set to 1 second during draft setup
4. Confirm that victory/draw messages appear in results channels with proper log links

### Why make this change?

The previous implementation had timing issues with log collection that sometimes resulted in incomplete data. Additionally, the Discord bot integration was inconsistent due to client reference issues. These changes improve reliability of the log collection process and ensure proper integration with Discord for posting results.