### PR TITLE
fix to draft log collection

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -121,8 +121,9 @@ async def main():
             logger.info(f"Starting to run {len(managers)} draft {task_type} reconnection tasks sequentially")
             for i, manager in enumerate(managers):
                 try:
+
                     # Start this specific connection and create a task to monitor it
-                    task = asyncio.create_task(manager.keep_connection_alive())
+                    task = asyncio.create_task(manager.keep_connection_alive()) if task_type == "setup" else asyncio.create_task(manager.keep_draft_session_alive())
                     logger.info(f"Started task {i+1}/{len(managers)} for draft ID: {manager.draft_id}")
                     
                     # Add a 1-second delay before the next task


### PR DESCRIPTION
### TL;DR

Fix draft reconnection task creation by using the appropriate method based on task type.

### What changed?

Modified the `monitor_reconnection_tasks` function to create the appropriate task based on the `task_type` parameter:
- For "setup" tasks, it continues to use `manager.keep_connection_alive()`
- For other task types, it now uses `manager.keep_draft_session_alive()`

### How to test?

1. Test draft reconnection with different task types:
   - Verify "setup" tasks use the connection alive method
   - Verify other task types use the draft session alive method
2. Check logs to confirm the correct tasks are being created
3. Ensure draft sessions remain active after reconnection

### Why make this change?

The previous implementation was using the same method (`keep_connection_alive()`) for all task types, which was incorrect. Different task types require different connection maintenance methods. This change ensures the appropriate method is called based on the task type, improving the reliability of draft reconnections.