### PR TITLE
remove restriction on ready check

### DIFF
--- a/views.py
+++ b/views.py
@@ -747,9 +747,9 @@ class PersistentView(discord.ui.View):
             return        
         
         sign_up_count = len(session.sign_ups)
-        if sign_up_count not in (6,8,10):
+        if sign_up_count < 6:
             await interaction.response.send_message(
-                f"Ready check only available with 6, 8, or 10 players. Currently {sign_up_count} players in queue."
+                f"Ready check only available with 6 or more players. Currently {sign_up_count} players in queue."
             )
             return
 


### PR DESCRIPTION
# Allow Ready Checks for Any Number of Players 6+

## Summary

Updates the ready check functionality to allow ready checks for any number of players 6 or above, removing the previous restriction that limited ready checks to exactly 6, 8, or 10 players.

## Background

This was a requested feature to improve draft management flexibility. Previously, if a draft had an odd number of players (like 7 or 9), users couldn't perform a ready check to verify attendance. This forced organizers to either wait for more players or kick someone without knowing if everyone was actually present.

## Changes Made

- **Updated `views.py:750`**: Changed condition from `if sign_up_count not in (6,8,10):` to `if sign_up_count < 6:`
- **Updated error message**: Changed from "Ready check only available with 6, 8, or 10 players" to "Ready check only available with 6 or more players"

## Use Case

This change enables better draft management by allowing organizers to:
1. Start a ready check with any number of players 6 or above (including odd numbers like 7, 9, 11, etc.)
2. Verify who is actually present before making decisions about draft size
3. If someone is missing, they can decide whether to wait or kick down to a lower even number for team balance

## Technical Details

**Before**: Ready checks only worked for exactly 6, 8, or 10 players  
**After**: Ready checks work for any number ≥ 6 players

The minimum of 6 players is maintained as this represents the practical minimum for team drafts.

## Impact

- Improved flexibility for draft organizers
- Better attendance verification at all player counts
- Enables informed decision-making about draft size adjustments
- No breaking changes to existing functionality
