### PR TITLE
add powersam cube

### DIFF
--- a/cube_views/CubeSelectionView.py
+++ b/cube_views/CubeSelectionView.py
@@ -20,7 +20,8 @@ class CubeUpdateSelectionView(discord.ui.View):
                 discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerMack", value="PowerMack"),
-                 discord.SelectOption(label="Powerslax", value="Powerslax"),
+                discord.SelectOption(label="Powerslax", value="Powerslax"),
+                discord.SelectOption(label="PowerSam", value="PowerSam"),
             ]
         }
         

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -6,7 +6,8 @@ CUBE_THUMBNAILS = {
     "LSVRetro": "https://cdn.discordapp.com/attachments/1239255966818635796/1348496825417470012/LSVRetro.png?ex=67cfad09&is=67ce5b89&hm=8d4d755e1e47993910f06f886f131b2f7930a8fff022db7651ca3e976d1582ce&",
     "AlphaFrog": "https://cdn.discordapp.com/attachments/1097030242507444226/1348723563481530378/585x620-Gavin-Thompson-Exner-2022-Profile-removebg-preview.png?ex=67d08033&is=67cf2eb3&hm=2962b1159ffafce373de1a69e527ffceec86f085453695f3348ee518e3954674&",
     "PowerMack": "https://cdn.discordapp.com/attachments/1097030242507444226/1348717924978004102/mac.png?ex=67d07af3&is=67cf2973&hm=c750d1ce62a06cc0aa0b224119b4d8a04e3c35e2933cb834f819a8a11061e4f8&",
-    "Powerslax": "https://cdn.discordapp.com/attachments/1239255966818635796/1376976644316594206/image.png?ex=683748ee&is=6835f76e&hm=626b466ead9ed12cbe258b67178e0044cb6f78ac4488441e3ee1dbb11dc4a95b&"
+    "Powerslax": "https://cdn.discordapp.com/attachments/1239255966818635796/1376976644316594206/image.png?ex=683748ee&is=6835f76e&hm=626b466ead9ed12cbe258b67178e0044cb6f78ac4488441e3ee1dbb11dc4a95b&",
+    "PowerSam": "https://cdn.discordapp.com/attachments/1239255966818635796/1379618572409507941/image.png?ex=6840e56b&is=683f93eb&hm=0cfc99d5e675abe261a87cd104504b38a4fea82985e0877fe52de97fb6620786&"
 }
 
 # Default thumbnail for cubes that don't have a specific image

--- a/modals.py
+++ b/modals.py
@@ -86,6 +86,7 @@ class CubeDraftSelectionView(discord.ui.View):
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerMack", value="PowerMack"),
                 discord.SelectOption(label="Powerslax", value="Powerslax"),
+                discord.SelectOption(label="PowerSam", value="PowerSam"),
                 discord.SelectOption(label="Custom Cube...", value="custom")
             ]
         )
@@ -147,6 +148,7 @@ class StakedCubeDraftSelectionView(discord.ui.View):
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerMack", value="PowerMack"),
                 discord.SelectOption(label="Powerslax", value="Powerslax"),
+                discord.SelectOption(label="PowerSam", value="PowerSam"),
                 discord.SelectOption(label="Custom Cube...", value="custom")
             ]
         )


### PR DESCRIPTION
### TL;DR

Added PowerSam cube to the available cube selection options.

### What changed?

- Added "PowerSam" as a new cube option in the dropdown selection menus in three files:
  - `CubeSelectionView.py`
  - `modals.py` (in two different select menus)
  - Added PowerSam's thumbnail image URL to the cube images dictionary in `helpers/utils.py`

### How to test?

1. Start a new draft or sealed session
2. Verify that "PowerSam" appears in the cube selection dropdown
3. Select PowerSam and confirm the correct thumbnail image appears

### Why make this change?

To expand the available cube options for users by adding the new PowerSam cube to the platform.