### PR TITLE
add /relase_draft_log command

### DIFF
--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -14,6 +14,186 @@ from sqlalchemy import select
 # Store active unpause ready checks
 ACTIVE_UNPAUSE_CHECKS = {}
 ACTIVE_SCRAP_VOTES = {}
+ACTIVE_LOG_RELEASE_VOTES = {}
+
+
+class LogReleaseVoteView(View):
+    def __init__(self, draft_session_id, participants, timeout=90.0):
+        super().__init__(timeout=timeout)
+        self.draft_session_id = draft_session_id
+        # Initialize with all participants set to None (haven't voted)
+        self.votes = {user_id: None for user_id in participants}  # None = not voted, True = yes, False = no
+        self.message = None
+        self.timer_task = None
+        self.complete = asyncio.Event()
+        self._start_time = datetime.now()
+        
+    async def start_timer(self):
+        """Start the timeout timer for the vote"""
+        try:
+            await asyncio.sleep(self.timeout)
+            if not self.complete.is_set():
+                # Time's up, mark the vote as complete
+                logger.info(f"Log release vote for session {self.draft_session_id} timed out")
+                await self.on_timeout()
+        except asyncio.CancelledError:
+            logger.debug(f"Timer for log release vote {self.draft_session_id} was cancelled")
+    
+    def get_vote_result(self):
+        """Check if the vote passed (more than half voted yes)"""
+        yes_votes = sum(1 for vote in self.votes.values() if vote is True)
+        total_participants = len(self.votes)
+        
+        # Vote passes if more than half vote yes
+        needed_votes = (total_participants // 2) + 1
+        return yes_votes >= needed_votes, yes_votes, total_participants
+    
+    @discord.ui.button(label="Yes, Release Logs", style=discord.ButtonStyle.primary)
+    async def yes_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Vote yes to release logs"""
+        user_id = str(interaction.user.id)
+        if user_id not in self.votes:
+            await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
+            return
+            
+        # Record vote
+        self.votes[user_id] = True
+        
+        # Update the message
+        embed = await self.generate_status_embed(interaction.guild)
+        await interaction.response.edit_message(embed=embed, view=self)
+        
+        # Check if vote has passed
+        passed, _, _ = self.get_vote_result()
+        if passed:
+            self.complete.set()
+            if self.timer_task:
+                self.timer_task.cancel()
+            
+            # Disable buttons
+            for child in self.children:
+                child.disabled = True
+                
+            await self.message.edit(view=self)
+            # The on_complete callback will handle releasing the logs
+        
+    @discord.ui.button(label="No, Keep Logs Private", style=discord.ButtonStyle.secondary)
+    async def no_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Vote no to keep logs private"""
+        user_id = str(interaction.user.id)
+        if user_id not in self.votes:
+            await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
+            return
+            
+        # Record vote
+        self.votes[user_id] = False
+        
+        # Update the message
+        embed = await self.generate_status_embed(interaction.guild)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+        # Check if vote cannot pass anymore
+        no_votes = sum(1 for vote in self.votes.values() if vote is False)
+        total_participants = len(self.votes)
+        needed_votes = (total_participants // 2) + 1
+        remaining_votes = sum(1 for vote in self.votes.values() if vote is None)
+        max_possible_yes = sum(1 for vote in self.votes.values() if vote is True) + remaining_votes
+
+        # If max possible yes votes can't reach threshold, end vote early
+        if max_possible_yes < needed_votes:
+            self.complete.set()
+            if self.timer_task:
+                self.timer_task.cancel()
+            
+            # Disable buttons
+            for child in self.children:
+                child.disabled = True
+                
+            await self.message.edit(view=self)
+    
+    async def generate_status_embed(self, guild):
+        """Generate an embed showing the current vote status"""
+        embed = discord.Embed(
+            title="Draft Logs Release Vote",
+            description="Vote to release the draft logs early.",
+            color=discord.Color.blue()
+        )
+        
+        # Add a field showing votes for each participant
+        status_lines = []
+        for user_id, vote in self.votes.items():
+            # Try to get member name
+            member = guild.get_member(int(user_id))
+            name = member.display_name if member else f"User {user_id}"
+            
+            # Add status emoji based on vote
+            if vote is True:
+                status = "✅ Voted to Release"
+            elif vote is False:
+                status = "❌ Voted to Keep Private"
+            else:
+                status = "⏳ Not Voted"
+                
+            status_lines.append(f"{name}: {status}")
+        
+        embed.add_field(
+            name="Participants",
+            value="\n".join(status_lines) or "No participants found",
+            inline=False
+        )
+        
+        # Add vote results field
+        passed, yes_votes, total_participants = self.get_vote_result()
+        needed_votes = (total_participants // 2) + 1
+        
+        embed.add_field(
+            name="Vote Status",
+            value=f"**{yes_votes}/{needed_votes}** votes needed to release logs\n" +
+                  (f"**Vote will pass!**" if passed else f"**Vote will not pass yet**"),
+            inline=False
+        )
+        
+        # Calculate expiry timestamp correctly
+        expiry_time = self._start_time.timestamp() + self.timeout
+        expiry_timestamp = int(expiry_time)
+        
+        embed.add_field(
+            name="Vote Ends",
+            value=f"<t:{expiry_timestamp}:R>",
+            inline=False
+        )
+        
+        return embed
+        
+    async def on_timeout(self):
+        """Called when the view times out"""
+        # Make sure we set the complete event
+        self.complete.set()
+        
+        # Disable all buttons
+        for child in self.children:
+            child.disabled = True
+            
+        # Update the message if it exists
+        if self.message:
+            embed = discord.Embed(
+                title="Draft Logs Release Vote - Ended",
+                description="The vote has ended.",
+                color=discord.Color.blue()
+            )
+            
+            passed, yes_votes, total_participants = self.get_vote_result()
+            needed_votes = (total_participants // 2) + 1
+            
+            embed.add_field(
+                name="Final Results",
+                value=f"**{yes_votes}/{needed_votes}** votes needed to release logs\n" +
+                      (f"**Vote passed!**" if passed else f"**Vote did not pass**"),
+                inline=False
+            )
+            
+            await self.message.edit(embed=embed, view=self)
+
 
 class DraftMancerReadyCheckView(View):
     def __init__(self, draft_session_id, participants, timeout=90.0):
@@ -389,6 +569,132 @@ class DraftControlCog(commands.Cog):
             logger.exception(f"Error in ready command: {e}")
             await ctx.followup.send(f"An error occurred: {str(e)}", ephemeral=True)
 
+
+    @discord.slash_command(name='release_draft_logs', description='Start a vote to release draft logs early')
+    async def releaselogs_command(self, ctx):
+        """Start a vote to release draft logs early"""
+        await ctx.defer(ephemeral=True)
+        
+        try:
+            # Find the draft session by chat channel ID
+            channel_id = str(ctx.channel.id)
+            logger.info(f"Looking for active draft in chat channel {channel_id}")
+            
+            # Get the draft session for this chat channel
+            async with db_session() as session:
+                from sqlalchemy import select
+                
+                stmt = select(DraftSession).where(
+                    DraftSession.draft_chat_channel == channel_id
+                )
+                
+                result = await session.execute(stmt)
+                draft_session = result.scalar_one_or_none()
+            
+            if not draft_session:
+                logger.warning(f"No active draft found for chat channel {channel_id}")
+                await ctx.followup.send("No active draft found for this channel.", ephemeral=True)
+                return
+                
+            session_id = draft_session.session_id
+            
+            # Get the manager for this session
+            manager = DraftSetupManager.get_active_manager(session_id)
+            if not manager:
+                logger.warning(f"No active manager found for session ID: {session_id}")
+                await ctx.followup.send("Draft manager is not active. Please wait a moment or contact an admin.", ephemeral=True)
+                return
+                
+            # Check if there's already an active log release vote
+            if session_id in ACTIVE_LOG_RELEASE_VOTES:
+                await ctx.followup.send("There's already an active vote to release logs for this draft.", ephemeral=True)
+                return
+                
+            sign_ups = draft_session.sign_ups or {}
+                
+            # Get all participants
+            participants = list(sign_ups.keys())
+            if not participants:
+                await ctx.followup.send("No draft participants found.", ephemeral=True)
+                return
+            
+            # Create log release vote view
+            view = LogReleaseVoteView(session_id, participants)
+            
+            # Format the pings for the message
+            user_pings = []
+            for player_id in sign_ups:
+                try:
+                    member = ctx.guild.get_member(int(player_id))
+                    if member:
+                        user_pings.append(member.mention)
+                except:
+                    pass
+                    
+            ping_text = " ".join(user_pings) if user_pings else "No players to ping."
+            
+            # Generate initial status embed
+            embed = await view.generate_status_embed(ctx.guild)
+            
+            # Send message with pings and view
+            message = await ctx.channel.send(
+                f"📝 **Draft Log Release Vote** initiated by {ctx.author.mention}\n\n{ping_text}\n\n"
+                f"Please vote on whether to release the draft logs early.",
+                embed=embed,
+                view=view
+            )
+            
+            # Store message reference
+            view.message = message
+            
+            # Store in active votes
+            ACTIVE_LOG_RELEASE_VOTES[session_id] = view
+            
+            # Start timeout timer
+            view.timer_task = asyncio.create_task(view.start_timer())
+            
+            # Acknowledge command
+            await ctx.followup.send("Log release vote initiated.", ephemeral=True)
+            
+            # Wait for completion
+            try:
+                await view.complete.wait()
+                
+                # Check if vote passed
+                passed, yes_votes, total_participants = view.get_vote_result()
+                if passed:
+                    # Vote passed, release the logs
+                    final_message = await ctx.channel.send("✅ **Vote passed!** Releasing logs in 5 seconds...")
+                    await asyncio.sleep(5)
+                    
+                    # Call the method to unlock the logs
+                    success = await manager.manually_unlock_draft_logs()
+                    
+                    if success:
+                        await final_message.edit(content="🔓 **Logs have been made public!**")
+                    else:
+                        await final_message.edit(content="❌ **Failed to release logs.** Please try again later.")
+                else:
+                    # Vote didn't pass
+                    await ctx.channel.send("❌ **Vote to release logs did not pass.** Logs will remain private until the end of the draft.")
+                
+                # Clean up
+                if session_id in ACTIVE_LOG_RELEASE_VOTES:
+                    del ACTIVE_LOG_RELEASE_VOTES[session_id]
+                    
+            except Exception as e:
+                logger.exception(f"Error while waiting for log release vote completion: {e}")
+                await ctx.channel.send("⚠️ An error occurred during the log release vote. Please try again.")
+                
+                # Clean up
+                if session_id in ACTIVE_LOG_RELEASE_VOTES:
+                    del ACTIVE_LOG_RELEASE_VOTES[session_id]
+                    
+        except Exception as e:
+            logger.exception(f"Error in releaselogs command: {e}")
+            await ctx.followup.send(f"An error occurred: {str(e)}", ephemeral=True)
+
+            
     @discord.slash_command(name='scrap', description='Start a vote to cancel the current draft')
     async def scrap_command(self, ctx):
         """Start a vote to completely cancel the draft"""


### PR DESCRIPTION
### TL;DR

Added a new `/release_draft_logs` command that allows draft participants to vote on releasing draft logs early.

### What changed?

- Created a new `LogReleaseVoteView` class that handles the voting UI and logic for releasing draft logs
- Added a global `ACTIVE_LOG_RELEASE_VOTES` dictionary to track ongoing votes
- Implemented the `/release_draft_logs` slash command that:
  - Verifies the command is used in an active draft channel
  - Creates a voting interface with "Yes" and "No" buttons
  - Pings all draft participants to vote
  - Automatically releases logs if more than half of participants vote "Yes"
  - Times out after 90 seconds if not enough votes are collected

### How to test?

1. Start a draft with multiple participants
2. During the draft, have any participant use the `/release_draft_logs` command
3. Verify that all participants receive a ping and can vote using the buttons
4. Test both scenarios:
   - When majority votes "Yes": logs should be released after 5 seconds
   - When majority votes "No" or time expires: logs should remain private

### Why make this change?

This feature gives draft participants the ability to collectively decide whether to make draft logs public before the draft officially ends. This is useful in scenarios where participants want to discuss their picks openly or when a draft has effectively concluded but hasn't been formally closed.