### PR TITLE
revise picktimer after testing

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1616,7 +1616,7 @@ class DraftSetupManager:
             await self.sio.emit('setDraftLogRecipients', "delayed")
             await self.sio.emit('setPersonalLogs', True)
             await self.sio.emit('teamDraft', True)  # Added teamDraft setting
-            await self.sio.emit('setPickTimer', 1)
+            await self.sio.emit('setPickTimer', 60)
             await self.sio.emit('setOwnerIsPlayer', False)
             
             return True


### PR DESCRIPTION
### TL;DR

Updated the pick timer value in draft settings from 1 second to 60 seconds.

### What changed?

Changed the `setPickTimer` parameter from 1 to 60 in the `update_draft_settings` method of the draft setup manager. This increases the time players have to make their draft picks from 1 second to 60 seconds.

### How to test?

1. Initialize a draft setup
2. Verify that the pick timer is set to 60 seconds
3. Confirm that players have 60 seconds to make their selections during the draft

### Why make this change?

The previous 1-second timer was too short for players to make meaningful draft decisions. The 60-second timer provides a more reasonable timeframe for players to evaluate their options and make strategic picks during the draft process.