### PR TITLE
add timer message to draftmancer ready check

### DIFF
--- a/views.py
+++ b/views.py
@@ -1156,14 +1156,18 @@ class PersistentView(discord.ui.View):
         await interaction.channel.send(embed=channel_embed)
 
         try:
-            
             # Look for an existing manager
             manager = DraftSetupManager.get_active_manager(self.draft_session_id)
             
             if manager:
                 logger.info(f"TEAMS CREATED: Found existing manager for session {self.draft_session_id}")
                 logger.info(f"TEAMS CREATED: Manager state - Seating set: {manager.seating_order_set}, "
-                        f"Users count: {manager.users_count}, Expected count: {manager.expected_user_count}")
+                            f"Users count: {manager.users_count}, Expected count: {manager.expected_user_count}")
+                        
+                # Make sure bot instance is set
+                manager.set_bot_instance(interaction.client)
+                logger.info(f"Set bot instance on manager to ensure Discord messaging works")
+                        
                 # Manager exists, force a check of session stage
                 logger.info("Check session from randomize teams normal draft")
                 await manager.check_session_stage_and_organize()
@@ -1173,6 +1177,12 @@ class PersistentView(discord.ui.View):
                     await manager.sio.emit('getUsers')
             else:
                 logger.info(f"DraftSetupManager not found for {self.draft_session_id}")
+
+        except Exception as e:
+            # Log the error but don't disrupt the normal flow
+            print(f"Error triggering seating order process: {e}")
+            import traceback
+            traceback.print_exc()
 
         except Exception as e:
             # Log the error but don't disrupt the normal flow


### PR DESCRIPTION
### TL;DR

Improved the ready check experience with a countdown timer and better message handling.

### What changed?

- Added a countdown timer that shows when the ready check will timeout
- Enhanced ready check messages with bell emojis for better visibility
- Implemented automatic cleanup of timeout messages when ready check completes or times out
- Fixed the ready check timeout message to include instructions for users
- Added bot instance setting in the team randomization callback to ensure Discord messaging works properly

### How to test?

1. Start a draft and trigger a ready check
2. Verify the countdown timer appears showing when the ready check will expire
3. Let a ready check timeout and confirm the timeout message includes instructions
4. Complete a ready check successfully and verify the timeout message is deleted
5. Test team randomization to ensure Discord messaging works correctly

### Why make this change?

These improvements provide users with clearer information about the ready check process, particularly how much time remains before timeout. The automatic cleanup of messages keeps the channel tidy, and the enhanced visibility of notifications helps users notice and respond to ready checks more quickly. The bot instance fix ensures reliable Discord messaging during the team randomization process.