### PR TITLE
update powerslax thumbnail

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -6,7 +6,7 @@ CUBE_THUMBNAILS = {
     "LSVRetro": "https://cdn.discordapp.com/attachments/1239255966818635796/1348496825417470012/LSVRetro.png?ex=67cfad09&is=67ce5b89&hm=8d4d755e1e47993910f06f886f131b2f7930a8fff022db7651ca3e976d1582ce&",
     "AlphaFrog": "https://cdn.discordapp.com/attachments/1097030242507444226/1348723563481530378/585x620-Gavin-Thompson-Exner-2022-Profile-removebg-preview.png?ex=67d08033&is=67cf2eb3&hm=2962b1159ffafce373de1a69e527ffceec86f085453695f3348ee518e3954674&",
     "PowerMack": "https://cdn.discordapp.com/attachments/1097030242507444226/1348717924978004102/mac.png?ex=67d07af3&is=67cf2973&hm=c750d1ce62a06cc0aa0b224119b4d8a04e3c35e2933cb834f819a8a11061e4f8&",
-    "Powerslax": "https://media.discordapp.net/attachments/1239255966818635796/1376970727819051028/rof.jpg?ex=6837436c&is=6835f1ec&hm=ef052c0113250a9e6179736a4e257fc81002a0c3824b48054d95555d1b57ef08&=&format=webp"
+    "Powerslax": "https://cdn.discordapp.com/attachments/1239255966818635796/1376976644316594206/image.png?ex=683748ee&is=6835f76e&hm=626b466ead9ed12cbe258b67178e0044cb6f78ac4488441e3ee1dbb11dc4a95b&"
 }
 
 # Default thumbnail for cubes that don't have a specific image


### PR DESCRIPTION
### TL;DR

Updated the Discord image URL for the Powerslax cube.

### What changed?

Changed the Discord image URL for the Powerslax cube in the `CUBE_THUMBNAILS` dictionary from a JPG format to a PNG format.

### How to test?

1. Run the application and navigate to where cube thumbnails are displayed
2. Verify that the Powerslax cube displays the correct PNG image
3. Ensure the image loads properly without any broken links

### Why make this change?

The new PNG image likely provides better quality or a more appropriate visual representation for the Powerslax cube. This update ensures users see the intended image when interacting with this cube.