### PR TITLE
more robust draft manager connections

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
 # Global flag to enable test features
 # Set to True during development to enable test buttons, False for production
-TEST_MODE_ENABLED = False
+TEST_MODE_ENABLED = True
 
 class Config:
     def __init__(self):


### PR DESCRIPTION
### TL;DR

Enable test mode and implement session ownership management for DraftBot to maintain control of draft sessions.

### What changed?

- Enabled test mode in the configuration
- Added session ownership tracking and management:
  - Added properties to track connection status, session owner, and non-bot users
  - Implemented periodic reconnection for when no users are present (every 5 minutes)
  - Added logic to detect when DraftBot is not the session owner and request ownership
  - Fixed a bug where a user joining during an active ready check was incorrectly logged as leaving
  - Improved session stage checking to only run when in "teams" stage
  - Added immediate draft info fetching upon connection
  - Fixed logic for status message updates to only post when in "teams" stage

### How to test?

1. Start a draft session and verify DraftBot connects properly
2. Test the periodic reconnection by having all users leave the session and verify DraftBot reconnects after 5 minutes
3. Test ownership management by:
   - Having another user take ownership (crown)
   - Verify DraftBot posts a message requesting ownership
4. Test user tracking by having users join/leave during various stages of the draft

### Why make this change?

This change addresses issues where DraftBot would lose connection or control of draft sessions. The periodic reconnection ensures DraftBot stays connected even when users temporarily leave, while the ownership management ensures DraftBot maintains control of the session for proper functionality. These improvements enhance reliability and provide a better user experience by maintaining consistent bot presence throughout the draft process.