### PR TITLE
update randomize teams callback to avoid race and improper button presses

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
 # Global flag to enable test features
 # Set to True during development to enable test buttons, False for production
-TEST_MODE_ENABLED = False
+TEST_MODE_ENABLED = True
 
 class Config:
     def __init__(self):


### PR DESCRIPTION
# Enable Test Mode and Fix Team Creation Race Conditions

### TL;DR
Enabled test mode and fixed race conditions in team creation process to prevent multiple simultaneous team creation attempts.

### What changed?
- Enabled `TEST_MODE_ENABLED` flag in config.py
- Added a global `PROCESSING_TEAMS_CREATION` dictionary to track ongoing team creation processes
- Moved the "Add Test Users" button to be available in all session types when test mode is enabled
- Completely refactored the `randomize_teams_callback` function to:
  - Check if teams are already being created for a session
  - Verify the user is in the sign-up queue before allowing team creation
  - Use proper response deferring for longer operations
  - Add proper error handling and cleanup of processing flags
  - Fix race conditions by using a global lock mechanism

### How to test?
1. Verify that the test button appears in all session types when test mode is enabled
2. Try to create teams simultaneously from multiple users and confirm only one request succeeds
3. Test the error handling by triggering various error conditions (odd number of players, missing stakes, etc.)
4. Verify that a user not in the queue cannot create teams

### Why make this change?
This change prevents race conditions where multiple users could trigger team creation simultaneously, which could lead to data corruption or duplicate teams. It also improves error handling and user feedback during the team creation process, making the system more robust and user-friendly.