### PR TITLE
always create rooms button works

### DIFF
--- a/views.py
+++ b/views.py
@@ -229,10 +229,7 @@ class PersistentView(discord.ui.View):
             for item in self.children:
                 if isinstance(item, discord.ui.Button):
                     if item.custom_id == f"create_rooms_pairings_{self.draft_session_id}":
-                        if self.draft_session_id in ACTIVE_MANAGERS:
-                            item.disabled = True
-                        else:
-                            item.disabled = False
+                        item.disabled = False
                     elif item.custom_id == f"cancel_draft_{self.draft_session_id}":
                         item.disabled = False
                     else:
@@ -1069,10 +1066,7 @@ class PersistentView(discord.ui.View):
                         )
                         
                         if item.custom_id == f"create_rooms_pairings_{draft_session_id}":
-                            if draft_session_id in ACTIVE_MANAGERS:
-                                button_copy.disabled = True
-                            else:
-                                button_copy.disabled = False
+                            button_copy.disabled = False
                         elif item.custom_id == f"cancel_draft_{draft_session_id}":
                             button_copy.disabled = False
                         else:


### PR DESCRIPTION
### TL;DR

Simplified button disabling logic for the "create rooms pairings" button.

### What changed?

Removed conditional logic that was checking if `draft_session_id` exists in `ACTIVE_MANAGERS` before enabling the "create rooms pairings" button. Now the button is always enabled regardless of whether the draft session is active or not.

This change affects two locations:
- In the `_apply_stage_button_disabling` method
- In the `create_teams_handler` function

### How to test?

1. Start a draft session
2. Verify that the "create rooms pairings" button is enabled regardless of the draft session's active status
3. Ensure the button functions correctly when clicked

### Why make this change?

The previous implementation was unnecessarily disabling the "create rooms pairings" button when a draft session was active. This change simplifies the logic and ensures the button is always available, improving the user experience by allowing room creation at any point during the draft process.