### PR TITLE
Fix ready check cleanup bugs and refactor into ReadyCheckSession

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ sudo journalctl -u draftbot.service -f       # View logs
 - Test locally with a copy of production data
 - Use `./fetch_prod_db.sh` to get production database
 - Always test migrations before deployment
-- **CRITICAL**: Check `config.py` - `TEST_MODE_ENABLED` should be `True` for testing
-- **NEVER commit with `TEST_MODE_ENABLED = True`** - always reset to `False` before committing
+- **CRITICAL**: Set `TEST_MODE=true` in `.env` (or environment) to enable test features locally
+- **NEVER set `TEST_MODE=true` in production** - production `.env` should not have this set
 
 #### Running Tests
 Tests are located in the `tests/` directory. **IMPORTANT:** Always use `python -m pytest` instead of `pytest`:
@@ -99,9 +99,9 @@ pipenv run python -m pytest tests/test_seating_order.py::TestSeatingOrder::test_
 - Guild-specific configurations in `config.py`
 - Special guild (`SPECIAL_GUILD_ID`) has enhanced features
 - Configuration files stored in `/configs/` directory as JSON
-- **Test Mode**: `TEST_MODE_ENABLED` flag in `config.py` controls test features
-  - Set to `True` for local testing/development
-  - **MUST be `False` for production commits**
+- **Test Mode**: `is_test_mode()` function in `config.py` reads the `TEST_MODE` env var
+  - Set `TEST_MODE=true` in `.env` for local testing/development
+  - Production `.env` should not include `TEST_MODE`
 
 ### Error Handling
 - Comprehensive logging with loguru
@@ -152,7 +152,7 @@ pipenv run python -m pytest tests/test_seating_order.py::TestSeatingOrder::test_
 3. **Commands**: Implement Discord slash commands
 4. **Views**: Add interactive UI components
 5. **Test**: Test with production data copy using `pipenv run`
-6. **Pre-commit Check**: Ensure `TEST_MODE_ENABLED = False` in `config.py`
+6. **Pre-commit Check**: Ensure `TEST_MODE=true` is not in the production `.env`
 7. **Deploy**: Use service restart for automatic migration
 
 ### Code Quality
@@ -163,7 +163,7 @@ pipenv run python -m pytest tests/test_seating_order.py::TestSeatingOrder::test_
 - Include logging for debugging
 - Write descriptive commit messages
 - **Pre-commit checklist**:
-  - [ ] `TEST_MODE_ENABLED = False` in `config.py`
+  - [ ] `TEST_MODE=true` is not set in production environment
   - [ ] All commands tested with `pipenv run`
   - [ ] Database migrations tested locally
 

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -619,14 +619,14 @@ class AdminCommands(commands.Cog):
     @has_bot_manager_role()
     async def test_disconnect(self, ctx):
         """Simulate a Draftmancer connection failure to test the notification system."""
-        from config import TEST_MODE_ENABLED
+        from config import is_test_mode
         from services.draft_setup_manager import ACTIVE_MANAGERS
 
         await ctx.defer(ephemeral=True)
 
-        if not TEST_MODE_ENABLED:
+        if not is_test_mode():
             await ctx.followup.send(
-                "❌ This command is only available when TEST_MODE_ENABLED is True in config.py",
+                "❌ This command is only available when TEST_MODE=true is set in the environment",
                 ephemeral=True
             )
             return

--- a/cogs/test_commands.py
+++ b/cogs/test_commands.py
@@ -1,12 +1,12 @@
 """
-Test-only commands. This cog only loads when TEST_MODE_ENABLED is True in config.py.
+Test-only commands. This cog only loads when TEST_MODE=true is set in the environment.
 """
 import asyncio
 import discord
 from discord.ext import commands
 from loguru import logger
 
-from config import TEST_MODE_ENABLED
+from config import is_test_mode
 from helpers.permissions import has_bot_manager_role
 
 
@@ -73,7 +73,7 @@ class TestCommands(commands.Cog):
 
 
 def setup(bot):
-    if not TEST_MODE_ENABLED:
-        logger.info("Test commands cog skipped (TEST_MODE_ENABLED is False)")
+    if not is_test_mode():
+        logger.info("Test commands cog skipped (TEST_MODE is not enabled)")
         return
     bot.add_cog(TestCommands(bot))

--- a/config.py
+++ b/config.py
@@ -11,9 +11,9 @@ SPECIAL_GUILD_ID = "336345350535118849"
 # Change this to switch between environments (prod, beta, dev)
 DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
-# Global flag to enable test features
-# Set to True during development to enable test buttons, False for production
-TEST_MODE_ENABLED = False
+def is_test_mode() -> bool:
+    """Returns True if TEST_MODE env var is set to a truthy value."""
+    return os.environ.get("TEST_MODE", "false").lower() in ("true", "1", "yes")
 
 class Config:
     def __init__(self):

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -16,7 +16,7 @@ class DraftSession(Base):
     true_skill_draft = Column(Boolean, default=False)
     ready_check_message_id = Column(String(64))
     draft_link = Column(String(256))
-    ready_check_status = Column(JSON)
+    ready_check_status = Column(JSON) # deprecated
     draft_start_time = Column(DateTime, default=datetime.now)
     deletion_time = Column(DateTime)
     teams_start_time = Column(DateTime)

--- a/ready_check.py
+++ b/ready_check.py
@@ -1,0 +1,310 @@
+import discord
+from loguru import logger
+from typing import Dict, Iterable, List, Literal, Optional
+
+from helpers.display_names import get_display_name_by_id
+from services.state_manager import state_manager
+from services.team_creator import create_and_display_teams
+from session import get_draft_session
+
+PlayerStatus = Literal['ready', 'not_ready', 'no_response']
+
+
+class ReadyCheckSession:
+    """In-memory state, business logic, and coordination for a single active in-chat ready check."""
+
+    def __init__(self, player_ids: Iterable[str], message_id: Optional[int] = None):
+        self.message_id: Optional[int] = message_id
+        # Single source of truth: player_id -> status
+        self._players: Dict[str, PlayerStatus] = {pid: 'no_response' for pid in player_ids}
+
+    # --- player state ---
+
+    def set_status(self, player_id: str, status: PlayerStatus) -> None:
+        """Update a tracked player's status. No-op if not in the check."""
+        if player_id in self._players:
+            self._players[player_id] = status
+
+    def add_player(self, player_id: str) -> None:
+        """Add a newly joined player as no_response. No-op if already tracked."""
+        if player_id not in self._players:
+            self._players[player_id] = 'no_response'
+
+    def remove_player(self, player_id: str) -> None:
+        """Remove a player who left the draft. No-op if not present."""
+        self._players.pop(player_id, None)
+
+    def has_player(self, player_id: str) -> bool:
+        return player_id in self._players
+
+    def players_with_status(self, status: PlayerStatus) -> List[str]:
+        return [pid for pid, s in self._players.items() if s == status]
+
+    def all_ready(self) -> bool:
+        """True when every player has responded ready and at least one player exists."""
+        return (
+            len(self._players) > 0
+            and all(s == 'ready' for s in self._players.values())
+        )
+
+    @property
+    def ready(self) -> List[str]:
+        return self.players_with_status('ready')
+
+    @property
+    def not_ready(self) -> List[str]:
+        return self.players_with_status('not_ready')
+
+    @property
+    def no_response(self) -> List[str]:
+        return self.players_with_status('no_response')
+
+    # --- Discord message operations (instance) ---
+
+    async def build_embed(self, sign_ups: dict, guild=None) -> discord.Embed:
+        """Build a ready check embed from current player state."""
+        def get_names(user_ids):
+            names = []
+            for uid in user_ids:
+                if guild:
+                    name = get_display_name_by_id(uid, guild, sign_ups.get(uid, "Unknown user"))
+                else:
+                    name = sign_ups.get(uid, "Unknown user")
+                names.append(name)
+            return "\n".join(names) or "None"
+
+        embed = discord.Embed(
+            title="Ready Check Initiated",
+            description="Please indicate if you are ready.\n\nDraftmancer links will be provided once teams are created.",
+            color=discord.Color.gold()
+        )
+        embed.add_field(name="Ready", value=get_names(self.ready), inline=False)
+        embed.add_field(name="Not Ready", value=get_names(self.not_ready), inline=False)
+        embed.add_field(name="No Response", value=get_names(self.no_response), inline=False)
+        return embed
+
+    async def delete_message(self, channel) -> None:
+        """Delete the Discord ready check message. No-op if message is missing or already gone."""
+        if not (self.message_id and channel):
+            return
+        try:
+            msg = await channel.fetch_message(self.message_id)
+            await msg.delete()
+        except discord.NotFound:
+            pass
+        except Exception as e:
+            logger.error(f"Error deleting ready check message {self.message_id}: {e}")
+
+    async def refresh_embed(self, channel, sign_ups: dict, guild=None, title: Optional[str] = None) -> bool:
+        """Rebuild the embed and edit the Discord message in-place.
+        Returns True on success. On NotFound, clears message_id and returns False.
+        """
+        if not self.message_id:
+            return False
+        try:
+            embed = await self.build_embed(sign_ups, guild=guild)
+            if title:
+                embed.title = title
+            msg = await channel.fetch_message(self.message_id)
+            await msg.edit(embed=embed)
+            return True
+        except discord.NotFound:
+            self.message_id = None
+            return False
+        except Exception as e:
+            logger.error(f"Error refreshing ready check embed: {e}")
+            return False
+
+    # --- class-level entry points (fetch session from state, delegate to instance) ---
+
+    @classmethod
+    async def cleanup(cls, session_id: str, channel) -> None:
+        """Delete the ready check message and remove the session from state."""
+        rc = state_manager.get_ready_check(session_id)
+        if rc:
+            await rc.delete_message(channel)
+        state_manager.remove_ready_check(session_id)
+
+    @classmethod
+    async def cancel(cls, session_id: str, bot, channel, cancelled_by: str) -> None:
+        """Abort the ready check, clean up, announce, and re-enable the Ready Check button."""
+        # Deferred to avoid circular import: ready_check -> views
+        from views import PersistentView
+
+        draft_session = await get_draft_session(session_id)
+        await cls.cleanup(session_id, channel)
+        await channel.send(f"**{cancelled_by}** cancelled the ready check.")
+
+        if not (draft_session and draft_session.message_id):
+            return
+        try:
+            draft_message = await channel.fetch_message(int(draft_session.message_id))
+            restored_view = PersistentView(
+                bot=bot,
+                draft_session_id=session_id,
+                session_type=draft_session.session_type,
+                team_a_name=draft_session.team_a_name,
+                team_b_name=draft_session.team_b_name
+            )
+            await draft_message.edit(view=restored_view)
+        except discord.NotFound:
+            pass
+        except Exception as e:
+            logger.error(f"Error restoring draft message after ready check cancel: {e}")
+
+    @classmethod
+    async def sync_added_player(cls, session_id: str, user_id: str, draft_session, interaction: discord.Interaction) -> None:
+        """Add a newly joined player to the active ready check and refresh the embed."""
+        rc = state_manager.get_ready_check(session_id)
+        if not rc:
+            return
+        rc.add_player(user_id)
+        await rc.refresh_embed(interaction.channel, draft_session.sign_ups, guild=interaction.guild)
+
+    @classmethod
+    async def sync_removed_player(cls, session_id: str, user_id: str, draft_session, interaction: discord.Interaction) -> None:
+        """Remove a player from the active ready check, refresh the embed, and trigger auto-create if all ready."""
+        rc = state_manager.get_ready_check(session_id)
+        if not rc:
+            return
+        rc.remove_player(user_id)
+        updated = await rc.refresh_embed(interaction.channel, draft_session.sign_ups, guild=interaction.guild)
+        if updated and rc.all_ready():
+            await cls.handle_all_ready(session_id, draft_session, interaction)
+
+    @classmethod
+    async def handle_all_ready(cls, session_id: str, draft_session, interaction: discord.Interaction) -> None:
+        """Update the ready check embed to the all-ready state, then create teams."""
+        rc = state_manager.get_ready_check(session_id)
+        if rc:
+            await rc.refresh_embed(
+                interaction.channel,
+                draft_session.sign_ups,
+                guild=interaction.guild,
+                title="✅ Ready Check Complete - All Players Ready!"
+            )
+
+        if state_manager.is_creating_teams(session_id):
+            logger.warning(f"Teams already being created for {session_id}")
+            return
+
+        state_manager.set_creating_teams(session_id, True)
+        try:
+            await interaction.channel.send("✅ **All players ready!** Creating teams now...")
+
+            bot = interaction.client
+            if not (draft_session and draft_session.message_id and draft_session.draft_channel_id):
+                return
+
+            channel = bot.get_channel(int(draft_session.draft_channel_id))
+            if not channel:
+                return
+
+            message = await channel.fetch_message(int(draft_session.message_id))
+
+            # Deferred to avoid circular import: views -> ready_check -> views
+            from views import PersistentView
+
+            persistent_view = PersistentView(
+                bot=bot,
+                draft_session_id=session_id,
+                session_type=draft_session.session_type,
+                team_a_name=draft_session.team_a_name,
+                team_b_name=draft_session.team_b_name
+            )
+
+            class _ChannelInteraction:
+                def __init__(self, original, msg):
+                    self.user = original.user
+                    self.guild = original.guild
+                    self.guild_id = original.guild_id
+                    self.channel = original.channel
+                    self.client = original.client
+                    self.message = msg
+                    self._followup = original.followup
+
+                @property
+                def followup(self):
+                    return self._followup
+
+            mock_interaction = _ChannelInteraction(interaction, message)
+            success = await create_and_display_teams(bot, session_id, mock_interaction, persistent_view)
+            if success:
+                await interaction.channel.send("✅ Teams created! Check the draft message above for teams and seating order.")
+            else:
+                await interaction.channel.send("❌ Error creating teams. You can try using the Create Teams button manually.")
+        except Exception as e:
+            logger.error(f"Error auto-creating teams after ready check: {e}")
+            await interaction.channel.send(f"❌ Error creating teams: {str(e)}\nYou can try using the Create Teams button manually.")
+        finally:
+            state_manager.set_creating_teams(session_id, False)
+
+
+class ReadyCheckView(discord.ui.View):
+    def __init__(self, draft_session_id):
+        super().__init__(timeout=None)
+        self.draft_session_id = draft_session_id
+        self.ready_button.custom_id = f"ready_check_ready_{self.draft_session_id}"
+        self.not_ready_button.custom_id = f"ready_check_not_ready_{self.draft_session_id}"
+        self.cancel_button.custom_id = f"ready_check_cancel_{self.draft_session_id}"
+
+    @discord.ui.button(label="Ready", style=discord.ButtonStyle.green, custom_id="placeholder_ready")
+    async def ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await self._handle_status(interaction, "ready")
+
+    @discord.ui.button(label="Not Ready", style=discord.ButtonStyle.red, custom_id="placeholder_not_ready")
+    async def not_ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await self._handle_status(interaction, "not_ready")
+
+    @discord.ui.button(label="Cancel Check", style=discord.ButtonStyle.grey, custom_id="placeholder_cancel_rc")
+    async def cancel_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            "Are you sure you want to cancel the ready check?",
+            view=ReadyCheckCancelConfirmView(self.draft_session_id, interaction.user.display_name),
+            ephemeral=True,
+        )
+
+    async def _handle_status(self, interaction: discord.Interaction, status: PlayerStatus) -> None:
+        rc = state_manager.get_ready_check(self.draft_session_id)
+        if not rc:
+            await interaction.response.send_message("Session data is missing.", ephemeral=True)
+            return
+
+        user_id = str(interaction.user.id)
+        if not rc.has_player(user_id):
+            await interaction.response.send_message("You are not authorized to interact with this button.", ephemeral=True)
+            return
+
+        rc.set_status(user_id, status)
+
+        draft_session = await get_draft_session(self.draft_session_id)
+        embed = await rc.build_embed(draft_session.sign_ups, guild=interaction.guild)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+        if rc.all_ready():
+            await ReadyCheckSession.handle_all_ready(self.draft_session_id, draft_session, interaction)
+
+
+class ReadyCheckCancelConfirmView(discord.ui.View):
+    def __init__(self, draft_session_id: str, cancelled_by: str):
+        super().__init__(timeout=60)
+        self.draft_session_id = draft_session_id
+        self.cancelled_by = cancelled_by
+
+    @discord.ui.button(label="Yes, Cancel", style=discord.ButtonStyle.danger)
+    async def confirm_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(view=self)
+        await ReadyCheckSession.cancel(
+            self.draft_session_id,
+            interaction.client,
+            interaction.channel,
+            cancelled_by=self.cancelled_by,
+        )
+
+    @discord.ui.button(label="No, Keep Going", style=discord.ButtonStyle.secondary)
+    async def deny_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        for child in self.children:
+            child.disabled = True
+        await interaction.response.edit_message(content="Cancelled.", view=self)

--- a/scripts/cleanup_test_channels.py
+++ b/scripts/cleanup_test_channels.py
@@ -10,7 +10,7 @@ Usage:
     pipenv run python scripts/cleanup_test_channels.py
 
 Safety Features:
-- Only works in test mode (TEST_MODE_ENABLED = True in config.py)
+- Only works in test mode (TEST_MODE=true in environment or .env)
 - Prompts for confirmation before deleting channels
 - Shows preview of channels to be deleted
 - Logs all deletions for audit trail
@@ -27,7 +27,7 @@ from dotenv import load_dotenv
 # Add parent directory to path to import project modules
 sys.path.append(str(Path(__file__).parent.parent))
 
-from config import TEST_MODE_ENABLED, get_config
+from config import is_test_mode, get_config
 
 # Load environment variables
 load_dotenv()
@@ -151,13 +151,13 @@ class ChannelCleanup:
         """Main cleanup function"""
         
         # Safety check - only run in test mode
-        if not TEST_MODE_ENABLED:
-            logger.error("ERROR: This script only runs when TEST_MODE_ENABLED = True in config.py")
+        if not is_test_mode():
+            logger.error("ERROR: This script only runs when TEST_MODE=true is set in the environment")
             logger.error("This prevents accidental deletion of production channels.")
             return False
-            
+
         logger.info("Starting test channel cleanup...")
-        logger.info("TEST_MODE_ENABLED = True - Proceeding with cleanup")
+        logger.info("TEST_MODE=true - Proceeding with cleanup")
         
         # Get guilds to clean up
         guilds_to_process = []
@@ -232,10 +232,10 @@ async def main():
         logger.add(sys.stderr, level="DEBUG")
     
     # Safety check
-    if not TEST_MODE_ENABLED:
+    if not is_test_mode():
         logger.error("\n" + "="*60)
         logger.error("SAFETY CHECK FAILED")
-        logger.error("TEST_MODE_ENABLED must be True in config.py")
+        logger.error("TEST_MODE=true must be set in the environment")
         logger.error("This prevents accidental deletion of production channels")
         logger.error("="*60)
         return 1

--- a/services/state_manager.py
+++ b/services/state_manager.py
@@ -2,8 +2,9 @@
 Registry for global state to prevent circular dependencies in views.py
 and provide clear typing for shared state.
 """
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 from datetime import datetime
+
 
 class DraftStateManager:
     """
@@ -13,68 +14,68 @@ class DraftStateManager:
     def __init__(self):
         # Maps user_id -> datetime of last ready check usage
         self.ready_check_cooldowns: Dict[str, datetime] = {}
-        
+
         # Maps session_id -> bool indicating if room creation/pairings is in progress
         self.processing_rooms_pairings: Dict[str, bool] = {}
-        
+
         # Maps session_id -> bool indicating if team creation is in progress
         self.processing_teams_creation: Dict[str, bool] = {}
-        
-        # Maps session_id -> Dict containing ready check state/data
-        # (Legacy: Was just a dict in views.py, exact type depends on usage in ReadyCheckView)
-        self.sessions: Dict[str, Any] = {}
+
+        # Maps session_id -> ReadyCheckSession (defined in ready_check.py)
+        self.ready_checks: Dict[str, Any] = {}
+
+    # --- team creation ---
 
     def is_creating_teams(self, session_id: str) -> bool:
-        """Check if teams are currently being created for a session."""
         return self.processing_teams_creation.get(session_id, False)
 
     def set_creating_teams(self, session_id: str, status: bool) -> None:
-        """Set the team creation status for a session."""
         if status:
             self.processing_teams_creation[session_id] = True
         elif session_id in self.processing_teams_creation:
             del self.processing_teams_creation[session_id]
 
+    # --- room processing ---
+
     def is_processing_rooms(self, session_id: str) -> bool:
-        """Check if rooms/pairings are currently being processed for a session."""
         return self.processing_rooms_pairings.get(session_id, False)
 
     def set_processing_rooms(self, session_id: str, status: bool) -> None:
-        """Set the room processing status for a session."""
         if status:
             self.processing_rooms_pairings[session_id] = True
         elif session_id in self.processing_rooms_pairings:
             del self.processing_rooms_pairings[session_id]
-            
-    def get_ready_check_session(self, session_id: str) -> Optional[Any]:
-        """Get the ready check session data."""
-        return self.sessions.get(session_id)
-        
-    def set_ready_check_session(self, session_id: str, data: Any) -> None:
-        """Set the ready check session data."""
-        self.sessions[session_id] = data
-        
-    def remove_ready_check_session(self, session_id: str) -> None:
-        """Remove a ready check session."""
-        if session_id in self.sessions:
-            del self.sessions[session_id]
 
-    def session_exists(self, session_id: str) -> bool:
-        """Check if a ready check session exists."""
-        return session_id in self.sessions
+    # --- ready checks ---
+
+    def get_ready_check(self, session_id: str) -> Any:
+        """Return the active ReadyCheckSession for a session, or None."""
+        return self.ready_checks.get(session_id)
+
+    def set_ready_check(self, session_id: str, rc: Any) -> None:
+        """Register an active ReadyCheckSession for a session."""
+        self.ready_checks[session_id] = rc
+
+    def remove_ready_check(self, session_id: str) -> None:
+        """Remove the ready check for a session, clearing all associated state."""
+        self.ready_checks.pop(session_id, None)
+
+    def has_ready_check(self, session_id: str) -> bool:
+        """Return True if a ready check is currently active for the session."""
+        return session_id in self.ready_checks
+
+    # --- cooldowns ---
 
     def get_cooldown(self, user_id: str) -> Optional[datetime]:
-        """Get the cooldown expiration time for a user."""
         return self.ready_check_cooldowns.get(user_id)
-        
+
     def set_cooldown(self, user_id: str, timestamp: datetime) -> None:
-        """Set the cooldown expiration time for a user."""
         self.ready_check_cooldowns[user_id] = timestamp
 
     def remove_cooldown(self, user_id: str) -> None:
-        """Remove a cooldown for a user."""
         if user_id in self.ready_check_cooldowns:
             del self.ready_check_cooldowns[user_id]
+
 
 # Global singleton instance
 state_manager = DraftStateManager()

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -69,15 +69,15 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
 
                 stake_info_by_player = {}
 
+                # Clean up any active ready check, regardless of session type
+                from ready_check import ReadyCheckSession
+                rc_channel = bot.get_channel(int(session.draft_channel_id)) if session.draft_channel_id else None
+                await ReadyCheckSession.cleanup(session_id, rc_channel)
+
                 # Create teams for random/test/staked/winston drafts
                 if session.session_type in ['random', 'test', 'staked', 'winston']:
                     await split_into_teams(bot, session.session_id)
                     updated_session = await DraftSessionModel.get_by_session_id(draft_session_id)
-
-                    # Clean up ready check data if it exists
-                    if state_manager.get_ready_check_session(session_id):
-                        logger.info(f"✅ Teams created - removing ready check data for session {session_id}")
-                        state_manager.remove_ready_check_session(session_id)
 
                     # Calculate stakes for staked drafts
                     if persistent_view.session_type == "staked" and updated_session and updated_session.team_a and updated_session.team_b:

--- a/tests/test_ready_check.py
+++ b/tests/test_ready_check.py
@@ -1,0 +1,410 @@
+"""Unit tests for ready_check.py.
+
+Covers pure logic and all classmethod paths using mocks — no live Discord needed.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+
+from ready_check import (
+    ReadyCheckCancelConfirmView,
+    ReadyCheckSession,
+)
+
+
+# ---------------------------------------------------------------------------
+# _all_ready
+# ---------------------------------------------------------------------------
+
+class TestReadyCheckSessionAllReady:
+    def _rc(self, ready=(), not_ready=(), no_response=()):
+        rc = ReadyCheckSession(player_ids=list(ready) + list(not_ready) + list(no_response))
+        for pid in ready:
+            rc.set_status(pid, 'ready')
+        for pid in not_ready:
+            rc.set_status(pid, 'not_ready')
+        return rc
+
+    def test_all_responded_ready(self):
+        assert self._rc(ready=["1", "2", "3"]).all_ready() is True
+
+    def test_some_not_ready(self):
+        assert self._rc(ready=["1"], not_ready=["2"]).all_ready() is False
+
+    def test_some_no_response(self):
+        assert self._rc(ready=["1"], no_response=["2"]).all_ready() is False
+
+    def test_nobody_ready(self):
+        assert self._rc(no_response=["1", "2"]).all_ready() is False
+
+    def test_no_players(self):
+        assert ReadyCheckSession(player_ids=[]).all_ready() is False
+
+    def test_single_player_ready(self):
+        assert self._rc(ready=["1"]).all_ready() is True
+
+    def test_mixed_all_three_lists(self):
+        assert self._rc(ready=["1"], not_ready=["2"], no_response=["3"]).all_ready() is False
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.build_embed
+# ---------------------------------------------------------------------------
+
+def _make_rc_with_statuses(ready=(), not_ready=(), no_response=(), message_id=None):
+    """Build a ReadyCheckSession with explicit per-bucket membership."""
+    rc = ReadyCheckSession(player_ids=list(ready) + list(not_ready) + list(no_response), message_id=message_id)
+    for pid in ready:
+        rc.set_status(pid, 'ready')
+    for pid in not_ready:
+        rc.set_status(pid, 'not_ready')
+    return rc
+
+
+@pytest.mark.asyncio
+class TestBuildEmbed:
+    async def test_returns_embed_with_three_fields(self):
+        sign_ups = {"1": "Alice", "2": "Bob"}
+        rc = _make_rc_with_statuses(ready=["1"], no_response=["2"])
+        embed = await rc.build_embed(sign_ups)
+        assert isinstance(embed, discord.Embed)
+        field_names = [f.name for f in embed.fields]
+        assert "Ready" in field_names
+        assert "Not Ready" in field_names
+        assert "No Response" in field_names
+
+    async def test_none_shown_for_empty_list(self):
+        sign_ups = {"1": "Alice"}
+        rc = _make_rc_with_statuses(ready=["1"])
+        embed = await rc.build_embed(sign_ups)
+        not_ready_field = next(f for f in embed.fields if f.name == "Not Ready")
+        assert not_ready_field.value == "None"
+
+    async def test_falls_back_to_unknown_user(self):
+        sign_ups = {}
+        rc = _make_rc_with_statuses(ready=["999"])
+        embed = await rc.build_embed(sign_ups)
+        ready_field = next(f for f in embed.fields if f.name == "Ready")
+        assert "Unknown user" in ready_field.value
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.cleanup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestCleanup:
+    def _make_channel(self, raise_not_found=False, raise_other=False):
+        channel = MagicMock()
+        if raise_not_found:
+            channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "not found"))
+        elif raise_other:
+            channel.fetch_message = AsyncMock(side_effect=RuntimeError("boom"))
+        else:
+            msg = MagicMock()
+            msg.delete = AsyncMock()
+            channel.fetch_message = AsyncMock(return_value=msg)
+        return channel
+
+    def _rc(self, message_id=42):
+        return ReadyCheckSession(player_ids=["1"], message_id=message_id)
+
+    async def test_deletes_message_and_clears_state(self):
+        channel = self._make_channel()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = self._rc(message_id=42)
+            await ReadyCheckSession.cleanup("sid", channel)
+
+        channel.fetch_message.assert_awaited_once_with(42)
+        channel.fetch_message.return_value.delete.assert_awaited_once()
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+    async def test_no_message_id_skips_fetch(self):
+        channel = self._make_channel()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = self._rc(message_id=None)
+            await ReadyCheckSession.cleanup("sid", channel)
+
+        channel.fetch_message.assert_not_awaited()
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+    async def test_no_ready_check_skips_fetch(self):
+        channel = self._make_channel()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = None
+            await ReadyCheckSession.cleanup("sid", channel)
+
+        channel.fetch_message.assert_not_awaited()
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+    async def test_none_channel_skips_fetch(self):
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = self._rc(message_id=99)
+            await ReadyCheckSession.cleanup("sid", None)
+
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+    async def test_not_found_is_swallowed(self):
+        channel = self._make_channel(raise_not_found=True)
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = self._rc()
+            await ReadyCheckSession.cleanup("sid", channel)  # Should not raise
+
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+    async def test_other_error_is_swallowed_state_still_cleared(self):
+        channel = self._make_channel(raise_other=True)
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = self._rc()
+            await ReadyCheckSession.cleanup("sid", channel)
+
+        sm.remove_ready_check.assert_called_once_with("sid")
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.cancel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestCancel:
+    def _make_channel(self, draft_msg=None):
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        msg = draft_msg or MagicMock()
+        msg.edit = AsyncMock()
+        channel.fetch_message = AsyncMock(return_value=msg)
+        return channel
+
+    def _make_session(self, message_id="777", channel_id="888"):
+        s = MagicMock()
+        s.message_id = message_id
+        s.draft_channel_id = channel_id
+        s.session_type = "random"
+        s.team_a_name = "Team A"
+        s.team_b_name = "Team B"
+        return s
+
+    async def test_posts_cancellation_message(self):
+        channel = self._make_channel()
+        bot = MagicMock()
+        with patch("ready_check.get_draft_session", AsyncMock(return_value=self._make_session())), \
+             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+             patch("ready_check.state_manager"), \
+             patch("views.PersistentView", MagicMock()):
+            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Alice")
+
+        channel.send.assert_awaited_once()
+        assert "Alice" in channel.send.call_args.args[0]
+
+    async def test_restores_draft_message_view(self):
+        channel = self._make_channel()
+        bot = MagicMock()
+        session = self._make_session()
+        mock_persistent_view = MagicMock()
+
+        with patch("ready_check.get_draft_session", AsyncMock(return_value=session)), \
+             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+             patch("ready_check.state_manager"), \
+             patch("views.PersistentView", return_value=mock_persistent_view):
+            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Bob")
+
+        channel.fetch_message.assert_awaited_once_with(int(session.message_id))
+        channel.fetch_message.return_value.edit.assert_awaited_once()
+
+    async def test_no_session_skips_draft_message_edit(self):
+        channel = self._make_channel()
+        bot = MagicMock()
+        with patch("ready_check.get_draft_session", AsyncMock(return_value=None)), \
+             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+             patch("ready_check.state_manager"):
+            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Eve")
+
+        channel.fetch_message.assert_not_awaited()
+
+    async def test_draft_message_not_found_is_swallowed(self):
+        channel = self._make_channel()
+        channel.fetch_message = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(), "gone")
+        )
+        bot = MagicMock()
+        with patch("ready_check.get_draft_session", AsyncMock(return_value=self._make_session())), \
+             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+             patch("ready_check.state_manager"), \
+             patch("views.PersistentView", MagicMock()):
+            # Should not raise
+            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Eve")
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.sync_removed_player
+# ---------------------------------------------------------------------------
+
+def _make_rc(ready=(), not_ready=(), no_response=(), message_id=55):
+    return _make_rc_with_statuses(ready=ready, not_ready=not_ready, no_response=no_response, message_id=message_id)
+
+
+def _make_interaction(guild=None):
+    interaction = MagicMock()
+    interaction.guild = guild or MagicMock()
+    msg = MagicMock()
+    msg.edit = AsyncMock()
+    interaction.channel = MagicMock()
+    interaction.channel.fetch_message = AsyncMock(return_value=msg)
+    return interaction
+
+
+def _make_draft_session():
+    ds = MagicMock()
+    ds.sign_ups = {"1": "Alice", "2": "Bob"}
+    ds.draft_link = None
+    return ds
+
+
+@pytest.mark.asyncio
+class TestSyncRemovedPlayer:
+    async def test_removes_player_from_ready(self):
+        rc = _make_rc(ready=["1", "2"])
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "1", _make_draft_session(), _make_interaction())
+
+        assert "1" not in rc.ready
+        assert "2" in rc.ready
+
+    async def test_removes_player_from_no_response(self):
+        rc = _make_rc(ready=["1"], no_response=["2"])
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "2", _make_draft_session(), _make_interaction())
+
+        assert "2" not in rc.no_response
+
+    async def test_no_active_ready_check_is_noop(self):
+        interaction = _make_interaction()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = None
+            await ReadyCheckSession.sync_removed_player("sid", "1", _make_draft_session(), interaction)
+
+        interaction.channel.fetch_message.assert_not_awaited()
+
+    async def test_no_message_id_is_noop(self):
+        rc = _make_rc(no_response=["1"], message_id=None)
+        interaction = _make_interaction()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "1", _make_draft_session(), interaction)
+
+        interaction.channel.fetch_message.assert_not_awaited()
+
+    async def test_message_not_found_clears_message_id(self):
+        rc = _make_rc(ready=["1"], no_response=["2"])
+        interaction = _make_interaction()
+        interaction.channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "gone"))
+
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "2", _make_draft_session(), interaction)
+
+        assert rc.message_id is None
+
+    async def test_triggers_auto_create_when_all_ready(self):
+        rc = _make_rc(ready=["1"], no_response=["2"])
+        with patch("ready_check.state_manager") as sm, \
+             patch.object(ReadyCheckSession, "handle_all_ready", AsyncMock()) as mock_trigger:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "2", _make_draft_session(), _make_interaction())
+
+        mock_trigger.assert_awaited_once()
+
+    async def test_does_not_handle_all_ready_when_not_all_ready(self):
+        rc = _make_rc(ready=["1"], no_response=["2", "3"])
+        with patch("ready_check.state_manager") as sm, \
+             patch.object(ReadyCheckSession, "handle_all_ready", AsyncMock()) as mock_trigger:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_removed_player("sid", "2", _make_draft_session(), _make_interaction())
+
+        mock_trigger.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.sync_added_player
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestSyncAddedPlayer:
+    async def test_adds_player_to_no_response(self):
+        rc = _make_rc(ready=["1"])
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), _make_interaction())
+
+        assert "2" in rc.no_response
+
+    async def test_no_active_ready_check_is_noop(self):
+        interaction = _make_interaction()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = None
+            await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), interaction)
+
+        interaction.channel.fetch_message.assert_not_awaited()
+
+    async def test_already_tracked_is_noop(self):
+        rc = _make_rc(ready=["1"], no_response=["2"])
+        interaction = _make_interaction()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), interaction)
+
+        assert rc.no_response.count("2") == 1  # Not added a second time
+
+    async def test_no_message_id_skips_embed_update(self):
+        rc = _make_rc(ready=["1"], message_id=None)
+        interaction = _make_interaction()
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), interaction)
+
+        interaction.channel.fetch_message.assert_not_awaited()
+        assert "2" in rc.no_response  # Player was still added to state
+
+    async def test_message_not_found_clears_message_id(self):
+        rc = _make_rc(ready=["1"])
+        interaction = _make_interaction()
+        interaction.channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "gone"))
+
+        with patch("ready_check.state_manager") as sm:
+            sm.get_ready_check.return_value = rc
+            await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), interaction)
+
+        assert rc.message_id is None
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckCancelConfirmView construction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestReadyCheckCancelConfirmView:
+    async def test_has_two_buttons(self):
+        view = ReadyCheckCancelConfirmView("sid", "Alice")
+        buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+        assert len(buttons) == 2
+
+    async def test_confirm_button_is_danger(self):
+        view = ReadyCheckCancelConfirmView("sid", "Alice")
+        confirm = next(c for c in view.children if "Yes" in c.label)
+        assert confirm.style == discord.ButtonStyle.danger
+
+    async def test_deny_button_is_secondary(self):
+        view = ReadyCheckCancelConfirmView("sid", "Alice")
+        deny = next(c for c in view.children if "No" in c.label)
+        assert deny.style == discord.ButtonStyle.secondary
+
+    async def test_stores_cancelled_by(self):
+        view = ReadyCheckCancelConfirmView("sid", "Charlie")
+        assert view.cancelled_by == "Charlie"
+
+    async def test_timeout_is_60(self):
+        view = ReadyCheckCancelConfirmView("sid", "Alice")
+        assert view.timeout == 60

--- a/utils.py
+++ b/utils.py
@@ -1414,10 +1414,11 @@ async def cleanup_sessions_task(bot):
                                     await msg.delete()
                                     logger.info(f"Cancelled inactive queue for session {session.session_id} (Draft-{session.draft_id})")
                             except discord.NotFound:
-                                # If the message is not found, silently continue
                                 pass
                             except discord.HTTPException as e:
                                 logger.error(f"Failed to delete message ID {session.message_id} in draft channel. Reason: {e}")
+                            from ready_check import ReadyCheckSession
+                            await ReadyCheckSession.cleanup(session.session_id, draft_channel)
                     
                     # Delete the session from the database
                     await db_session.delete(session)

--- a/views.py
+++ b/views.py
@@ -7,6 +7,7 @@ from discord import SelectOption
 from discord.ui import Button, View, Select, select
 from config import is_test_mode, should_reset_on_signup, get_queue_inactivity_minutes
 from notification_service import send_ready_check_dms
+from ready_check import ReadyCheckView, ReadyCheckSession
 from draft_organization.stake_calculator import calculate_stakes_with_strategy
 from services.draft_setup_manager import DraftSetupManager, ACTIVE_MANAGERS
 from session import StakeInfo, AsyncSessionLocal, get_draft_session, DraftSession, MatchResult
@@ -539,7 +540,10 @@ class PersistentView(discord.ui.View):
 
             # Update the draft message to reflect the new list of sign-ups
             await update_draft_message(interaction.client, self.draft_session_id)
-            
+
+            # If a ready check is active, add the new player to no_response and refresh the embed
+            await ReadyCheckSession.sync_added_player(self.draft_session_id, user_id, draft_session_updated, interaction)
+
             if self.session_type == "winston":
                 if len(sign_ups) == 2:
                     sign_up_tags = ' '.join([f"<@{user_id}>" for user_id in draft_session_updated.sign_ups.keys()])
@@ -608,7 +612,9 @@ class PersistentView(discord.ui.View):
             
             # Update the draft message to reflect the new list of sign-ups
             await update_draft_message(interaction.client, self.draft_session_id)
-    
+
+            await ReadyCheckSession.sync_removed_player(self.draft_session_id, user_id, draft_session_updated, interaction)
+
     async def update_cube_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         """Callback for the Update Cube button - Shows a selection view for choosing a new cube"""
         try:
@@ -731,7 +737,7 @@ class PersistentView(discord.ui.View):
             await interaction.response.send_message("The draft session could not be found.", ephemeral=True)
             return        
         
-        sign_up_count = len(session.sign_ups)
+        sign_up_count = len(session.sign_ups) if session.sign_ups else 0
         if sign_up_count < 6:
             await interaction.response.send_message(
                 f"Ready check only available with 6 or more players. Currently {sign_up_count} players in queue."
@@ -764,47 +770,40 @@ class PersistentView(discord.ui.View):
         # We'll use followup.send() later to send the actual message
         await interaction.response.defer()
 
-        # Create a dictionary to store the initial ready check status
-        # Test users (ID >= 900000000000000000) are automatically marked as ready
+        # Build the initial ready check state.
+        # All players start as no_response; initiator and test users are marked ready immediately.
         TEST_USER_ID_START = 900000000000000000
 
-        ready_check_status = {
-            "ready": [user_id],  # Add the initiator to ready immediately
-            "not_ready": [],
-            "no_response": []
-        }
-
-        # Separate real users from test users
+        rc = ReadyCheckSession(player_ids=session.sign_ups.keys())
+        rc.set_status(user_id, 'ready')
         for uid in session.sign_ups.keys():
-            if uid == user_id:
-                continue  # Initiator already in ready list
-
-            # Check if this is a test user (ID >= 900000000000000000)
-            if int(uid) >= TEST_USER_ID_START:
-                ready_check_status["ready"].append(uid)
+            if uid != user_id and int(uid) >= TEST_USER_ID_START:
+                rc.set_status(uid, 'ready')
                 logger.debug(f"Auto-marked test user {uid} as ready")
-            else:
-                ready_check_status["no_response"].append(uid)
 
-        # Save this status in a global sessions dictionary
-        state_manager.set_ready_check_session(self.draft_session_id, ready_check_status)
-        logger.info(f"✅ Ready check initiated - registered session ID {self.draft_session_id} in sessions dictionary")
-        logger.debug(f"Sessions dictionary now contains {list(state_manager.sessions.keys())}")
+        state_manager.set_ready_check(self.draft_session_id, rc)
+        logger.info(f"✅ Ready check initiated - registered session ID {self.draft_session_id}")
 
-        # Disable the "Ready Check" button
+
+        # Disable the "Ready Check" button and persist it to the draft message
         for item in self.children:
-            if isinstance(item, discord.ui.Button) and item.custom_id.endswith("ready_check"):
+            if isinstance(item, discord.ui.Button) and item.custom_id == f"ready_check_{self.draft_session_id}":
                 item.disabled = True
                 break
+        try:
+            await interaction.message.edit(view=self)
+        except Exception as e:
+            logger.error(f"Failed to disable ready check button in draft message: {e}")
 
         # Generate the initial embed with personalized links
-        embed = await generate_ready_check_embed(ready_check_status=ready_check_status, sign_ups=session.sign_ups, draft_link=session.draft_link, draft_session=session, guild=interaction.guild)
+        embed = await rc.build_embed(session.sign_ups, guild=interaction.guild)
         
         # Create the view with the buttons
         view = ReadyCheckView(self.draft_session_id)
 
         # Send the initial ready check message (using followup since we deferred)
         main_message = await interaction.followup.send(embed=embed, view=view)
+        rc.message_id = main_message.id
 
         # Construct a message that mentions all users who need to respond to the ready check
         user_mentions = ' '.join([f"<@{user_id}>" for user_id in session.sign_ups.keys()])
@@ -823,24 +822,15 @@ class PersistentView(discord.ui.View):
             guild_name=interaction.guild.name
         )
 
-        # asyncio.create_task(self.cleanup_ready_check(self.draft_session_id))
+        # In test mode all test users are pre-marked ready — skip waiting for button clicks
+        if rc.all_ready():
+            await ReadyCheckSession.handle_all_ready(self.draft_session_id, session, interaction)
 
     async def remove_cooldown(self, draft_session_id):
         await asyncio.sleep(60)  # Wait for 60 seconds
         # Reset cooldown on successful full ready
         state_manager.remove_cooldown(draft_session_id)
 
-    # async def cleanup_ready_check(self, draft_session_id):
-    #     await asyncio.sleep(1800)  # Wait for 30 minutes
-    #     try:
-    #         if draft_session_id in sessions:
-    #             logger.warning(f"⚠️ Removing session {draft_session_id} from sessions dictionary due to timeout")
-    #             del sessions[draft_session_id]  # Clean up the session data
-    #             logger.debug(f"Sessions dictionary after cleanup: {list(sessions.keys())}")
-    #         else:
-    #             logger.info(f"Session {draft_session_id} already removed from sessions dictionary")
-    #     except Exception as e:
-    #         logger.error(f"Failed during ready check cleanup: {e}")
 
     async def _validate_team_creation_request(self, interaction: discord.Interaction, session_id: str, user_id: str):
         """Validate initial conditions for team creation"""
@@ -867,8 +857,8 @@ class PersistentView(discord.ui.View):
     async def _validate_staked_draft_requirements(self, interaction: discord.Interaction, session_id: str):
         """Validate staked draft specific requirements"""
         # Check if a ready check has been performed
-        ready_check_performed = state_manager.session_exists(session_id)
-        logger.info(f"Ready check verification: session_id={session_id}, in sessions dict={ready_check_performed}")
+        ready_check_performed = state_manager.has_ready_check(session_id)
+        logger.info(f"Ready check verification: session_id={session_id}, has active ready check={ready_check_performed}")
         
         if not ready_check_performed:
             logger.warning(f"❌ Ready check verification failed for session {session_id}")
@@ -927,7 +917,7 @@ class PersistentView(discord.ui.View):
             # Defer the response early since team creation might take time
             await interaction.response.defer()
 
-            logger.info(f"Create teams - checking sessions dict: {list(state_manager.sessions.keys())}")
+            logger.info(f"Create teams - active ready checks: {list(state_manager.ready_checks.keys())}")
 
             # Validate staked draft requirements if needed
             if self.session_type == "staked":
@@ -1547,167 +1537,6 @@ class PersistentView(discord.ui.View):
                 await interaction.followup.send("An error occurred.", ephemeral=True)
             return False
 
-async def generate_ready_check_embed(ready_check_status, sign_ups, draft_link, draft_session=None, guild=None):
-    # Define a function to convert user IDs to their names
-    def get_names(user_ids):
-        names = []
-        for user_id in user_ids:
-            if guild:
-                # Use get_display_name_by_id for crown icon support
-                name = get_display_name_by_id(user_id, guild, sign_ups.get(user_id, "Unknown user"))
-            else:
-                # Fallback to stored name if no guild
-                name = sign_ups.get(user_id, "Unknown user")
-            names.append(name)
-        return "\n".join(names) or "None"
-
-    # Generate the embed with fields for "Ready", "Not Ready", and "No Response"
-    embed = discord.Embed(title="Ready Check Initiated", description="Please indicate if you are ready.\n\nDraftmancer links will be provided once teams are created.", color=discord.Color.gold())
-    embed.add_field(name="Ready", value=get_names(ready_check_status['ready']), inline=False)
-    embed.add_field(name="Not Ready", value=get_names(ready_check_status['not_ready']), inline=False)
-    embed.add_field(name="No Response", value=get_names(ready_check_status['no_response']), inline=False)
-
-    return embed
-
-class ReadyCheckView(discord.ui.View):
-    def __init__(self, draft_session_id):
-        super().__init__(timeout=None)
-        self.draft_session_id = draft_session_id
-        # Append the session ID to each custom_id to make it unique
-        self.ready_button.custom_id = f"ready_check_ready_{self.draft_session_id}"
-        self.not_ready_button.custom_id = f"ready_check_not_ready_{self.draft_session_id}"
-
-    @discord.ui.button(label="Ready", style=discord.ButtonStyle.green, custom_id="placeholder_ready")
-    async def ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
-        await self.handle_ready_not_ready_interaction(interaction, "ready")
-
-    @discord.ui.button(label="Not Ready", style=discord.ButtonStyle.red, custom_id="placeholder_not_ready")
-    async def not_ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
-        await self.handle_ready_not_ready_interaction(interaction, "not_ready")
-
-    async def handle_ready_not_ready_interaction(self, interaction: discord.Interaction, status):
-        session = state_manager.get_ready_check_session(self.draft_session_id)
-        if not session:
-            await interaction.response.send_message("Session data is missing.", ephemeral=True)
-            return
-
-        user_id = str(interaction.user.id)
-        if user_id not in session['no_response'] and user_id not in session['ready'] and user_id not in session['not_ready']:
-            await interaction.response.send_message("You are not authorized to interact with this button.", ephemeral=True)
-            return
-
-        # Update the ready check status
-        for state in ['ready', 'not_ready', 'no_response']:
-            if user_id in session[state]:
-                session[state].remove(user_id)
-        session[status].append(user_id)
-
-        # Update the session status in the database if necessary
-        # await update_draft_session(self.draft_session_id, session)
-        draft_session = await get_draft_session(self.draft_session_id)
-        # Generate the updated embed with personalized links
-        embed = await generate_ready_check_embed(session, draft_session.sign_ups, draft_session.draft_link, draft_session, guild=interaction.guild)
-
-        # Check if all players are ready
-        all_responded = len(session['no_response']) == 0
-        all_ready = len(session['not_ready']) == 0
-        ready_check_complete = all_responded and all_ready and len(session['ready']) > 0
-
-        if ready_check_complete:
-            # Update embed title to show success
-            embed.title = "✅ Ready Check Complete - All Players Ready!"
-
-        # Update the message
-        await interaction.response.edit_message(embed=embed, view=self)
-
-        # If ready check is complete, automatically create teams
-        if ready_check_complete:
-            # Check for race condition
-            if state_manager.is_creating_teams(self.draft_session_id):
-                logger.warning(f"Teams already being created for {self.draft_session_id}")
-                return
-
-            state_manager.set_creating_teams(self.draft_session_id, True)
-
-            try:
-                await interaction.followup.send(
-                    "✅ **All players ready!** Creating teams now...",
-                    ephemeral=False
-                )
-
-                # Get bot from interaction.client
-                bot = interaction.client
-
-                # Fetch the draft session to get the message and create the view
-                if draft_session and draft_session.message_id and draft_session.draft_channel_id:
-                    # Get the channel and message
-                    channel = bot.get_channel(int(draft_session.draft_channel_id))
-                    if channel:
-                        try:
-                            message = await channel.fetch_message(int(draft_session.message_id))
-
-                            # Recreate the PersistentView for team creation
-                            persistent_view = PersistentView(
-                                bot=bot,
-                                draft_session_id=self.draft_session_id,
-                                session_type=draft_session.session_type,
-                                team_a_name=draft_session.team_a_name,
-                                team_b_name=draft_session.team_b_name
-                            )
-
-                            # Use the team creator service
-                            from services.team_creator import create_and_display_teams
-
-                            # Create a mock interaction for the service
-                            # Since we need to pass the message for updates
-                            class AutoReadyInteraction:
-                                def __init__(self, original_interaction, message):
-                                    self.user = original_interaction.user
-                                    self.guild = original_interaction.guild
-                                    self.guild_id = original_interaction.guild_id
-                                    self.channel = original_interaction.channel
-                                    self.client = original_interaction.client
-                                    self.message = message
-                                    self._followup = original_interaction.followup
-
-                                @property
-                                def followup(self):
-                                    return self._followup
-
-                            mock_interaction = AutoReadyInteraction(interaction, message)
-                            success = await create_and_display_teams(
-                                bot, self.draft_session_id, mock_interaction, persistent_view
-                            )
-
-                            if success:
-                                await interaction.followup.send(
-                                    "✅ Teams created! Check the draft message above for teams and seating order.",
-                                    ephemeral=False
-                                )
-                            else:
-                                await interaction.followup.send(
-                                    "❌ Error creating teams. You can try using the Create Teams button manually.",
-                                    ephemeral=False
-                                )
-                        except Exception as e:
-                            logger.error(f"Error updating draft message after auto-create: {e}")
-                            await interaction.followup.send(
-                                f"❌ Error creating teams: {str(e)}\nYou can try using the Create Teams button manually.",
-                                ephemeral=False
-                            )
-
-            except Exception as e:
-                logger.error(f"Error auto-creating teams after ready check: {e}")
-                await interaction.followup.send(
-                    f"❌ Error creating teams: {str(e)}\nYou can try using the Create Teams button manually.",
-                    ephemeral=False
-                )
-            finally:
-                state_manager.set_creating_teams(self.draft_session_id, False)
-        
-
-
-
 class UserRemovalSelect(Select):
     def __init__(self, options: list[SelectOption], session_id: str, *args, **kwargs):
         super().__init__(*args, **kwargs, placeholder="Choose a user to remove...", min_values=1, max_values=1, options=options)
@@ -1745,6 +1574,7 @@ class UserRemovalSelect(Select):
                 await PersistentView.update_team_view(interaction)
 
             await interaction.followup.send(f"Removed {removed_user_name} from the draft.")
+            await ReadyCheckSession.sync_removed_player(self.session_id, user_id_to_remove, session, interaction)
         else:
             await interaction.response.send_message("User not found in sign-ups.", ephemeral=True)
 
@@ -2495,14 +2325,16 @@ class CancelConfirmationView(discord.ui.View):
         else:
             logger.info(f"No active draft manager found for session {self.draft_session_id}")
         
-        # Then delete the message
+        await ReadyCheckSession.cleanup(self.draft_session_id, channel)
+
+        # Then delete the draft sign-up message
         if channel:
             try:
                 message = await channel.fetch_message(int(session.message_id))
                 await message.delete()
             except Exception as e:
                 logger.error(f"Failed to delete draft message: {e}")
-        
+
         # Remove from database
         async with AsyncSessionLocal() as db_session:
             async with db_session.begin():

--- a/views.py
+++ b/views.py
@@ -5,7 +5,7 @@ import pytz
 from datetime import datetime, timedelta
 from discord import SelectOption
 from discord.ui import Button, View, Select, select
-from config import TEST_MODE_ENABLED, should_reset_on_signup, get_queue_inactivity_minutes
+from config import is_test_mode, should_reset_on_signup, get_queue_inactivity_minutes
 from notification_service import send_ready_check_dms
 from draft_organization.stake_calculator import calculate_stakes_with_strategy
 from services.draft_setup_manager import DraftSetupManager, ACTIVE_MANAGERS
@@ -132,8 +132,8 @@ class PersistentView(discord.ui.View):
         self._add_button("Generate Seating Order", "primary", "generate_seating", self.randomize_teams_callback)
 
         # Add test button only if global test mode is enabled
-        if TEST_MODE_ENABLED:
-            logger.debug(f"🧪 TEST_MODE_ENABLED=True - Adding 'Add Test Users' button for premade session {self.draft_session_id}")
+        if is_test_mode():
+            logger.debug(f"🧪 TEST_MODE=True - Adding 'Add Test Users' button for premade session {self.draft_session_id}")
             self._add_button("🧪 Fill Teams (Test)", "grey", "add_test_users_premade", self.add_test_users_premade_callback)
 
 
@@ -150,11 +150,11 @@ class PersistentView(discord.ui.View):
             self._add_button("How Bets Work 💰", "green", "explain_stakes", self.explain_stakes_callback)
 
         # Add test button only if global test mode is enabled
-        if TEST_MODE_ENABLED:
-            logger.debug(f"🧪 TEST_MODE_ENABLED=True - Adding 'Add Test Users' button for session {self.draft_session_id}")
+        if is_test_mode():
+            logger.debug(f"🧪 TEST_MODE=True - Adding 'Add Test Users' button for session {self.draft_session_id}")
             self._add_button("🧪 Add Test Users", "grey", "add_test_users", self.add_test_users_callback)
         else:
-            logger.debug(f"TEST_MODE_ENABLED=False - Skipping 'Add Test Users' button for session {self.draft_session_id}")
+            logger.debug(f"TEST_MODE=False - Skipping 'Add Test Users' button for session {self.draft_session_id}")
 
 
     def _apply_stage_button_disabling(self):


### PR DESCRIPTION
Fixes #312

## Summary

- Replace `TEST_MODE_ENABLED` constant with `is_test_mode()` env var function (read from `TEST_MODE` in `.env`)
- Fix ready check message not being deleted on draft cancel, player removal, team creation, and inactivity cleanup
- Fix cancel button not showing confirmation dialog before cancelling (now matches draft cancel UX)
- Fix ready check button on draft message never actually being disabled (wrong `custom_id` suffix check: `endswith` instead of exact match)
- Fix test mode: auto-trigger team creation when all users are pre-marked ready, without waiting for a button click
- Add player join/leave sync during active ready check (joined → added to No Response; left → removed from embed; if last blocker leaves → auto-create teams)
- Refactor: extract `ReadyCheckSession` into `ready_check.py`, owning all in-memory state, business logic, and coordination; `ReadyCheckView` is now pure UI only; `DraftStateManager` holds a single `ready_checks` dict instead of two separate dicts; add unit tests

## Test plan

- [ ] Start a ready check → Ready Check button on draft message is disabled
- [ ] Cancel Check → confirmation dialog appears → confirm → message deleted, draft message buttons restored, cancellation announced in channel
- [ ] Cancel Check → deny → ready check message untouched
- [ ] Player signs up during active ready check → added to No Response in embed
- [ ] Player leaves during active ready check → removed from embed
- [ ] All players click Ready → embed updates to "✅ Ready Check Complete - All Players Ready!", teams auto-created
- [ ] Last blocking player leaves → remaining players all ready → teams auto-created
- [ ] Draft scrapped during ready check → ready check message deleted
- [ ] Create Teams pressed manually while ready check is active → ready check message deleted, teams created
- [ ] Staked draft: Create Teams without ready check → blocked with error message

### Screen recordings


https://github.com/user-attachments/assets/ceaf1d08-082c-43d7-9941-d29e282b52e4


https://github.com/user-attachments/assets/2244e9ee-dbb4-4ae2-adf1-19066a2de32c



🤖 Generated with [Claude Code](https://claude.com/claude-code)