### PR TITLE
fix potentail error if someone joins/leaves queue during ready check

### DIFF
--- a/views.py
+++ b/views.py
@@ -1951,9 +1951,14 @@ class ReadyCheckView(discord.ui.View):
             queue_size = session.get("queue_size", 6)
             required_votes = 4 if queue_size == 6 else 5  # 4 out of 6, or 5 out of 8
             
-            if len(session['fire']) >= required_votes:
+            if len(session['fire']) >= required_votes and len(draft_session.sign_ups) == queue_size:
                 # Majority wants to fire! Auto-trigger team creation
                 await self.auto_create_teams(interaction, draft_session, queue_size)
+            elif len(draft_session.sign_ups) != queue_size:
+                # Queue size not correct
+                await interaction.channel.send(
+                    f"Vote complete! However, someone has left and/or joined the queue. Aborting auto team creation. Currently {len(draft_session.sign_ups)} people in queue."
+                )
             else:
                 # Not enough votes to fire, inform users
                 await interaction.channel.send(


### PR DESCRIPTION
### TL;DR

Added a check to prevent auto team creation when queue size changes during voting.

### What changed?

Modified the `handle_vote` function to verify that the number of sign-ups matches the expected queue size before auto-creating teams. If the queue size has changed during voting (people joining or leaving), the system now aborts the auto team creation process and sends a notification message to the channel.

### How to test?

1. Start a draft session with a specific queue size (6 or 8)
2. Have users vote to fire
3. During voting, have someone leave or join the queue
4. Verify that when votes reach the threshold, the system sends the abort message instead of creating teams
5. Check that the message correctly displays the current number of people in the queue

### Why make this change?

This prevents teams from being created with an incorrect number of players when the queue composition changes during the voting process. The previous implementation would create teams regardless of queue size changes, potentially leading to unbalanced teams or errors in the team creation process.