### PR TITLE
update the mocs cube link

### DIFF
--- a/cube_views/CubeSelectionView.py
+++ b/cube_views/CubeSelectionView.py
@@ -17,7 +17,7 @@ class CubeUpdateSelectionView(discord.ui.View):
             "default": [
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="3txn8"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerLSV", value="PowerLSV"),
                 discord.SelectOption(label="Powerslax", value="Powerslax"),

--- a/modals.py
+++ b/modals.py
@@ -82,7 +82,7 @@ class CubeDraftSelectionView(discord.ui.View):
                 options=[
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="3txn8"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerLSV", value="PowerLSV"),
                 discord.SelectOption(label="Powerslax", value="Powerslax"),
@@ -144,7 +144,7 @@ class StakedCubeDraftSelectionView(discord.ui.View):
             options=[
                 discord.SelectOption(label="LSVCube", value="LSVCube"),
                 discord.SelectOption(label="AlphaFrog", value="AlphaFrog"),
-                discord.SelectOption(label="2025 MOCS Vintage Cube", value="APR25"),
+                discord.SelectOption(label="2025 MOCS Vintage Cube", value="3txn8"),
                 discord.SelectOption(label="LSVRetro", value="LSVRetro"),
                 discord.SelectOption(label="PowerLSV", value="PowerLSV"),
                 discord.SelectOption(label="Powerslax", value="Powerslax"),


### PR DESCRIPTION
## Summary

Updates the 2025 MOCS Vintage Cube reference to use the correct CubeCobra URL.

### Changes Made

- Updated `modals.py`: Changed APR25 to 3txn8 in both CubeDraftSelectionView and StakedCubeDraftSelectionView dropdown options
- Updated `cube_views/CubeSelectionView.py`: Changed APR25 to 3txn8 in CubeUpdateSelectionView dropdown options

### Technical Details

The bot uses cube codes as identifiers in dropdown menus, which are then used to construct CubeCobra URLs dynamically using the pattern `https://cubecobra.com/cube/list/{cube_code}`.

**Before**: `https://cubecobra.com/cube/list/APR25`  
**After**: `https://cubecobra.com/cube/list/3txn8`

### Files Changed

- `modals.py` (2 locations)
- `cube_views/CubeSelectionView.py` (1 location)

### Impact

Users selecting "2025 MOCS Vintage Cube" from any draft creation dropdown will now be directed to the correct CubeCobra cube at https://cubecobra.com/cube/overview/3txn8.