### PR TITLE
fix for draftlog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -148,7 +148,7 @@ async def main():
         # Wait for the bot to fully connect to all guilds
         await bot.wait_until_ready()
         # Add an extra safety delay
-        await asyncio.sleep(30)
+        await asyncio.sleep(120)
         # Then refresh all leaderboards
         try:
             from cogs.leaderboard import refresh_all_leaderboards

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1704,17 +1704,14 @@ class DraftSetupManager:
         try:
             self.logger.info(f"Starting connection task for draft_id: DB{self.draft_id}")
             websocket_url = get_draftmancer_websocket_url(self.draft_id)
-            
-            # Connect to the websocket
-            if self.sio.connected:
-                self.logger.warning("Socket is already connected, disconnecting first...")
-                await self.disconnect_safely()
+                
+            # Log the URL to help with debugging
+            self.logger.debug(f"Attempting connection to URL: {websocket_url}")
 
-            await self.sio.connect(
-                websocket_url,
-                transports='websocket',
-                wait_timeout=10
-            )
+            connection_successful = await self.connect_with_retry(websocket_url)
+            if not connection_successful:
+                self.logger.error("Failed to connect after multiple retries, aborting connection task")
+                return
             
             # If initial cube import fails, end the task
             if not self.cube_imported and not await self.import_cube():
@@ -1766,37 +1763,10 @@ class DraftSetupManager:
                         except Exception as e:
                             self.logger.error(f"Error getting users: {e}")
                     
-                    # Draft completed logic
-                    if not self.drafting and not self.draft_cancelled:
-                        # If this is the first time we've noticed draft is not active
-                        if draft_ended_time is None:
-                            draft_ended_time = datetime.now()
-                            self.logger.info(f"Draft not active, setting draft_ended_time to {draft_ended_time}")
-                            
-                            # # Immediately attempt to collect logs if not attempted yet
-                            # if not self.logs_collection_attempted and not self.logs_collection_in_progress:
-                            #     self.logger.info("Attempting to collect logs immediately")
-                            #     last_log_attempt_time = datetime.now()
-                            #     await self.collect_draft_logs()
-                        else:
-                            # If logs were collected successfully, we can disconnect
-                            if self.logs_collection_success:
-                                self.logger.info("Logs collected successfully, disconnecting")
-                                self._should_disconnect = True
-                                break
-                                
-                            # # If logs were attempted but failed, retry periodically (every 30 minutes)
-                            # if (self.logs_collection_attempted and not self.logs_collection_success and 
-                            #     last_log_attempt_time and 
-                            #     (datetime.now() - last_log_attempt_time).total_seconds() > 1800):
-                                
-                            #     self.logger.info(f"Retrying log collection after {(datetime.now() - last_log_attempt_time).total_seconds()} seconds")
-                            #     self.logs_collection_attempted = False  # Reset to allow retry
-                            #     last_log_attempt_time = datetime.now()
-                            #     await self.collect_draft_logs()
-                    else:
-                        # If draft is active again, reset the ended time
-                        draft_ended_time = None
+                    # If logs were collected successfully, we can disconnect
+                    if self.logs_collection_success:
+                        self.logger.info("Logs collected successfully, disconnecting")
+                        self._should_disconnect = True
                         
                     await asyncio.sleep(10)  # Regular check interval
                         
@@ -1811,6 +1781,24 @@ class DraftSetupManager:
             # Only disconnect if requested
             if self._should_disconnect:
                 await self.disconnect_safely()
+
+    @exponential_backoff(max_retries=5, base_delay=2)
+    async def connect_with_retry(self, url):
+        """Handle Socket.IO connection with retries and better error reporting"""
+        try:
+            await self.sio.connect(
+                url,
+                transports='websocket',
+                wait_timeout=10
+            )
+            self.logger.info(f"Successfully connected to {url}")
+            return True
+        except socketio.exceptions.ConnectionError as e:
+            self.logger.error(f"Socket.IO connection error: {str(e)}")
+            return False
+        except Exception as e:
+            self.logger.error(f"Unexpected error during connection: {str(e)}")
+            return False
                 
     async def manually_unlock_draft_logs(self):
         """


### PR DESCRIPTION
# Improve Draft Connection Reliability and Extend Leaderboard Refresh Delay

### TL;DR

Enhances the draft connection system with retry logic and increases the leaderboard refresh delay to ensure proper initialization.

### What changed?

- Increased the leaderboard refresh delay from 30 to 120 seconds to ensure the bot is fully ready before refreshing
- Implemented a new `connect_with_retry` method with exponential backoff for more reliable websocket connections
- Simplified the draft completion logic by removing unnecessary time tracking and focusing on log collection status
- Added better error handling and logging for websocket connections to help with debugging

### How to test?

1. Start the bot and verify it waits the full 120 seconds before refreshing leaderboards
2. Create a draft and observe the connection logs to ensure retry logic works properly
3. Complete a draft and verify the bot properly disconnects after logs are collected

### Why make this change?

The previous connection system would sometimes fail to establish a stable connection to the draft server, especially during network instability. The shorter leaderboard refresh delay was also causing issues with incomplete initialization. These changes make the system more resilient to temporary connection issues and provide better diagnostic information when problems occur.