### PR TITLE
all staked drafts have 20 tix min now

### DIFF
--- a/cogs/draft_logs_cog.py
+++ b/cogs/draft_logs_cog.py
@@ -642,7 +642,7 @@ class DraftLogsCog(commands.Cog):
             if discord_channel:
                 embed = discord.Embed(
                     title="📊 Anonymous Draft Log Review",
-                    description="Draft Logs posted twice a day (10am ET / 1pm ET)!",
+                    description="Draft Logs posted at 9am daily!",
                     color=discord.Color.purple()
                 )
                 

--- a/sessions/staked_session.py
+++ b/sessions/staked_session.py
@@ -22,10 +22,9 @@ class StakedSession(RandomSession):
             "3. Teams will be created randomly. Max bets are **NOT** factored in when making teams\n"
             f"4. Minimum bet: {self.session_details.min_stake} tix\n\n"
             "**How it works:**\n"
-            "• To be written when a methodology is finalized\n"
-            "• Basic rules: Ensure both teams can fulfill all 10/20/50 bets on opposing team\n"
-            "• If a team cannot, process using Proportional Method\n"
-            "• If both teams can, allocate all 10/20/50 bets, then proportionaly distribute all remaining bets\n"
+            "• Basic rules: Ensure both teams can fulfill all 20/50 bets on opposing team\n"
+            "• If a team cannot, process using a Proportional Method\n"
+            "• If both teams can, allocate all 20/50 bets, then proportionaly distribute all remaining bets\n"
             f"{self.get_common_description()}"
         )
         embed = Embed(title=title, description=description, color=Color.gold())


### PR DESCRIPTION
### TL;DR

Updated draft logs schedule and standardized staked draft minimum to 20 tickets.

### What changed?

- Changed draft logs posting schedule from twice daily (10am ET / 1pm ET) to once daily at 9am
- Set a fixed minimum stake of 20 tickets for all staked drafts
- Removed the minimum stake input field from the staked draft modal
- Refactored the staked draft modal to only show when needed
- Updated the staked session description to reflect the 20/50 bet tiers (removed mention of 10 tix bets)
- Added a separate handler function for staked draft sessions

### How to test?

1. Verify draft logs are posted at 9am daily
2. Start a staked draft and confirm the minimum stake is set to 20 tickets
3. Check that the staked draft modal no longer shows the minimum stake input field
4. Verify the staked session description correctly shows the 20/50 bet tiers

### Why make this change?

Simplifying the draft logs schedule to once daily makes it more consistent and easier to manage. Standardizing the minimum stake to 20 tickets streamlines the staked draft process and removes unnecessary user input, while aligning with the updated betting tiers (20/50) mentioned in the session description.