### PR TITLE
always allow create rooms button

### DIFF
--- a/views.py
+++ b/views.py
@@ -229,10 +229,7 @@ class PersistentView(discord.ui.View):
             for item in self.children:
                 if isinstance(item, discord.ui.Button):
                     if item.custom_id == f"create_rooms_pairings_{self.draft_session_id}":
-                        if self.draft_session_id in ACTIVE_MANAGERS:
-                            item.disabled = True
-                        else:
-                            item.disabled = False
+                        item.disabled = False
                     elif item.custom_id == f"cancel_draft_{self.draft_session_id}":
                         item.disabled = False
                     else:
@@ -1075,10 +1072,7 @@ class PersistentView(discord.ui.View):
                             
                             # Set disabled state based on button type
                             if item.custom_id == f"create_rooms_pairings_{self.draft_session_id}":
-                                if self.draft_session_id in ACTIVE_MANAGERS:
-                                    button_copy.disabled = True
-                                else:
-                                    button_copy.disabled = False
+                                button_copy.disabled = False
                             elif item.custom_id == f"cancel_draft_{self.draft_session_id}":
                                 button_copy.disabled = False
                             else:
@@ -1135,10 +1129,7 @@ class PersistentView(discord.ui.View):
                     if isinstance(item, discord.ui.Button):
                         # Enable "Create Rooms" and "Cancel Draft" buttons
                         if item.custom_id == f"create_rooms_pairings_{self.draft_session_id}":
-                            if self.draft_session_id in ACTIVE_MANAGERS:
-                                item.disabled = True
-                            else:
-                                item.disabled = False
+                            item.disabled = False
                         elif item.custom_id == f"cancel_draft_{self.draft_session_id}":
                             item.disabled = False
                         else:


### PR DESCRIPTION
### TL;DR

Always enable the "Create Rooms" button regardless of active manager status.

### What changed?

Simplified the button disabling logic in three locations by removing the conditional check that was disabling the "Create Rooms" button when a draft session ID was in the `ACTIVE_MANAGERS` list. Now the button will always be enabled when it should be visible.

### How to test?

1. Start a draft session
2. Verify that the "Create Rooms" button is always enabled, regardless of whether the draft session ID is in `ACTIVE_MANAGERS`
3. Test the button functionality to ensure it still works correctly

### Why make this change?

The previous implementation was preventing users from creating rooms when a manager was active, which was likely causing confusion. This change ensures the button is consistently available when needed, improving the user experience by removing an unnecessary restriction.