### PR TITLE
adjust error message for clarity

### DIFF
--- a/views.py
+++ b/views.py
@@ -1882,7 +1882,7 @@ class ReadyCheckView(discord.ui.View):
     async def handle_vote(self, interaction: discord.Interaction, vote_type):
         session = sessions.get(self.draft_session_id)
         if not session:
-            await interaction.response.send_message("Session data is missing.", ephemeral=True)
+            await interaction.response.send_message("No Active Ready Check.", ephemeral=True)
             return
 
         user_id = str(interaction.user.id)


### PR DESCRIPTION
### TL;DR

Updated error message when a user interacts with an expired ready check.

### What changed?

Changed the error message in the `handle_vote` method from "Session data is missing." to "No Active Ready Check." when a user tries to interact with a session that no longer exists.

### How to test?

1. Start a ready check in Discord
2. Wait for the ready check to expire or be completed
3. Try to interact with the expired ready check buttons
4. Verify the new error message "No Active Ready Check." appears

### Why make this change?

The new error message is more user-friendly and clearly communicates that the ready check they're trying to interact with is no longer active, rather than suggesting there's a technical issue with missing session data.