### PR TITLE
fix for not connecting to session properly

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1704,17 +1704,19 @@ class DraftSetupManager:
         try:
             self.logger.info(f"Starting connection task for draft_id: DB{self.draft_id}")
             websocket_url = get_draftmancer_websocket_url(self.draft_id)
+                
+            # Log the URL to help with debugging
+            self.logger.debug(f"Attempting connection to URL: {websocket_url}")
             
-            # Connect to the websocket
+            # Connect to the websocket with retries
             if self.sio.connected:
                 self.logger.warning("Socket is already connected, disconnecting first...")
                 await self.disconnect_safely()
 
-            await self.sio.connect(
-                websocket_url,
-                transports='websocket',
-                wait_timeout=10
-            )
+            connection_successful = await self.connect_with_retry(websocket_url)
+            if not connection_successful:
+                self.logger.error("Failed to connect after multiple retries, aborting connection task")
+                return
             
             # If initial cube import fails, end the task
             if not self.cube_imported and not await self.import_cube():
@@ -1766,37 +1768,10 @@ class DraftSetupManager:
                         except Exception as e:
                             self.logger.error(f"Error getting users: {e}")
                     
-                    # Draft completed logic
-                    if not self.drafting and not self.draft_cancelled:
-                        # If this is the first time we've noticed draft is not active
-                        if draft_ended_time is None:
-                            draft_ended_time = datetime.now()
-                            self.logger.info(f"Draft not active, setting draft_ended_time to {draft_ended_time}")
-                            
-                            # # Immediately attempt to collect logs if not attempted yet
-                            # if not self.logs_collection_attempted and not self.logs_collection_in_progress:
-                            #     self.logger.info("Attempting to collect logs immediately")
-                            #     last_log_attempt_time = datetime.now()
-                            #     await self.collect_draft_logs()
-                        else:
-                            # If logs were collected successfully, we can disconnect
-                            if self.logs_collection_success:
-                                self.logger.info("Logs collected successfully, disconnecting")
-                                self._should_disconnect = True
-                                break
-                                
-                            # # If logs were attempted but failed, retry periodically (every 30 minutes)
-                            # if (self.logs_collection_attempted and not self.logs_collection_success and 
-                            #     last_log_attempt_time and 
-                            #     (datetime.now() - last_log_attempt_time).total_seconds() > 1800):
-                                
-                            #     self.logger.info(f"Retrying log collection after {(datetime.now() - last_log_attempt_time).total_seconds()} seconds")
-                            #     self.logs_collection_attempted = False  # Reset to allow retry
-                            #     last_log_attempt_time = datetime.now()
-                            #     await self.collect_draft_logs()
-                    else:
-                        # If draft is active again, reset the ended time
-                        draft_ended_time = None
+                    # If logs were collected successfully, we can disconnect
+                    if self.logs_collection_success:
+                        self.logger.info("Logs collected successfully, disconnecting")
+                        self._should_disconnect = True
                         
                     await asyncio.sleep(10)  # Regular check interval
                         
@@ -1811,6 +1786,24 @@ class DraftSetupManager:
             # Only disconnect if requested
             if self._should_disconnect:
                 await self.disconnect_safely()
+
+    @exponential_backoff(max_retries=5, base_delay=2)
+    async def connect_with_retry(self, url):
+        """Handle Socket.IO connection with retries and better error reporting"""
+        try:
+            await self.sio.connect(
+                url,
+                transports='websocket',
+                wait_timeout=10
+            )
+            self.logger.info(f"Successfully connected to {url}")
+            return True
+        except socketio.exceptions.ConnectionError as e:
+            self.logger.error(f"Socket.IO connection error: {str(e)}")
+            return False
+        except Exception as e:
+            self.logger.error(f"Unexpected error during connection: {str(e)}")
+            return False
                 
     async def manually_unlock_draft_logs(self):
         """


### PR DESCRIPTION
### TL;DR

Improved WebSocket connection reliability with retry mechanism and better error handling.

### What changed?

- Added a new `connect_with_retry` method that implements exponential backoff for WebSocket connections
- Enhanced logging to include the WebSocket URL for easier debugging
- Simplified the draft completion logic by removing unnecessary time tracking and focusing on log collection status
- Improved error handling during connection attempts with specific error type detection

### How to test?

1. Initiate a draft connection that might fail initially (can be simulated with network interruption)
2. Verify that the connection is retried automatically with increasing delays
3. Check logs to confirm improved error reporting and connection status updates
4. Verify that drafts properly disconnect after logs are collected successfully

### Why make this change?

WebSocket connections to the draft service were occasionally failing without proper recovery, leading to abandoned drafts and missing log data. This implementation adds resilience through retries with exponential backoff, provides clearer error information for troubleshooting, and simplifies the connection lifecycle management.