### PR TITLE
Add pyrefly type checker and fix all type errors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pipenv run pyrefly *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 key
 *.pub
 *.json
+!.claude/settings.json
 *.db
 *.xlsx
 *.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ pipenv run alembic revision --autogenerate   # Generate new migration
 # Running the bot locally
 pipenv run python bot.py
 
+# Type checking
+pipenv run pyrefly check .                   # Run type checker (must pass clean)
+
 # Service management (production)
 sudo systemctl restart draftbot.service      # Restart with auto-migration
 sudo journalctl -u draftbot.service -f       # View logs
@@ -166,6 +169,7 @@ pipenv run python -m pytest tests/test_seating_order.py::TestSeatingOrder::test_
   - [ ] `TEST_MODE=true` is not set in production environment
   - [ ] All commands tested with `pipenv run`
   - [ ] Database migrations tested locally
+  - [ ] Type checker passes: `pipenv run pyrefly check .` reports 0 errors
 
 ### Security Considerations
 - Never commit secrets or tokens

--- a/Pipfile
+++ b/Pipfile
@@ -25,6 +25,10 @@ aiohttp = "*"
 [dev-packages]
 pytest = "*"
 pytest-asyncio = "*"
+pyrefly = "*"
 
 [requires]
 python_version = "3.11"
+
+[pipenv]
+venv_in_project = true

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ pandas = "==2.2.3"
 python-dotenv = "==1.0.1"
 python-socketio = "==5.11.4"
 pytz = "==2024.2"
-sqlalchemy = "==2.0.21"
+sqlalchemy = {extras = ["asyncio"], version = "==2.0.21"}
 trueskill = "==0.4.5"
 loguru = "*"
 win32-setctime = {version = "*", markers = "sys_platform == 'win32'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b4660a928260cb61c339f3b7f83e3bbec5f14714a310529447f7da9a0985e9be"
+            "sha256": "13025bf74e28fd6b7be28ae8ccc73482089e1d660ef7ed316fe6da4431492c58"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1157,7 +1157,10 @@
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.21"
+            "version": "==2.0.21",
+            "extras": [
+                "asyncio"
+            ]
         },
         "trueskill": {
             "hashes": [
@@ -1445,6 +1448,91 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==1.23.0"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:01e32e9d2b1714a2b06184cb3071ff2a2fd9bc7d065e39198ab21f7253dad421",
+                "sha256:0488ca77c94da5e09d1d9958f98b58cebba1b8fd9664c24898499133de927574",
+                "sha256:049827baab63dda8ab8ec5a6d07fc6eb0f418319cfc757fc8737a605e99ca1ad",
+                "sha256:0629377725977252159de1ebd3c6e49c170a63856e585446797bb3d66d4d9c34",
+                "sha256:09201fa698768db245920b00fdc86ee3e73540f01ca6db162be9632642e1a473",
+                "sha256:0977af2df83136f81c1f76e76d4e2fe7d0dc56ea9c101a86af26a95190b9ca32",
+                "sha256:120b77c2a18ebf629c3a7886f68c6d01e065654844ad468f15bb93ace66f2094",
+                "sha256:1587ff8b58fdf806993ed1490a06ac19c22d47b219c68b30954380029045d8d4",
+                "sha256:1724499fc08388208408681c53c5062e9803c334e5a0bdaeb616228ba882aac8",
+                "sha256:1adc23c50f22b0f5979521909a8360ab4a3d3bef8b641ce633a04cf1b1c967ea",
+                "sha256:1c31219badba285858ba8ed117f403dea7fafee6bade9a1991875aae530c3ceb",
+                "sha256:1d554cd96841a68d464d75a3736f8e87408a7b02b1930a75fa32feb408ad62f8",
+                "sha256:1f052fff492c52fdfa99bd3b3c1389a53de37dae76a0562741417f0d018f02b3",
+                "sha256:24c59cb7db9d5c694cb8fd0c76eef8e456b2123afdfa7e4b8f2a67a0860d7682",
+                "sha256:26aed8d9503ca78889141a9739d71b383efea5f472a7c522b5410f7eb2a1b163",
+                "sha256:2c3b3311af72b3d3b03cc0f1ffd11f072e834be5d0444105cf715fc44434e39c",
+                "sha256:2c6d6bfa4fdd7c39a0dbf112cdf28edbd19c517c810eefb6e4e71b0d55933a4c",
+                "sha256:2debcd0ef9455b7d4879589903efc8e497d4b8fb8c0ae772309e44d1ca5e957f",
+                "sha256:2ee6288f1933d698b4f098127ed17bda2910a75d2807915bd16294a972055d6c",
+                "sha256:30252d191d6959df1d040b559a38fc017139606c5ecc2ad00416557c0355d742",
+                "sha256:36cfea2aa075d544617176b2e84450480f0797070ad8799a8c41ada2fe449d32",
+                "sha256:3be00501fb4a8c37f6b4b3c4773808ceb26ea65c7ea64fd5735d0f330b3786de",
+                "sha256:3c2315045f9983e2e50d7e89d95405c21bddb8745f2da4487bc080ab3525f904",
+                "sha256:3c417cd6c593bbbef6f7aa31a79f37d3db7d18832fc56b694a2150130bde784e",
+                "sha256:3dff6cd3aac35f6cd3fc23460105acf576f5faf6c378de0bc088bf37c913864a",
+                "sha256:423167363c510a75b649f5cd58d873c29498ea03598b9e4b1c3b73e0f899f3d5",
+                "sha256:4e554809538bd4867f24421b43abde170f9c9b8192149b30df5e164bcac6124f",
+                "sha256:537c5c4f30395020bb9f48f53146070e3b997c3c75da14011ab732aaa19ce3ef",
+                "sha256:561dd919c02236a613fbf226791cbd77ee5002cbd5cb7e838869aa3ac7a71e16",
+                "sha256:5795e883e915333c0d5648faaa691857fbc7180136883edc377f50f0d509c2a8",
+                "sha256:5930d3946ecae99fa7fc0e3f3ae515426ad85058ebd9bfc6c00cca8016e6206b",
+                "sha256:5eba55076d79e8a5176e6925295cfb901ebc95dae493342ede22230f75d8bee2",
+                "sha256:6d78b5c1c178dad90447f1b8452262709d3eef4c98f825569e74c9d0b2260ac9",
+                "sha256:6d9e19257794e28821c9ebd5e23f86d7c267cd9d390089374f068d2049f949e3",
+                "sha256:6e9e49d732ee92a189bb7035e293029244aeba648297a9b856dc733d17ca7f0d",
+                "sha256:6f1e473c06ae8be00c9034c2bb10fa277b08a93287e3111c395b839f01d27e1f",
+                "sha256:6f96ed6f4adc1066954ae95f45717657cb67468ef3b89e9a3632e14a625a8f39",
+                "sha256:711028c953cd6ce5dc01bbb5a1747e3ad6bd8b2f7ded73778bb936e8dab9e3b6",
+                "sha256:76dae33e97b52743a19210931ee3e78a88fe1438bc2fc4ee5e7512d289bfad4f",
+                "sha256:7a7bfc200be40d04961d7e80e8337d726c0c1a50777e588123c3ed8ba731dcb9",
+                "sha256:7bb811753703739ad318112f16eccfaabdac050037b6d092debaa8b23566b4ce",
+                "sha256:7fe6062b1f35534e1e8fb28dfed406cf4eeff3e0bca3a0d9f8ff69f20a4abb00",
+                "sha256:87359c23eb4e8f1b16da68faad29bf5aeb80e3628d7d8e4aa2e41c36879ddedd",
+                "sha256:89da99ee8345b458ea2f16831dad31c88ddcdec454b48704d569a0b8fb28f146",
+                "sha256:9558cae989faeab6fbb425cd98a0cfa4190a47fba6443973fbee0a1eb0b0b6c3",
+                "sha256:98a52d6a50d4deaba304331d83ee3e10ebbdc1517fcca40b2715d1de4534065c",
+                "sha256:9dc23f0e5ad76415457212a4b947d22ebe4dc80baf02adf7dd5647a90f38bb4e",
+                "sha256:9df9daae96848508450011d0d86ed7c95f8829a354ce438284a77b24896fd1f8",
+                "sha256:9e194b996aa1b89d933cfe136e5eb39b22a8b72ba59d376ef39a55bca4dbf47f",
+                "sha256:a0314aa832c94633355dc6f3ee54f195159533355a323f26926fc63b98b2ccbb",
+                "sha256:a1759fa4f14c398508cf20dc8037de55cc23ae8bd14c185c2718257837195ca5",
+                "sha256:a1789a6244ea1ba61fd4386c9a6a31873e9b0234762103364be98ef87dcb19f3",
+                "sha256:a207023f1cf8695fd82580b8099c09c5809be18bc2282362cdfb965dd884a317",
+                "sha256:a2ddf9eddc617681108dd071b3feabf3f4a4cd64846254aec4d4ceda098b639a",
+                "sha256:a3f76a94e2d6e1fee8f302265679d8cc47d71a203936dd03c6e2ace0f9cfd46d",
+                "sha256:a850f6224088ef7dcc70f1a545cb6b3d119c35d6dca63b925b9f35da0635cdad",
+                "sha256:a9476cbead736dc48ce89e3cd97acff95ecc48cbf21273603a438f9870c4a014",
+                "sha256:a96457a30384de52d9c5d2fd33abf6c1daae3db392cd556738f408b1a79a1cf0",
+                "sha256:b4ac902af825cbac8e9b2fccab8122236fd2ba6c8b71a080116d2c2ec72671b1",
+                "sha256:b4cad42662c796334c2d24607c411e3ed82481c1fb4e1e8ec3a5a8416060092e",
+                "sha256:b9318cdeb9abdbfdd8bc8464ee4a06dffde2c7846e1def138365a6240ab2c9a5",
+                "sha256:bc18b8d33e6976804b9b792fe11cb3b1fee8b646e8a9e20bf521a429ddf73520",
+                "sha256:bf493b3c1c0a2324c49b0472e2280ba4665f3510d8115f6f807759a6163b15f7",
+                "sha256:c0ea4eb3de23f0bac1d75205e10ccfa9b418b17b01a2d7bf19e3b69dda08900a",
+                "sha256:c1b906220d83c140361cdd12eef970fb5881a168b98ee58a43786426173da14c",
+                "sha256:c1c1e5ad80f1f38ea479b83b39dccb20874cfe9ad5e52f87225fa294ba4d39a1",
+                "sha256:c674a1dd4fe41f6a93febe7ab366ceabf15080ea31a9307811c56dac5f435f73",
+                "sha256:ca92411942154023c65851e6077d8ca0d00f19de5fa80bb2c6f196ff6c920ba9",
+                "sha256:d7792398872f89466c6671d5d193537eff163ecf7fac78d82e6ddc25017fb4f5",
+                "sha256:db548d5ab6c2a8ead82c013f875090d79b5d7d2b67fc513934ce6cf66492ad7f",
+                "sha256:dbebc038fcdda8f8f21cce985fd04e34e0f42007e7fc7ab7ad285caf77974b95",
+                "sha256:e063263ce9047878480d7e536012fc8b7c8e1922989eb5f03b9ab998a2ee7b7e",
+                "sha256:e4af5d4961818ab651d09c1448a03b1ba2a1726a076266ebb62330bab9f3238c",
+                "sha256:e976f9f6941f57d87a194c91868622c8b22a142a741d2fde31655c319133ade6",
+                "sha256:f41feb9f2b59e2e61ac9bea4e344ddd9396bf3cacb2583f73a3595ed7df6f8e7",
+                "sha256:f4d67c1684db3f9782c37ee4bade3f86f5a23a8fcf3f8359224106018ca40728",
+                "sha256:f9bbd6216c45a563c2a61e478e038b439d9f248bde44f775ea37d339da643af4",
+                "sha256:f9ed777c6891d8253e54468576f55e27f8fc1a662a664f946a191003574c0a74",
+                "sha256:feb721811d2754bfd16b48de151dd6b1f222c048e625151f2ca44cfdfd69f59c"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.5.2"
         }
     },
     "develop": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "13025bf74e28fd6b7be28ae8ccc73482089e1d660ef7ed316fe6da4431492c58"
+            "sha256": "6d53169a903cff4f589145593a32d5d18e77e6e2b929d7cfe5bc9992d0f2a42f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1593,6 +1593,25 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.15.0"
+        },
+        "pyrefly": {
+            "hashes": [
+                "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84",
+                "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb",
+                "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742",
+                "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520",
+                "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5",
+                "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407",
+                "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d",
+                "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd",
+                "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208",
+                "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8",
+                "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759",
+                "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ Using `python -m pytest` runs pytest as a module, which automatically adds the c
 
 Using just `pytest` will result in import errors because the project root won't be in the Python path.
 
+Type Checking
+-------------
+
+DraftBot uses [Pyrefly](https://github.com/facebook/pyrefly) (Meta's Python type checker) at the **default** strictness preset. The type checker must pass clean before merging any changes.
+
+```bash
+# Run type checker (must report 0 errors)
+pipenv run pyrefly check .
+```
+
+Configuration is in `pyrefly.toml`. One-off migration scripts (`legacy_stats.py`, `backfill_draft_win_streaks.py`, `analysis.py`, `scripts/`) have errors suppressed inline since they are not part of the production bot.
+
 Contribution
 ------------
 

--- a/analysis.py
+++ b/analysis.py
@@ -176,11 +176,13 @@ class StakeAnalyzer:
         
         if not has_victory_message:
             logger.warning(f"Draft {draft.session_id} does not have a victory message, skipping")
+            # pyrefly: ignore [bad-return]
             return None
             
         stakes = await self.fetch_stakes_for_draft(draft.session_id)
         if not stakes:
             logger.warning(f"Draft {draft.session_id} has no stakes, skipping")
+            # pyrefly: ignore [bad-return]
             return None
         
         # Get team assignments
@@ -189,6 +191,7 @@ class StakeAnalyzer:
         
         if not team_a or not team_b:
             logger.warning(f"Draft {draft.session_id} has incomplete team data, skipping")
+            # pyrefly: ignore [bad-return]
             return None
         
         # Determine min and max teams
@@ -214,10 +217,13 @@ class StakeAnalyzer:
         # Record the outcome
         if winner:
             if winner == min_team:
+                # pyrefly: ignore [bad-assignment]
                 result['outcome'] = 'min_win'
             elif winner == max_team:
+                # pyrefly: ignore [bad-assignment]
                 result['outcome'] = 'max_win'
         else:
+            # pyrefly: ignore [bad-assignment]
             result['outcome'] = 'draw'
         
         logger.info(f"Draft {draft.session_id} - Min Team: {min_team} ({min_team_stakes}), "
@@ -251,8 +257,11 @@ class StakeAnalyzer:
         
         # Calculate percentages
         if self.results['valid_drafts'] > 0:
+            # pyrefly: ignore [bad-assignment]
             self.results['min_team_win_pct'] = (self.results['min_team_wins'] / self.results['valid_drafts']) * 100
+            # pyrefly: ignore [bad-assignment]
             self.results['max_team_win_pct'] = (self.results['max_team_wins'] / self.results['valid_drafts']) * 100
+            # pyrefly: ignore [bad-assignment]
             self.results['draw_pct'] = (self.results['draws'] / self.results['valid_drafts']) * 100
         
         return self.results
@@ -379,6 +388,7 @@ class StakeAnalyzer:
                 draws = row['draw'] if 'draw' in row else 0
                 draw_pct = row['draw_pct'] if 'draw_pct' in row else 0
                 
+                # pyrefly: ignore [bad-argument-type]
                 print(f"Bucket {bucket+1}     | {ratio_range:13} | {int(total_drafts):12d} | {int(min_wins):4d} ({min_pct:5.1f}%) | {int(max_wins):4d} ({max_pct:5.1f}%) | {int(draws):2d} ({draw_pct:5.1f}%)")
         
         # Print overall row

--- a/backfill_draft_win_streaks.py
+++ b/backfill_draft_win_streaks.py
@@ -180,14 +180,19 @@ async def backfill_historical_streaks(dry_run=False):
 
                 if result == "team_a":  # Win
                     if player_streaks[key]["current"] == 0:
+                        # pyrefly: ignore [unsupported-operation]
                         player_streaks[key]["started_at"] = draft_time
+                        # pyrefly: ignore [unsupported-operation]
                         player_streaks[key]["current_started_at"] = draft_time
+                    # pyrefly: ignore [unsupported-operation]
                     player_streaks[key]["current"] += 1
+                    # pyrefly: ignore [unsupported-operation]
                     if player_streaks[key]["current"] > player_streaks[key]["longest"]:
                         player_streaks[key]["longest"] = player_streaks[key]["current"]
                 elif result == "tie":  # Tie - maintain streak
                     pass
                 else:  # Loss - break streak
+                    # pyrefly: ignore [unsupported-operation]
                     if player_streaks[key]["current"] > 0:
                         # Record historical streak
                         historical_streaks.append({
@@ -209,14 +214,19 @@ async def backfill_historical_streaks(dry_run=False):
 
                 if result == "team_b":  # Win
                     if player_streaks[key]["current"] == 0:
+                        # pyrefly: ignore [unsupported-operation]
                         player_streaks[key]["started_at"] = draft_time
+                        # pyrefly: ignore [unsupported-operation]
                         player_streaks[key]["current_started_at"] = draft_time
+                    # pyrefly: ignore [unsupported-operation]
                     player_streaks[key]["current"] += 1
+                    # pyrefly: ignore [unsupported-operation]
                     if player_streaks[key]["current"] > player_streaks[key]["longest"]:
                         player_streaks[key]["longest"] = player_streaks[key]["current"]
                 elif result == "tie":  # Tie - maintain streak
                     pass
                 else:  # Loss - break streak
+                    # pyrefly: ignore [unsupported-operation]
                     if player_streaks[key]["current"] > 0:
                         # Record historical streak
                         historical_streaks.append({
@@ -261,6 +271,7 @@ async def backfill_historical_streaks(dry_run=False):
                         logger.warning(f"PlayerStats not found for player {player_id} in guild {guild_id}")
 
                 # Insert historical streaks (only those >= 3)
+                # pyrefly: ignore [unsupported-operation]
                 significant_streaks = [s for s in historical_streaks if s["streak_length"] >= 3]
                 logger.info(f"Inserting {len(significant_streaks)} significant historical streaks (>= 3)")
 
@@ -276,6 +287,7 @@ async def backfill_historical_streaks(dry_run=False):
         for (player_id, guild_id), streak_data in list(player_streaks.items())[:10]:
             logger.info(f"  Player {player_id} in guild {guild_id}: current={streak_data['current']}, longest={streak_data['longest']}")
         logger.info(f"  ... and {len(player_streaks) - 10} more")
+        # pyrefly: ignore [unsupported-operation]
         logger.info(f"Would insert {len([s for s in historical_streaks if s['streak_length'] >= 3])} historical streaks")
 
 

--- a/backfill_spaces_keys.py
+++ b/backfill_spaces_keys.py
@@ -85,8 +85,9 @@ async def list_all_json_files() -> Dict[str, str]:
         # Spaces returns: "magic-draft-logs/team/file.json"
         # We want to store: "team/file.json" (boto3 expects this format)
         normalized_key = key_path
-        if key_path.startswith(f"{helper.bucket}/"):
-            normalized_key = key_path[len(helper.bucket) + 1:]
+        bucket = helper.bucket
+        if bucket and key_path.startswith(f"{bucket}/"):
+            normalized_key = key_path[len(bucket) + 1:]
 
         # Only process JSON files
         if not normalized_key.endswith('.json'):

--- a/bot.py
+++ b/bot.py
@@ -49,6 +49,9 @@ async def main():
     intents.reactions = True
 
     TOKEN = os.getenv("BOT_TOKEN")
+    if not TOKEN:
+        logger.error("BOT_TOKEN environment variable is not set; cannot start the bot.")
+        return
 
     bot = commands.Bot(command_prefix="!", intents=intents)
 

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -2,6 +2,7 @@ from discord.ext import commands
 import asyncio
 import os
 from pathlib import Path
+from typing import Any, cast
 import discord
 from loguru import logger
 from config import get_config, save_config
@@ -9,6 +10,7 @@ from leaderboard_config import CROWN_ICONS, DEFAULT_CROWN_ROLE_NAMES
 from stats_display import get_stats_embed_for_player
 
 from helpers.permissions import has_bot_manager_role, ADMIN_ROLE_NAME
+from helpers.utils import not_none
 from cube_views.CubeListModal import CubeListModal
 
 
@@ -199,9 +201,9 @@ class AdminCommands(commands.Cog):
     async def post_announcement(self, ctx, channel: discord.TextChannel):
         """Post an announcement from the announcement.md file"""
         await ctx.defer(ephemeral=True)
+        announcement_path = "announcement.md"
         try:
             # Read the announcement file
-            announcement_path = "announcement.md"
             with open(announcement_path, 'r', encoding='utf-8') as f:
                 announcement = f.read()
 
@@ -268,7 +270,7 @@ class AdminCommands(commands.Cog):
             role_name = role_names[count]
 
             # Prepare role properties
-            role_kwargs = {
+            role_kwargs: dict[str, Any] = {
                 "color": discord.Color.gold(),
                 "hoist": True,  # Show separately in member list
                 "mentionable": False,
@@ -454,7 +456,7 @@ class AdminCommands(commands.Cog):
     async def set_crown_timeframe(
         self,
         ctx,
-        timeframe: discord.Option(
+        timeframe: discord.Option(  # pyrefly: ignore
             str,
             description="The timeframe for crown calculations",
             choices=["14d", "30d", "90d", "lifetime"]
@@ -510,8 +512,8 @@ class AdminCommands(commands.Cog):
     @has_bot_manager_role()
     async def set_leaderboard_channel(
         self, ctx,
-        channel: discord.Option(discord.TextChannel, "Existing channel to use", required=False) = None,
-        new_channel_name: discord.Option(str, "Create a new channel with this name", required=False) = None,
+        channel: discord.Option(discord.TextChannel, "Existing channel to use", required=False) = None,  # pyrefly: ignore
+        new_channel_name: discord.Option(str, "Create a new channel with this name", required=False) = None,  # pyrefly: ignore
     ):
         """Set the channel for leaderboard posts.
 
@@ -604,7 +606,7 @@ class AdminCommands(commands.Cog):
     async def set_cube_list(
         self,
         ctx,
-        session_type: discord.Option(str, "Which draft type to configure", choices=["default"], required=True),
+        session_type: discord.Option(str, "Which draft type to configure", choices=["default"], required=True),  # pyrefly: ignore
     ):
         current = get_config(ctx.guild.id).get("cubes", {}).get(session_type, [])
         prefill = "\n".join(f"{c['label']} : {c['value']}" for c in current)
@@ -814,8 +816,8 @@ class AdminCommands(commands.Cog):
     async def cleanup_stale_drafts(
         self,
         ctx,
-        hours_old: discord.Option(int, "Complete drafts older than this many hours (minimum 12)", default=24),
-        dry_run: discord.Option(bool, "Preview without actually completing/deleting", default=True)
+        hours_old: discord.Option(int, "Complete drafts older than this many hours (minimum 12)", default=24),  # pyrefly: ignore
+        dry_run: discord.Option(bool, "Preview without actually completing/deleting", default=True)  # pyrefly: ignore
     ):
         """Complete old stale drafts as draws, clean up channels, and remove database records."""
         from config import is_cleanup_exempt
@@ -939,7 +941,7 @@ class AdminCommands(commands.Cog):
                 for detail in sessions_to_complete[:5]:
                     status = "completed" if detail['is_completed'] else "incomplete"
                     preview_msg += (
-                        f"• Session {detail['session_id'][:8]}... ({status}): "
+                        f"• Session {str(detail['session_id'])[:8]}... ({status}): "
                         f"{detail['missing_matches']} to create, "
                         f"{detail['unplayed_matches']} unplayed\n"
                     )
@@ -1089,7 +1091,7 @@ class AdminCommands(commands.Cog):
         supports_icons = ctx.guild.premium_tier >= 2
 
         # Prepare role properties
-        role_kwargs = {
+        role_kwargs: dict[str, Any] = {
             "color": discord.Color.from_rgb(218, 165, 32),  # Gold color
             "hoist": True,  # Show separately in member list
             "mentionable": False,

--- a/cogs/debt_admin_commands.py
+++ b/cogs/debt_admin_commands.py
@@ -10,6 +10,7 @@ Commands:
 import asyncio
 from datetime import datetime
 import discord
+from helpers.utils import not_none
 from discord.ext import commands
 from discord.commands import SlashCommandGroup, option
 from loguru import logger
@@ -66,7 +67,7 @@ class DebtNotifyConfirmView(discord.ui.View):
     async def on_timeout(self):
         self.disable_all_items()
         try:
-            await self.message.edit(content="Timed out.", embed=None, view=None)
+            await not_none(self.message).edit(content="Timed out.", embed=None, view=None)
         except Exception:
             pass
 
@@ -268,9 +269,9 @@ class DebtAdminCommands(commands.Cog):
     async def debt_admin_history(
         self,
         ctx: discord.ApplicationContext,
-        player: discord.User = None,
+        player: discord.User | None = None,
         limit: int = 25,
-        older_than_days: int = None
+        older_than_days: int | None = None
     ):
         """View complete debt history (drafts, settlements, and admin modifications)."""
         await ctx.defer(ephemeral=True)
@@ -422,7 +423,7 @@ class DebtAdminCommands(commands.Cog):
     async def debt_admin_notify(
         self,
         ctx: discord.ApplicationContext,
-        player: discord.User = None
+        player: discord.User | None = None
     ):
         """Send DM notifications to players about their outstanding debts."""
         await ctx.defer(ephemeral=True)

--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 import asyncio
+from typing import cast
 from loguru import logger
 from models.draft_session import DraftSession
 from models.match import MatchResult
@@ -8,6 +9,7 @@ from discord.ui import View, Button
 from datetime import datetime, timedelta
 from sqlalchemy import select, and_, desc, update
 from database.db_session import db_session
+from helpers.utils import not_none
 from services.draft_setup_manager import DraftSetupManager, create_rooms_and_pairings_with_fallback
 
 # Store active unpause ready checks
@@ -52,7 +54,7 @@ async def abandon_draft_session(session_id, session_factory=None):
 def _disable_all(view):
     """Disable every component on a view (so a settled prompt can't be re-clicked)."""
     for child in view.children:
-        child.disabled = True
+        cast(discord.ui.Button, child).disabled = True
 
 
 class BaseVoteView(View):
@@ -77,11 +79,12 @@ class BaseVoteView(View):
     action_verb = "pass"   # used in "votes needed to {action_verb}"
     log_name = "vote"      # used in timeout log lines
 
-    def __init__(self, draft_session_id, participants, timeout=90.0):
+    def __init__(self, draft_session_id, participants, timeout: float = 90.0):
         super().__init__(timeout=timeout)
         self.draft_session_id = draft_session_id
-        self.votes = {user_id: None for user_id in participants}  # None=not voted, True=yes, False=no
-        self.message = None
+        self._timeout_seconds: float = timeout
+        self.votes: dict[str, bool | None] = {user_id: None for user_id in participants}  # None=not voted, True=yes, False=no
+        self.message: discord.Message | None = None
         self.timer_task = None
         self.complete = asyncio.Event()
         self._start_time = datetime.now()
@@ -91,7 +94,7 @@ class BaseVoteView(View):
 
     async def start_timer(self):
         try:
-            await asyncio.sleep(self.timeout)
+            await asyncio.sleep(self._timeout_seconds)
             if not self.complete.is_set():
                 logger.info(f"{self.log_name} for session {self.draft_session_id} timed out")
                 await self.on_timeout()
@@ -119,7 +122,7 @@ class BaseVoteView(View):
 
     @discord.ui.button(label="Yes", style=discord.ButtonStyle.primary)
     async def yes_button(self, button: discord.ui.Button, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if user_id not in self.votes:
             await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
             return
@@ -129,11 +132,12 @@ class BaseVoteView(View):
 
         if self.get_vote_result()[0]:
             self._finish()
-            await self.message.edit(view=self)
+            if self.message:
+                await self.message.edit(view=self)
 
     @discord.ui.button(label="No", style=discord.ButtonStyle.secondary)
     async def no_button(self, button: discord.ui.Button, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if user_id not in self.votes:
             await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
             return
@@ -144,7 +148,8 @@ class BaseVoteView(View):
         # End early if the vote can no longer reach a majority.
         if not self.can_still_pass():
             self._finish()
-            await self.message.edit(view=self)
+            if self.message:
+                await self.message.edit(view=self)
 
     def _participant_status(self, vote):
         if vote is True:
@@ -172,7 +177,7 @@ class BaseVoteView(View):
                   ("**Vote will pass!**" if passed else "**Vote will not pass yet**"),
             inline=False,
         )
-        expiry_timestamp = int(self._start_time.timestamp() + self.timeout)
+        expiry_timestamp = int(self._start_time.timestamp() + self._timeout_seconds)
         embed.add_field(name="Vote Ends", value=f"<t:{expiry_timestamp}:R>", inline=False)
         return embed
 
@@ -267,11 +272,12 @@ class ReplaceWithBotsVoteView(BaseVoteView):
     log_name = "Replace with bots vote"
 
 class DraftMancerReadyCheckView(View):
-    def __init__(self, draft_session_id, participants, timeout=90.0):
+    def __init__(self, draft_session_id, participants, timeout: float = 90.0):
         super().__init__(timeout=timeout)
         self.draft_session_id = draft_session_id
-        self.participants = {user_id: False for user_id in participants}  # False = not ready
-        self.message = None
+        self._timeout_seconds: float = timeout
+        self.participants: dict[str, bool] = {user_id: False for user_id in participants}  # False = not ready
+        self.message: discord.Message | None = None
         self.timer_task = None
         self.complete = asyncio.Event()
         self._start_time = datetime.now()
@@ -279,7 +285,7 @@ class DraftMancerReadyCheckView(View):
     async def start_timer(self):
         """Start the timeout timer for the ready check"""
         try:
-            await asyncio.sleep(self.timeout)
+            await asyncio.sleep(self._timeout_seconds)
             if not self.complete.is_set():
                 # Time's up, mark the check as complete
                 logger.info(f"Unpause ready check for session {self.draft_session_id} timed out")
@@ -294,7 +300,7 @@ class DraftMancerReadyCheckView(View):
     @discord.ui.button(label="Ready", style=discord.ButtonStyle.green)
     async def ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Mark user as ready"""
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if user_id not in self.participants:
             await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
             return
@@ -314,15 +320,16 @@ class DraftMancerReadyCheckView(View):
             
             # Disable buttons
             for child in self.children:
-                child.disabled = True
+                cast(discord.ui.Button, child).disabled = True
                 
-            await self.message.edit(view=self)
+            if self.message:
+                await self.message.edit(view=self)
             # The on_complete callback will handle the actual resuming
         
     @discord.ui.button(label="Not Ready", style=discord.ButtonStyle.red)
     async def not_ready_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Mark user as not ready"""
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if user_id not in self.participants:
             await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
             return
@@ -359,7 +366,7 @@ class DraftMancerReadyCheckView(View):
             inline=False
         )
         
-        expiry_time = self._start_time.timestamp() + self.timeout
+        expiry_time = self._start_time.timestamp() + self._timeout_seconds
         expiry_timestamp = int(expiry_time)
 
         embed.add_field(
@@ -375,7 +382,7 @@ class DraftMancerReadyCheckView(View):
         
         # Disable all buttons
         for child in self.children:
-            child.disabled = True
+            cast(discord.ui.Button, child).disabled = True
             
         # Update the message if it exists
         if self.message:

--- a/cogs/draft_logs_cog.py
+++ b/cogs/draft_logs_cog.py
@@ -27,7 +27,7 @@ class DraftLogsCog(commands.Cog):
         self, 
         ctx,
         channel: discord.TextChannel,
-        time_zone: Optional[str] = "UTC"
+        time_zone: str = "UTC"
     ):
         """
         Set up a channel for posting draft logs

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -238,8 +238,8 @@ class LeaderboardCog(commands.Cog):
         # Try to update existing message
         message_updated = False
         if hasattr(leaderboard_record, msg_id_field) and getattr(leaderboard_record, msg_id_field):
+            message_id = str(getattr(leaderboard_record, msg_id_field))
             try:
-                message_id = getattr(leaderboard_record, msg_id_field)
                 existing_msg = await channel.fetch_message(int(message_id))
                 if category != "hot_streak":
                     await existing_msg.edit(embed=embed, view=view)
@@ -308,8 +308,8 @@ async def refresh_all_leaderboards(bot):
             
             # Process each leaderboard
             for leaderboard in all_leaderboards:
+                guild_id = str(leaderboard.guild_id)
                 try:
-                    guild_id = leaderboard.guild_id
                     guild = bot.get_guild(int(guild_id))
                     
                     if not guild:
@@ -354,8 +354,8 @@ async def refresh_all_leaderboards(bot):
                             # Try to update existing message
                             message_updated = False
                             if hasattr(leaderboard, msg_id_field) and getattr(leaderboard, msg_id_field):
+                                message_id = str(getattr(leaderboard, msg_id_field))
                                 try:
-                                    message_id = getattr(leaderboard, msg_id_field)
                                     existing_msg = await channel.fetch_message(int(message_id))
                                     
                                     if category != "hot_streak":

--- a/cogs/quiz_commands.py
+++ b/cogs/quiz_commands.py
@@ -1,6 +1,5 @@
 import discord
 import random
-import asyncio
 from utils import safe_pin
 from io import BytesIO
 from typing import Optional, Tuple, List, Set
@@ -48,7 +47,7 @@ class QuizCommands(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def _select_random_draft_and_seat(self, guild_id: str) -> Tuple[Optional[DraftSession], Optional[int]]:
+    async def _select_random_draft_and_seat(self, guild_id: str) -> Optional[Tuple[DraftSession, int]]:
         """
         Select a random eligible draft and seat combination that hasn't been used for a quiz yet.
 
@@ -59,7 +58,7 @@ class QuizCommands(commands.Cog):
             guild_id: Guild ID to search drafts for
 
         Returns:
-            Tuple of (DraftSession, starting_seat) or (None, None) if no eligible combinations found
+            Tuple of (DraftSession, starting_seat), or None if no eligible combinations found
         """
         one_year_ago = datetime.now() - timedelta(days=ELIGIBLE_DRAFT_DAYS)
 
@@ -84,7 +83,7 @@ class QuizCommands(commands.Cog):
 
         if not eligible_drafts:
             logger.warning(f"No eligible drafts found for guild {guild_id}")
-            return None, None
+            return None
 
         # Shuffle drafts for random selection
         random.shuffle(eligible_drafts)
@@ -118,7 +117,7 @@ class QuizCommands(commands.Cog):
                 continue
 
         logger.warning(f"No unused draft+seat combinations found for guild {guild_id} (checked {drafts_checked} drafts, {len(used_combos)} combinations already used)")
-        return None, None
+        return None
 
     async def _prepare_quiz_data(self, draft_session: DraftSession, starting_seat: int):
         """
@@ -309,6 +308,9 @@ class QuizCommands(commands.Cog):
 
             logger.info(f"[QUIZ_IMAGE] channel.send() completed, message_id={message.id}")
 
+        else:
+            message = await channel.send(embed=embed, view=view)
+
         # Update QuizSession with message_id
         async with db_session() as session:
             await session.execute(
@@ -337,14 +339,15 @@ class QuizCommands(commands.Cog):
         await ctx.response.defer(ephemeral=True)
 
         # Select random draft and seat combination
-        draft_session, starting_seat = await self._select_random_draft_and_seat(ctx.guild.id)
-        if not draft_session:
+        selection = await self._select_random_draft_and_seat(ctx.guild.id)
+        if selection is None:
             await ctx.followup.send(
                 "No eligible draft+seat combinations found from the last year in this guild.\n"
                 "Drafts must have stored data in Spaces.",
                 ephemeral=True
             )
             return
+        draft_session, starting_seat = selection
 
         # Prepare quiz data with specific starting seat
         quiz_data = await self._prepare_quiz_data(draft_session, starting_seat)
@@ -404,9 +407,10 @@ class QuizCommands(commands.Cog):
                 return False
 
             # Select random draft and seat combination
-            draft_session, starting_seat = await self._select_random_draft_and_seat(guild.id)
-            if not draft_session:
+            selection = await self._select_random_draft_and_seat(guild.id)
+            if selection is None:
                 return False
+            draft_session, starting_seat = selection
 
             # Prepare quiz data with specific starting seat
             quiz_data = await self._prepare_quiz_data(draft_session, starting_seat)

--- a/cogs/quiz_scheduling_cog.py
+++ b/cogs/quiz_scheduling_cog.py
@@ -24,7 +24,7 @@ class QuizSchedulingCog(commands.Cog):
         self,
         ctx,
         channel: discord.TextChannel,
-        time_zone: Optional[str] = "UTC"
+        time_zone: str = "UTC"
     ):
         """
         Set up a channel for posting scheduled quizzes

--- a/cogs/test_commands.py
+++ b/cogs/test_commands.py
@@ -23,7 +23,7 @@ class TestCommands(commands.Cog):
     async def delete_draft_channels(
         self,
         ctx,
-        dry_run: discord.Option(bool, "Preview what would be deleted without actually deleting", default=True)
+        dry_run: discord.Option(bool, "Preview what would be deleted without actually deleting", default=True)  # pyrefly: ignore
     ):
         """Delete all draft-related channels (draft-chat*, red-team*, blue-team*) across the server."""
         await ctx.defer(ephemeral=True)

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -170,11 +170,11 @@ class TournamentCog(commands.Cog):
     async def create(
         self,
         ctx,
-        name: discord.Option(str, "Tournament name"),
-        format: discord.Option(
+        name: discord.Option(str, "Tournament name"),  # pyrefly: ignore
+        format: discord.Option(  # pyrefly: ignore
             str, "Pairing format", choices=["swiss", "round_robin", "manual"], default="swiss"
         ),
-        rounds: discord.Option(
+        rounds: discord.Option(  # pyrefly: ignore
             int, "Number of Swiss rounds (Swiss only)", min_value=1, max_value=20,
             required=False, default=None,
         ),
@@ -206,7 +206,7 @@ class TournamentCog(commands.Cog):
     async def register(
         self,
         ctx,
-        team: discord.Option(str, "Your team name"),
+        team: discord.Option(str, "Your team name"),  # pyrefly: ignore
     ):
         if not await self._check_enabled(ctx):
             return
@@ -243,8 +243,8 @@ class TournamentCog(commands.Cog):
     async def add_team(
         self,
         ctx,
-        team: discord.Option(str, "Team name"),
-        captain: discord.Option(discord.Member, "The team's captain"),
+        team: discord.Option(str, "Team name"),  # pyrefly: ignore
+        captain: discord.Option(discord.Member, "The team's captain"),  # pyrefly: ignore
     ):
         if not await self._check_enabled(ctx):
             return
@@ -269,7 +269,7 @@ class TournamentCog(commands.Cog):
     async def remove_team(
         self,
         ctx,
-        team: discord.Option(str, "Team name"),
+        team: discord.Option(str, "Team name"),  # pyrefly: ignore
     ):
         if not await self._check_enabled(ctx):
             return
@@ -290,8 +290,8 @@ class TournamentCog(commands.Cog):
     async def add_match(
         self,
         ctx,
-        team_a: discord.Option(str, "First team"),
-        team_b: discord.Option(str, "Second team"),
+        team_a: discord.Option(str, "First team"),  # pyrefly: ignore
+        team_b: discord.Option(str, "Second team"),  # pyrefly: ignore
     ):
         if not await self._check_enabled(ctx):
             return
@@ -340,9 +340,9 @@ class TournamentCog(commands.Cog):
     async def set_result(
         self,
         ctx,
-        team: discord.Option(str, "Either team in the match"),
-        team_wins: discord.Option(int, "Game wins for that team", min_value=0, max_value=10),
-        opponent_wins: discord.Option(int, "Game wins for their opponent", min_value=0, max_value=10),
+        team: discord.Option(str, "Either team in the match"),  # pyrefly: ignore
+        team_wins: discord.Option(int, "Game wins for that team", min_value=0, max_value=10),  # pyrefly: ignore
+        opponent_wins: discord.Option(int, "Game wins for their opponent", min_value=0, max_value=10),  # pyrefly: ignore
     ):
         if not await self._check_enabled(ctx):
             return
@@ -455,7 +455,7 @@ class TournamentCog(commands.Cog):
             matches = (await session.execute(
                 select(TournamentMatch).where(TournamentMatch.round_id == round_id)
             )).scalars().all()
-            rows = []
+            rows: list[tuple[int, str, str | None, bool]] = []
             for m in matches:
                 part_a = await session.get(TournamentParticipant, m.team_a_participant_id)
                 if m.is_bye:

--- a/commands.py
+++ b/commands.py
@@ -1,5 +1,6 @@
 import discord
 import aiocron
+from helpers.utils import not_none
 import pytz
 import asyncio
 from session import  Team, AsyncSessionLocal, Match, WeeklyLimit, DraftSession
@@ -161,6 +162,9 @@ async def core_commands(bot):
                 return
             
             # If we get here, we have a single match
+            if not isinstance(result, str):
+                await ctx.followup.send("Could not resolve player ID.", ephemeral=True)
+                return
             opponent_id = result
             
             # Get head-to-head stats with legacy data incorporated
@@ -332,7 +336,7 @@ async def scheduled_posts(bot):
                     date_str = end_time.strftime("%B %d, %Y")
                     top_drafters_field_value = "\n".join([f"{index + 1}. **{name}:** {count} drafts" for index, (name, count) in enumerate(top_drafters)])
                     embed = discord.Embed(title=f"Open Queue Weekly Summary - Week Ending {date_str}", description="", color=discord.Color.magenta())
-                    embed.add_field(name="**Completed Drafts**", value=total_drafts, inline=False)
+                    embed.add_field(name="**Completed Drafts**", value=str(total_drafts), inline=False)
                     embed.add_field(name="**Top 10 Drafters**\n", value=top_drafters_field_value, inline=False)
                     embed.add_field(name="**Multiple Weekly Trophies**", value=undefeated_drafters_field_value or "No trophies :(", inline=False)
 
@@ -394,7 +398,7 @@ async def scheduled_posts(bot):
                     date_str = start_time.strftime("%B %d, %Y")
                     top_drafters_field_value = "\n".join([f"**{name}:** {count} drafts" for name, count in top_five_drafters])
                     embed = discord.Embed(title=f"Open Queue Daily Results - {date_str}", description="", color=discord.Color.dark_purple())
-                    embed.add_field(name="**Completed Drafts**", value=total_drafts, inline=False)
+                    embed.add_field(name="**Completed Drafts**", value=str(total_drafts), inline=False)
                     embed.add_field(name="**Top 5 Drafters**\n", value=top_drafters_field_value, inline=False)
                     embed.add_field(name="**Trophy Drafters**", value=undefeated_drafters_field_value or "No trophies :(", inline=False)
 
@@ -660,7 +664,7 @@ class CategoryDropdown(discord.ui.Select):
     
     async def callback(self, interaction: discord.Interaction):
         # Get the selected category
-        category = self.values[0]
+        category = str(self.values[0])
         
         # Create a new view to show settings in this category
         from config import get_config
@@ -759,8 +763,7 @@ class ConfigModal(discord.ui.Modal):
         self.add_item(self.value_input)
     
     async def callback(self, interaction: discord.Interaction):
-        # Get the new value
-        new_value = self.value_input.value
+        new_value = not_none(self.value_input.value)
         
         try:
             # Try to convert to appropriate type
@@ -923,7 +926,8 @@ class SetupRolesView(discord.ui.View):
     @discord.ui.button(label="Continue", style=discord.ButtonStyle.primary)
     async def continue_button(self, button, interaction):
         # Get guild roles for selection
-        guild_roles = interaction.guild.roles
+        guild = not_none(interaction.guild)
+        guild_roles = guild.roles
         
         # Filter out @everyone and integration roles
         selectable_roles = [role for role in guild_roles 
@@ -960,7 +964,7 @@ class SetupRolesView(discord.ui.View):
         )
         
         # Define callback within this scope to capture needed variables
-        async def role_select_callback(role_interaction):
+        async def role_select_callback(interaction: discord.Interaction):
             if role_select.values:
                 # Save selected role
                 self.config["roles"]["selected"] = role_select.values
@@ -969,7 +973,7 @@ class SetupRolesView(discord.ui.View):
                 self.config["roles"]["selected"] = []
             
             # Now move to matchmaking view
-            await role_interaction.response.edit_message(
+            await interaction.response.edit_message(
                 content="## Step 4: Team Balancing\n\n"
                         "How often should the bot use skill-based team balancing?\n\n"
                         "0% = Always random teams\n"
@@ -1041,7 +1045,7 @@ class MatchmakingModal(discord.ui.Modal):
     async def callback(self, interaction):
         try:
             # Parse the percentage value (handle both "50" and "50%")
-            value = self.percentage.value.strip().rstrip('%')
+            value = not_none(self.percentage.value).strip().rstrip('%')
             percentage = float(value)
             
             # Validate the range
@@ -1117,12 +1121,12 @@ class SetupConfirmView(discord.ui.View):
     async def confirm_button(self, button, interaction):
         # Create everything
         created_items = []
-        guild = interaction.guild
-        
+        guild = not_none(interaction.guild)
+
         # Create category if needed
         category = None
+        category_name = self.config["categories"].get("draft_name", "Draft Channels")
         if self.config["categories"].get("draft", False):
-            category_name = self.config["categories"].get("draft_name", "Draft Channels")
             category = await guild.create_category(category_name)
             created_items.append(f"📁 Category: {category.name}")
         

--- a/config.py
+++ b/config.py
@@ -237,8 +237,8 @@ class Config:
             
         # Load existing guild configs
         for config_file in config_dir.glob("*.json"):
+            guild_id = config_file.stem
             try:
-                guild_id = config_file.stem
                 with open(config_file, "r") as f:
                     self.configs[guild_id] = json.load(f)
             except Exception as e:

--- a/cube_views/CubeListModal.py
+++ b/cube_views/CubeListModal.py
@@ -1,6 +1,7 @@
 import discord
 from config import get_config, save_config
 from loguru import logger
+from helpers.utils import not_none
 
 
 def parse_cube_list(raw: str):
@@ -37,13 +38,19 @@ class CubeListModal(discord.ui.Modal):
         ))
 
     async def callback(self, interaction: discord.Interaction):
-        raw = self.children[0].value
+        raw = not_none(self.children[0].value)
         cubes, errors = parse_cube_list(raw)
 
         if errors:
             await interaction.response.send_message(
                 "❌ Could not parse the following lines:\n" + "\n".join(errors),
                 ephemeral=True,
+            )
+            return
+
+        if interaction.guild_id is None or interaction.guild is None or interaction.user is None:
+            await interaction.response.send_message(
+                "This can only be used in a server.", ephemeral=True
             )
             return
 

--- a/cube_views/CubeSelectionView.py
+++ b/cube_views/CubeSelectionView.py
@@ -13,7 +13,7 @@ class CubeUpdateSelectionView(BaseCubeSelectionView):
 
     submit_label = "Update Cube"
 
-    def __init__(self, session_type: str, guild_id: int, current_cube=None, on_submit=None):
+    def __init__(self, session_type: str, guild_id: int, current_cube: str | None = None, on_submit=None):
         super().__init__(session_type, guild_id, current_cube)
         self.on_submit = on_submit
 
@@ -27,4 +27,4 @@ class CubeUpdateSelectionView(BaseCubeSelectionView):
         if self.cube_choice == "custom":
             await interaction.response.send_modal(CustomCubeNameModal(self, self.on_submit))
         else:
-            await self.on_submit(interaction, self)
+            await self.on_submit(interaction, self)  # pyrefly: ignore

--- a/cube_views/pack_options.py
+++ b/cube_views/pack_options.py
@@ -8,6 +8,7 @@ otherwise create.
 """
 import discord
 from config import get_cube_options
+from helpers.utils import not_none
 
 # Default pack structure (standard MTG draft / Draftmancer defaults).
 DEFAULT_PACKS_PER_PLAYER = 3
@@ -33,7 +34,8 @@ def pack_format_display(packs_per_player, cards_per_pack):
 
 def selected_value(interaction: discord.Interaction):
     """Pull the chosen string-select value from the raw interaction payload."""
-    values = (interaction.data or {}).get("values") or []
+    raw_data: dict = interaction.data or {}  # pyrefly: ignore
+    values = raw_data.get("values") or []
     return values[0] if values else None
 
 
@@ -89,8 +91,8 @@ class AdvancedOptionsModal(discord.ui.Modal):
             )
             return
 
-        self.view_ref.packs_per_player = packs
-        self.view_ref.cards_per_pack = cards
+        self.view_ref.packs_per_player = not_none(packs)
+        self.view_ref.cards_per_pack = not_none(cards)
         await interaction.response.send_message(
             f"✅ Advanced options set: **{packs}** packs per player, **{cards}** cards per pack.\n"
             "Select a cube (if you haven't) and click the green ✅ button when ready.",
@@ -138,7 +140,7 @@ class BaseCubeSelectionView(discord.ui.View):
         self.packs_per_player = DEFAULT_PACKS_PER_PLAYER
         self.cards_per_pack = DEFAULT_CARDS_PER_PACK
 
-        options = [discord.SelectOption(**opt) for opt in get_cube_options(guild_id, session_type)]
+        options = [discord.SelectOption(**opt) for opt in get_cube_options(guild_id, session_type)]  # pyrefly: ignore
         options.append(discord.SelectOption(label="Custom Cube...", value="custom"))
         self.cube_select = discord.ui.Select(placeholder="Select a Cube", options=options)
         self.cube_select.callback = self.cube_select_callback

--- a/database/db_session.py
+++ b/database/db_session.py
@@ -28,7 +28,7 @@ engine = create_async_engine(
 )
 
 # Create session factory
-AsyncSessionLocal = sessionmaker(
+AsyncSessionLocal = sessionmaker(  # pyrefly: ignore
     engine,
     expire_on_commit=False,
     class_=AsyncSession

--- a/database/message_management.py
+++ b/database/message_management.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, cast
 import discord
 from helpers.pin_helpers import safe_pin
 from sqlalchemy import JSON, Column, Integer, String, Boolean, Float, select, text, REAL
@@ -65,7 +65,7 @@ async def fetch_all_sticky_messages(session: AsyncSession) -> list[Message]:
     result = await session.execute(
         select(Message).filter_by(is_sticky=True)
     )
-    return result.scalars().all()
+    return list(result.scalars().all())
 
 
 async def _get_guild(bot: discord.Client, guild_id: str) -> Optional[discord.Guild]:
@@ -175,7 +175,7 @@ class DraftStickyStrategy(StickyStrategy):
         updated_metadata["session_stage"] = draft_session.session_stage
 
         # Get existing embed from old message, or regenerate if not found
-        channel = await bot.fetch_channel(int(sticky_message.channel_id))
+        channel = cast(discord.TextChannel, await bot.fetch_channel(int(sticky_message.channel_id)))
         try:
             old_message = await channel.fetch_message(int(sticky_message.message_id))
             embed = old_message.embeds[0] if old_message.embeds else None
@@ -274,8 +274,9 @@ class DebtSummaryStickyStrategy(StickyStrategy):
         from debt_views.helpers import build_guild_debt_embed_pages
         from debt_views.settle_views import PublicSettleDebtsView
 
+        from helpers.utils import not_none
         guild_id = sticky_message.guild_id
-        guild = bot.get_guild(int(guild_id))
+        guild = not_none(bot.get_guild(int(guild_id)))
 
         # Re-fetch debt data to allow the sticky update to refresh content
         rows = await get_guild_debt_rows(guild_id)
@@ -353,7 +354,7 @@ async def handle_sticky_message_update(
         await session.commit()
         return StickyUpdateResult.CLEANED_UP
 
-    channel = await bot.fetch_channel(int(sticky_message.channel_id))
+    channel = cast(discord.TextChannel, await bot.fetch_channel(int(sticky_message.channel_id)))
 
     # Generate new content
     try:
@@ -366,7 +367,12 @@ async def handle_sticky_message_update(
 
     # Send new message
     try:
-        new_message = await channel.send(content=content, embed=embed, view=view)
+        send_kwargs: dict = {"content": content}
+        if embed is not None:
+            send_kwargs["embed"] = embed
+        if view is not None:
+            send_kwargs["view"] = view
+        new_message = await channel.send(**send_kwargs)
     except discord.Forbidden:
         logger.error(f"Missing permissions to send message in {channel.id}")
         return StickyUpdateResult.FAILED
@@ -543,7 +549,8 @@ async def remove_sticky_message(message: discord.Message) -> None:
         # If notification exists, try delete
         if sticky_message.notification_message_id:
             try:
-                guild = message.guild
+                from helpers.utils import not_none
+                guild = not_none(message.guild)
                 notification_channel = await find_notification_channel(guild)
                 if notification_channel:
                     notification_msg = await notification_channel.fetch_message(int(sticky_message.notification_message_id))

--- a/datacollections.py
+++ b/datacollections.py
@@ -14,6 +14,7 @@ from session import AsyncSessionLocal, DraftSession
 from loguru import logger
 from config import get_draftmancer_base_url, get_draftmancer_websocket_url
 from services.draft_socket_client import DraftSocketClient
+from helpers.utils import not_none
 
 load_dotenv()
 
@@ -278,7 +279,7 @@ class DraftLogManager:
         """Find draft-logs channel and send the embed if found."""
         try:
             # Find the guild
-            guild = self.discord_client.get_guild(self.guild_id)
+            guild = not_none(self.discord_client).get_guild(self.guild_id)
             if not guild:
                 logger.warning(f"Could not find guild with ID {self.guild_id}")
                 return
@@ -477,9 +478,9 @@ class DraftLogManager:
 
     async def generate_magicprotools_embed(self, draft_data):
         """Generate a Discord embed with MagicProTools links for all drafters and store them in the database."""
+        import discord  # Import locally to avoid issues if Discord isn't available
+        from models.match import MatchResult  # Import MatchResult class
         try:
-            import discord  # Import locally to avoid issues if Discord isn't available
-            from models.match import MatchResult  # Import MatchResult class
             
             DO_SPACES_REGION = os.getenv("DO_SPACES_REGION")
             DO_SPACES_BUCKET = os.getenv("DO_SPACES_BUCKET")

--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -9,6 +9,8 @@ import traceback
 import discord
 from discord.ui import View, Button, Select, Modal, InputText
 from loguru import logger
+from typing import cast
+from helpers.utils import not_none
 
 from services.debt_service import (
     get_all_balances_for,
@@ -55,7 +57,7 @@ class SettleDebtsButton(Button):
 
     async def callback(self, interaction: discord.Interaction):
         """Handle button click - show user's debts with participants."""
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         logger.info(f"[SettleDebts] Button clicked by user {user_id} for session {self.session_id}")
 
         try:
@@ -75,12 +77,12 @@ class SettleDebtsButton(Button):
                 )
                 return
 
-            embed = build_user_balance_embed(interaction.guild, balances)
+            embed = build_user_balance_embed(not_none(interaction.guild), balances)
             view = await _build_settle_entry_view(
                 user_id=user_id,
                 guild_id=self.guild_id,
                 balances=balances,
-                guild=interaction.guild
+                guild=not_none(interaction.guild)
             )
 
             logger.info(f"[SettleDebts] Sending balance embed with {len(balances)} counterparties")
@@ -118,7 +120,7 @@ class SettleDebtsButton(Button):
 class SettleDebtsView(View):
     """View containing the Settle Debts button for victory messages."""
 
-    def __init__(self, session_id: str, guild_id: str, timeout: float = None):
+    def __init__(self, session_id: str, guild_id: str, timeout: float | None = None):
         # No timeout for persistent views
         super().__init__(timeout=timeout)
         self.add_item(SettleDebtsButton(session_id=session_id, guild_id=guild_id))
@@ -167,7 +169,7 @@ class CounterpartySelectView(View):
     async def select_callback(self, interaction: discord.Interaction):
         """Handle counterparty selection."""
         try:
-            counterparty_id = interaction.data['values'][0]
+            counterparty_id = interaction.data['values'][0]  # pyrefly: ignore
             balance = self.balances.get(counterparty_id, 0)
 
             logger.info(f"[CounterpartySelect] User {self.user_id} selected counterparty {counterparty_id}, balance: {balance}")
@@ -274,7 +276,7 @@ class AmountInputView(View):
     async def enter_amount(self, button: Button, interaction: discord.Interaction):
         """Open modal for amount input."""
         try:
-            logger.info(f"[AmountInputView] Enter Amount clicked by user {interaction.user.id}")
+            logger.info(f"[AmountInputView] Enter Amount clicked by user {not_none(interaction.user).id}")
             modal = AmountConfirmationModal(
                 user_id=self.user_id,
                 guild_id=self.guild_id,
@@ -303,7 +305,7 @@ class AmountInputView(View):
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
     async def cancel(self, button: Button, interaction: discord.Interaction):
         """Cancel settlement."""
-        logger.info(f"[AmountInputView] Cancel clicked by user {interaction.user.id}")
+        logger.info(f"[AmountInputView] Cancel clicked by user {not_none(interaction.user).id}")
         await interaction.response.edit_message(
             content="Settlement cancelled.",
             embed=None,
@@ -454,7 +456,7 @@ class TransferCreditorSelectView(View):
     async def select_callback(self, interaction: discord.Interaction):
         """Handle creditor selection - show debtor dropdown."""
         try:
-            creditor_id = interaction.data['values'][0]
+            creditor_id = interaction.data['values'][0]  # pyrefly: ignore
             transferable_debtors = self._creditor_lookup[creditor_id]
             creditor_name_plain = get_member_name_plain(self.guild, creditor_id)
             creditor_name_decorated = get_member_name(self.guild, creditor_id)
@@ -544,7 +546,7 @@ class DebtorSelectView(View):
     async def select_callback(self, interaction: discord.Interaction):
         """Handle debtor selection - open transfer amount modal."""
         try:
-            debtor_id = interaction.data['values'][0]
+            debtor_id = interaction.data['values'][0]  # pyrefly: ignore
             amount_owed, max_transfer = self._debtor_lookup[debtor_id]
             debtor_name_plain = get_member_name_plain(self.guild, debtor_id)
             debtor_name_decorated = get_member_name(self.guild, debtor_id)
@@ -622,10 +624,10 @@ class TransferAmountModal(Modal):
 
     async def callback(self, interaction: discord.Interaction):
         """Handle modal submission."""
-        logger.info(f"[TransferModal] Submitted by user {interaction.user.id}")
+        logger.info(f"[TransferModal] Submitted by user {not_none(interaction.user).id}")
 
         try:
-            amount = int(self.amount_input.value)
+            amount = int(not_none(self.amount_input.value))
             if amount <= 0:
                 await interaction.response.send_message(
                     "Amount must be positive.",
@@ -693,7 +695,7 @@ class TransferAmountModal(Modal):
 
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
-    async def on_error(self, interaction: discord.Interaction, error: Exception):
+    async def on_error(self, interaction: discord.Interaction, error: Exception):  # pyrefly: ignore
         logger.error(f"[TransferModal] Error: {error}")
         logger.error(f"[TransferModal] Traceback: {traceback.format_exc()}")
         try:
@@ -734,7 +736,7 @@ class TransferConfirmView(View):
     async def confirm(self, button: Button, interaction: discord.Interaction):
         """Execute the debt transfer."""
         if self._processing:
-            logger.warning(f"[TransferConfirm] Ignoring duplicate click from user {interaction.user.id}")
+            logger.warning(f"[TransferConfirm] Ignoring duplicate click from user {not_none(interaction.user).id}")
             await interaction.response.send_message(
                 "Transfer is already being processed...",
                 ephemeral=True
@@ -742,12 +744,12 @@ class TransferConfirmView(View):
             return
 
         self._processing = True
-        logger.info(f"[TransferConfirm] Confirm clicked by user {interaction.user.id}")
+        logger.info(f"[TransferConfirm] Confirm clicked by user {not_none(interaction.user).id}")
 
         await interaction.response.defer()
 
         for item in self.children:
-            item.disabled = True
+            cast(discord.ui.Button, item).disabled = True
 
         try:
             await interaction.edit_original_response(
@@ -806,7 +808,7 @@ class TransferConfirmView(View):
             logger.error(f"[TransferConfirm] Traceback: {traceback.format_exc()}")
             self._processing = False
             for item in self.children:
-                item.disabled = False
+                cast(discord.ui.Button, item).disabled = False
             try:
                 await interaction.edit_original_response(
                     content=f"Failed to record transfer: {str(e)}",
@@ -825,7 +827,7 @@ class TransferConfirmView(View):
             )
             return
 
-        logger.info(f"[TransferConfirm] Cancel clicked by user {interaction.user.id}")
+        logger.info(f"[TransferConfirm] Cancel clicked by user {not_none(interaction.user).id}")
         await interaction.response.edit_message(
             content="Transfer cancelled.",
             embed=None,
@@ -871,11 +873,11 @@ class AmountConfirmationModal(Modal):
 
     async def callback(self, interaction: discord.Interaction):
         """Handle modal submission (py-cord uses 'callback' not 'on_submit')."""
-        logger.info(f"[AmountModal] Modal submitted by user {interaction.user.id}")
+        logger.info(f"[AmountModal] Modal submitted by user {not_none(interaction.user).id}")
         logger.debug(f"[AmountModal] Amount input value: '{self.amount_input.value}'")
 
         try:
-            amount = int(self.amount_input.value)
+            amount = int(not_none(self.amount_input.value))
             logger.debug(f"[AmountModal] Parsed amount: {amount}")
             if amount <= 0:
                 logger.warning(f"[AmountModal] Invalid amount (non-positive): {amount}")
@@ -972,7 +974,7 @@ class AmountConfirmationModal(Modal):
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
         logger.debug(f"[AmountModal] Confirmation sent successfully")
 
-    async def on_error(self, interaction: discord.Interaction, error: Exception):
+    async def on_error(self, interaction: discord.Interaction, error: Exception):  # pyrefly: ignore
         """Handle errors in modal submission."""
         logger.error(f"[AmountModal] Error in on_submit: {error}")
         logger.error(f"[AmountModal] Traceback: {traceback.format_exc()}")
@@ -1012,7 +1014,7 @@ class SettlementConfirmView(View):
         """Create the settlement."""
         # Guard against double-clicks
         if self._processing:
-            logger.warning(f"[SettlementConfirm] Ignoring duplicate click from user {interaction.user.id}")
+            logger.warning(f"[SettlementConfirm] Ignoring duplicate click from user {not_none(interaction.user).id}")
             await interaction.response.send_message(
                 "Settlement is already being processed...",
                 ephemeral=True
@@ -1020,7 +1022,7 @@ class SettlementConfirmView(View):
             return
 
         self._processing = True
-        logger.info(f"[SettlementConfirm] Confirm clicked by user {interaction.user.id}")
+        logger.info(f"[SettlementConfirm] Confirm clicked by user {not_none(interaction.user).id}")
 
         # Defer immediately to avoid Discord's 3-second timeout
         # Other async operations (like leaderboard updates) can delay us
@@ -1028,7 +1030,7 @@ class SettlementConfirmView(View):
 
         # Disable buttons immediately to prevent double-clicks
         for item in self.children:
-            item.disabled = True
+            cast(discord.ui.Button, item).disabled = True
 
         try:
             # Update the message to show processing state
@@ -1063,7 +1065,7 @@ class SettlementConfirmView(View):
             try:
                 asyncio.create_task(send_settlement_notification_dm(
                     bot=interaction.client,
-                    guild=interaction.guild,
+                    guild=not_none(interaction.guild),
                     guild_id=self.guild_id,
                     settler_id=self.user_id,
                     payer_id=self.payer_id,
@@ -1086,7 +1088,7 @@ class SettlementConfirmView(View):
             self._processing = False  # Allow retry on error
             # Re-enable buttons on error
             for item in self.children:
-                item.disabled = False
+                cast(discord.ui.Button, item).disabled = False
             try:
                 await interaction.edit_original_response(
                     content=f"Failed to record settlement: {str(e)}",
@@ -1105,7 +1107,7 @@ class SettlementConfirmView(View):
             )
             return
 
-        logger.info(f"[SettlementConfirm] Cancel clicked by user {interaction.user.id}")
+        logger.info(f"[SettlementConfirm] Cancel clicked by user {not_none(interaction.user).id}")
         await interaction.response.edit_message(
             content="Settlement cancelled.",
             embed=None,
@@ -1195,8 +1197,8 @@ class PublicSettleDebtsView(View):
     )
     async def settle_button(self, button: Button, interaction: discord.Interaction):
         """Handle button click - show user's debts and launch settlement flow."""
-        user_id = str(interaction.user.id)
-        guild_id = str(interaction.guild.id)
+        user_id = str(not_none(interaction.user).id)
+        guild_id = str(not_none(interaction.guild).id)
         logger.info(f"[PublicSettle] Button clicked by user {user_id} in guild {guild_id}")
 
         try:
@@ -1213,12 +1215,12 @@ class PublicSettleDebtsView(View):
                 )
                 return
 
-            embed = build_user_balance_embed(interaction.guild, balances)
+            embed = build_user_balance_embed(not_none(interaction.guild), balances)
             view = await _build_settle_entry_view(
                 user_id=user_id,
                 guild_id=guild_id,
                 balances=balances,
-                guild=interaction.guild
+                guild=not_none(interaction.guild)
             )
 
             await interaction.response.send_message(
@@ -1267,7 +1269,7 @@ class DMSettleDebtsView(View):
     )
     async def settle_button(self, button: Button, interaction: discord.Interaction):
         """Handle button click in DM - resolve guild from bot and launch settlement flow."""
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         logger.info(f"[DMSettle] Button clicked by user {user_id} for guild {self.guild_id}")
 
         try:

--- a/draft_organization/stake_calculator.py
+++ b/draft_organization/stake_calculator.py
@@ -142,9 +142,10 @@ class StakeCalculator:
         
         return results
     
-    def tiered_stakes_calculator(team_a: List[str], team_b: List[str], 
+    @staticmethod
+    def tiered_stakes_calculator(team_a: List[str], team_b: List[str],
                                 stakes: Dict[str, int], min_stake: int = 10,
-                                multiple: int = 10, cap_info: Dict[str, bool] = None) -> List[StakePair]:
+                                multiple: int = 10, cap_info: Dict[str, bool] | None = None) -> List[StakePair]:
         """
         Calculate stake pairings using a tiered approach that prioritizes 10/20/50 bets
         and applies proportional allocation to higher bets.
@@ -497,7 +498,9 @@ class StakeCalculator:
                 
                 # Store final high tier allocations
                 for player_id, allocation, adjusted_stake, original_stake in high_tier_allocations:
-                    allocations[player_id] = allocation
+                    # allocation is a whole multiple of `multiple` (see rounding above);
+                    # round() keeps allocations as int tix, consistent with StakePair.amount.
+                    allocations[player_id] = round(allocation)
                     percentage = (allocation / original_stake) * 100
                     stake_logger.info(f"Max team high tier player {player_id} allocation: {allocation}/{original_stake} ({percentage:.1f}%)")
             
@@ -1017,7 +1020,7 @@ class StakeCalculator:
 def calculate_stakes_with_strategy(team_a: List[str], team_b: List[str], 
                                  stakes: Dict[str, int], min_stake: int = 10,
                                  multiple: int = 10, use_optimized: bool = False,
-                                 cap_info: Dict[str, bool] = None) -> List[StakePair]:
+                                 cap_info: Dict[str, bool] | None = None) -> List[StakePair]:
     """
     Calculate stake pairings using either the original or optimized algorithm.
     

--- a/draft_organization/tournament.py
+++ b/draft_organization/tournament.py
@@ -1,10 +1,11 @@
 import random
 
 class Tournament:
-    def __init__(self, sign_ups=None, from_state=None):
+    def __init__(self, sign_ups: dict | None = None, from_state=None):
         if from_state:
             self.__dict__.update(from_state)
         else:
+            sign_ups = sign_ups or {}
             self.players = {}
             self.round_number = 0
             self.matches = []

--- a/helpers/digital_ocean_helper.py
+++ b/helpers/digital_ocean_helper.py
@@ -223,7 +223,7 @@ class DigitalOceanHelper:
                     self.logger.debug(f"No contents found for prefix {prefix}")
                     return []
 
-                keys = [obj['Key'] for obj in response['Contents']]
+                keys: list[str] = [obj['Key'] for obj in response['Contents']]
                 self.logger.debug(f"Found {len(keys)} keys for prefix {prefix}")
                 return keys
 

--- a/helpers/display_names.py
+++ b/helpers/display_names.py
@@ -48,7 +48,7 @@ def get_crown_icon(member: discord.Member, guild: Optional[discord.Guild]) -> st
     return ""
 
 
-def get_display_name(member: discord.Member, guild: Optional[discord.Guild] = None) -> str:
+def get_display_name(member: discord.Member | discord.User, guild: Optional[discord.Guild] = None) -> str:
     """
     Get display name for a Discord member, with ring bearer and/or crown icon if applicable.
 
@@ -65,8 +65,8 @@ def get_display_name(member: discord.Member, guild: Optional[discord.Guild] = No
 
     icons = []
 
-    # Check for ring bearer icon first
-    if guild:
+    # Check for ring bearer icon first (Member-only: requires .roles)
+    if guild and isinstance(member, discord.Member):
         from config import get_config
         config = get_config(guild.id)
         rb_config = config.get("ring_bearer", {})
@@ -78,8 +78,8 @@ def get_display_name(member: discord.Member, guild: Optional[discord.Guild] = No
                 rb_icon = rb_config.get("icon", "💎")
                 icons.append(rb_icon)
 
-    # Then check for crown icon
-    crown_icon = get_crown_icon(member, guild) if guild else ""
+    # Then check for crown icon (Member-only)
+    crown_icon = get_crown_icon(member, guild) if guild and isinstance(member, discord.Member) else ""
     if crown_icon:
         icons.append(crown_icon)
 

--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -202,27 +202,27 @@ class MagicProtoolsHelper:
                 user_filename = f"DraftLog_{user_id}.txt"
                 
                 # Upload to DO Spaces
-                result = await self.do_helper.upload_text(
+                upload_result = await self.do_helper.upload_text(
                     mpt_format,
                     base_path,
                     user_filename
                 )
 
-                if result.success:
+                if upload_result.success:
                     # Get the public URL
                     txt_key = f"{base_path}/{user_filename}"
                     txt_url = self.do_helper.get_public_url(txt_key)
-                    
+
                     # Try direct API submission first
                     mpt_url = None
                     if self.api_key:
                         mpt_url = await self.submit_to_api(user_id, draft_data)
-                    
+
                     # Fallback to import URL if direct submission failed
                     if not mpt_url:
                         import_url = f"https://magicprotools.com/draft/import?url={urllib.parse.quote(txt_url)}"
                         mpt_url = import_url
-                    
+
                     # Store the URLs
                     result[user_id] = {
                         "name": user_name,

--- a/helpers/pack_compositor.py
+++ b/helpers/pack_compositor.py
@@ -8,7 +8,7 @@ import asyncio
 import aiohttp
 from io import BytesIO
 from PIL import Image
-from typing import Optional, List
+from typing import Optional, List, Tuple
 from loguru import logger
 
 
@@ -141,12 +141,12 @@ class PackCompositor:
                 card_images = await asyncio.gather(*download_tasks, return_exceptions=True)
 
             # Filter out failed downloads and exceptions
-            valid_images = []
+            valid_images: List[Tuple[int, Image.Image]] = []
             for i, img in enumerate(card_images):
-                if isinstance(img, Exception):
-                    logger.warning(f"Exception downloading card {i}: {img}")
-                elif img is not None:
+                if isinstance(img, Image.Image):
                     valid_images.append((i, img))
+                elif isinstance(img, BaseException):
+                    logger.warning(f"Exception downloading card {i}: {img}")
                 else:
                     logger.warning(f"Failed to download card at index {i}")
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,3 +1,18 @@
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+
+def not_none(x: _T | None) -> _T:
+    """Assert a value is not None, raising at runtime if the assumption is wrong.
+    
+        Use this sparingly, only when you are certain of something the typechecker cannot
+        infer (pycord types frequently)
+    """
+    if x is None:
+        raise ValueError(f"Expected non-None value, got None")
+    return x
+
 
 # Define a mapping of cube names to thumbnail URLs
 # This is used for consistent cube thumbnails across the app

--- a/leaderboard_config.py
+++ b/leaderboard_config.py
@@ -15,6 +15,16 @@ The category will automatically propagate to:
 """
 
 import discord
+from typing import Callable, TypedDict
+
+
+class CategoryConfig(TypedDict):
+    """Shape of each leaderboard category's display configuration."""
+    title: str
+    description_template: str
+    color: discord.Color
+    formatter: Callable[[dict, int], str]
+
 
 # Helper function for formatting (used by all categories)
 def get_medal(rank):
@@ -41,7 +51,7 @@ def _format_ended_streak(p):
 
 
 # Category configuration - SINGLE SOURCE OF TRUTH
-CATEGORY_CONFIGS = {
+CATEGORY_CONFIGS: dict[str, CategoryConfig] = {
     "draft_record": {
         "title": "Draft Record Leaderboard",
         "description_template": "Players with the highest team draft win percentage (min {drafts} drafts, 50%+ win rate)",

--- a/legacy_stats.py
+++ b/legacy_stats.py
@@ -249,6 +249,7 @@ def get_legacy_player_stats(user_id, time_frame=None):
     # Calculate team win percentage
     # Calculate team draft win percentage using shared utility
     team_losses = stats['team_drafts_played'] - stats['team_drafts_won'] - stats['team_drafts_tied']
+    # pyrefly: ignore [bad-assignment]
     stats['team_draft_win_percentage'] = calculate_team_draft_win_percentage(
         stats['team_drafts_won'],
         team_losses,
@@ -257,6 +258,7 @@ def get_legacy_player_stats(user_id, time_frame=None):
 
     # Calculate match win percentage using shared utility
     matches_lost = stats['matches_played'] - stats['matches_won']
+    # pyrefly: ignore [bad-assignment]
     stats['match_win_percentage'] = calculate_win_percentage(stats['matches_won'], matches_lost)
         
     return stats
@@ -358,11 +360,14 @@ def get_legacy_head_to_head_stats(user1_id, user2_id, time_frame=None):
     
     # Calculate win percentages for match stats using shared utility
     total_matches = match_stats['matches_played']
+    # pyrefly: ignore [bad-assignment]
     match_stats['user1_win_percentage'] = calculate_win_percentage(match_stats['user1_wins'], total_matches - match_stats['user1_wins'])
+    # pyrefly: ignore [bad-assignment]
     match_stats['user2_win_percentage'] = calculate_win_percentage(match_stats['user2_wins'], total_matches - match_stats['user2_wins'])
 
     # Calculate win percentages for team stats using shared utility
     for stats in [opposing_stats, teammate_stats]:
+        # pyrefly: ignore [unsupported-operation]
         stats['win_percentage'] = calculate_win_percentage(stats['wins'], stats['losses'], stats['draws'])
     
     return {
@@ -395,12 +400,19 @@ async def get_player_statistics_with_legacy(user_id, time_frame=None, user_displ
         
         # Merge the stats
         merged_stats = {
+            # pyrefly: ignore [unsupported-operation]
             "drafts_played": current_stats.get("drafts_played", 0) + legacy_stats.get("drafts_played", 0),
+            # pyrefly: ignore [unsupported-operation]
             "matches_played": current_stats.get("matches_played", 0) + legacy_stats.get("matches_played", 0),
+            # pyrefly: ignore [unsupported-operation]
             "matches_won": current_stats.get("matches_won", 0) + legacy_stats.get("matches_won", 0),
+            # pyrefly: ignore [unsupported-operation]
             "trophies_won": current_stats.get("trophies_won", 0) + legacy_stats.get("trophies_won", 0),
+            # pyrefly: ignore [unsupported-operation]
             "team_drafts_played": current_stats.get("team_drafts_played", 0) + legacy_stats.get("team_drafts_played", 0),
+            # pyrefly: ignore [unsupported-operation]
             "team_drafts_won": current_stats.get("team_drafts_won", 0) + legacy_stats.get("team_drafts_won", 0),
+            # pyrefly: ignore [unsupported-operation]
             "team_drafts_tied": current_stats.get("team_drafts_tied", 0) + legacy_stats.get("team_drafts_tied", 0),
             "display_name": current_stats.get("display_name", user_display_name),
             "cube_stats": current_stats.get("cube_stats", {}),
@@ -457,8 +469,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_lifetime_matches = legacy_lifetime.get("match_stats", {})
         
         merged_lifetime = {
+            # pyrefly: ignore [missing-attribute]
             "matches_played": current_lifetime.get("matches_played", 0) + legacy_lifetime_matches.get("matches_played", 0),
+            # pyrefly: ignore [missing-attribute]
             "user1_wins": current_lifetime.get("user1_wins", 0) + legacy_lifetime_matches.get("user1_wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "user2_wins": current_lifetime.get("user2_wins", 0) + legacy_lifetime_matches.get("user2_wins", 0)
         }
         
@@ -472,8 +487,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_monthly_matches = legacy_monthly.get("match_stats", {})
         
         merged_monthly = {
+            # pyrefly: ignore [missing-attribute]
             "matches_played": current_monthly.get("matches_played", 0) + legacy_monthly_matches.get("matches_played", 0),
+            # pyrefly: ignore [missing-attribute]
             "user1_wins": current_monthly.get("user1_wins", 0) + legacy_monthly_matches.get("user1_wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "user2_wins": current_monthly.get("user2_wins", 0) + legacy_monthly_matches.get("user2_wins", 0)
         }
         
@@ -487,8 +505,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_weekly_matches = legacy_weekly.get("match_stats", {})
         
         merged_weekly = {
+            # pyrefly: ignore [missing-attribute]
             "matches_played": current_weekly.get("matches_played", 0) + legacy_weekly_matches.get("matches_played", 0),
+            # pyrefly: ignore [missing-attribute]
             "user1_wins": current_weekly.get("user1_wins", 0) + legacy_weekly_matches.get("user1_wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "user2_wins": current_weekly.get("user2_wins", 0) + legacy_weekly_matches.get("user2_wins", 0)
         }
         
@@ -502,8 +523,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_opposing_lifetime = legacy_lifetime.get("opposing_stats", {})
         
         merged_opposing_lifetime = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_opposing_lifetime.get("wins", 0) + legacy_opposing_lifetime.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_opposing_lifetime.get("losses", 0) + legacy_opposing_lifetime.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_opposing_lifetime.get("draws", 0) + legacy_opposing_lifetime.get("draws", 0)
         }
         
@@ -519,8 +543,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_opposing_monthly = legacy_monthly.get("opposing_stats", {})
         
         merged_opposing_monthly = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_opposing_monthly.get("wins", 0) + legacy_opposing_monthly.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_opposing_monthly.get("losses", 0) + legacy_opposing_monthly.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_opposing_monthly.get("draws", 0) + legacy_opposing_monthly.get("draws", 0)
         }
         
@@ -534,8 +561,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_opposing_weekly = legacy_weekly.get("opposing_stats", {})
         
         merged_opposing_weekly = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_opposing_weekly.get("wins", 0) + legacy_opposing_weekly.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_opposing_weekly.get("losses", 0) + legacy_opposing_weekly.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_opposing_weekly.get("draws", 0) + legacy_opposing_weekly.get("draws", 0)
         }
         
@@ -550,8 +580,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_teammate_lifetime = legacy_lifetime.get("teammate_stats", {})
         
         merged_teammate_lifetime = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_teammate_lifetime.get("wins", 0) + legacy_teammate_lifetime.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_teammate_lifetime.get("losses", 0) + legacy_teammate_lifetime.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_teammate_lifetime.get("draws", 0) + legacy_teammate_lifetime.get("draws", 0)
         }
         
@@ -566,8 +599,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_teammate_monthly = legacy_monthly.get("teammate_stats", {})
         
         merged_teammate_monthly = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_teammate_monthly.get("wins", 0) + legacy_teammate_monthly.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_teammate_monthly.get("losses", 0) + legacy_teammate_monthly.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_teammate_monthly.get("draws", 0) + legacy_teammate_monthly.get("draws", 0)
         }
         
@@ -581,8 +617,11 @@ async def get_head_to_head_stats_with_legacy(user1_id, user2_id, user1_display_n
         legacy_teammate_weekly = legacy_weekly.get("teammate_stats", {})
         
         merged_teammate_weekly = {
+            # pyrefly: ignore [missing-attribute]
             "wins": current_teammate_weekly.get("wins", 0) + legacy_teammate_weekly.get("wins", 0),
+            # pyrefly: ignore [missing-attribute]
             "losses": current_teammate_weekly.get("losses", 0) + legacy_teammate_weekly.get("losses", 0),
+            # pyrefly: ignore [missing-attribute]
             "draws": current_teammate_weekly.get("draws", 0) + legacy_teammate_weekly.get("draws", 0)
         }
         

--- a/models/draft_domain.py
+++ b/models/draft_domain.py
@@ -9,7 +9,7 @@ Immutable dataclasses representing core entities in an MTG draft:
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Dict
+from typing import List, Dict
 
 
 @dataclass(frozen=True)
@@ -63,10 +63,10 @@ class Pick:
     """
     user_id: str
     user_name: str
-    pack_num: int
-    pick_num: int
+    pack_num: int | None
+    pick_num: int | None
     booster_ids: List[str]  # Card UUIDs in booster
-    picked_id: str          # UUID of picked card
+    picked_id: str | None  # UUID of picked card (None if pick data is invalid)
 
     @property
     def booster_size(self) -> int:
@@ -128,7 +128,7 @@ class Player:
     """
     user_id: str
     user_name: str
-    seat_num: Optional[int] = None
+    seat_num: int | None = None
 
     @property
     def has_seat(self) -> bool:
@@ -179,11 +179,11 @@ class PackTrace:
         return [p.user_name for p in self.picks]
 
     @property
-    def pick_numbers(self) -> List[int]:
+    def pick_numbers(self) -> List[int | None]:
         """Pick numbers in chronological order."""
         return [p.pick_num for p in self.picks]
 
     @property
-    def picked_ids(self) -> List[str]:
+    def picked_ids(self) -> List[str | None]:
         """Card UUIDs that were picked in order."""
         return [p.picked_id for p in self.picks]

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -148,7 +148,7 @@ class DraftSession(Base):
             await session.commit()
     
     @classmethod
-    async def get_active_sessions(cls, guild_id: str = None):
+    async def get_active_sessions(cls, guild_id: str | None = None):
         """Get all active draft sessions, optionally filtered by guild ID"""
         async with db_session() as session:
             query = select(cls).where(cls.session_stage != "COMPLETED")
@@ -167,7 +167,7 @@ class DraftSession(Base):
             result = await session.execute(query)
             return result.scalar_one_or_none()
 
-    def get_draft_link_for_user(self, user_name: str) -> str:
+    def get_draft_link_for_user(self, user_name: str) -> str | None:
         """
         Get a personalized draft link for a specific user.
         

--- a/models/session_details.py
+++ b/models/session_details.py
@@ -3,14 +3,15 @@ import random
 import discord
 from loguru import logger
 from config import get_draftmancer_session_url
+from helpers.utils import not_none
 
 class SessionDetails:
     def __init__(self, interaction: discord.Interaction, draft_start_time=None):
         self.draft_start_time = draft_start_time or int(datetime.now().timestamp())
-        self.session_id = f"{interaction.user.id}-{self.draft_start_time}"
+        self.session_id = f"{not_none(interaction.user).id}-{self.draft_start_time}"
         self.draft_id = ''.join(random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789') for _ in range(8))
         self.draft_link = get_draftmancer_session_url(self.draft_id)
-        self.guild_id = str(interaction.guild_id)
+        self.guild_id = str(interaction.guild_id) if interaction.guild_id is not None else None
         self.cube_choice = None
         self.team_a_name = None
         self.team_b_name = None

--- a/notification_service.py
+++ b/notification_service.py
@@ -8,13 +8,14 @@ from loguru import logger
 from helpers.display_names import get_member_name_plain
 from preference_service import get_players_dm_notification_preferences
 from services.debt_service import get_balance_with
+from helpers.utils import not_none
 
 # Rate limiting constants to avoid Discord API throttling
 DM_BATCH_SIZE = 8  # Number of DMs to send per batch (matches typical draft size)
 DM_BATCH_DELAY = 1.0  # Seconds to wait between batches
 
 
-async def send_dm(bot_or_client, user_id: str, message: str, view=None, label: str = None) -> bool:
+async def send_dm(bot_or_client, user_id: str, message: str, view=None, label: str | None = None) -> bool:
     """
     Send a DM to a single user with standard error handling.
 
@@ -27,7 +28,7 @@ async def send_dm(bot_or_client, user_id: str, message: str, view=None, label: s
     who = f"{label} ({user_id})" if label else f"user {user_id}"
     logger.debug(f"Attempting DM to {who}: {message}")
     try:
-        user = bot_or_client.get_user(int(user_id)) or await bot_or_client.fetch_user(int(user_id))
+        user = not_none(bot_or_client.get_user(int(user_id)) or await bot_or_client.fetch_user(int(user_id)))
         await user.send(message, view=view)
         logger.info(f"Successfully sent DM to {who}")
         return True

--- a/player_stats.py
+++ b/player_stats.py
@@ -8,6 +8,10 @@ from models.perfect_streak_history import PerfectStreakHistory
 from loguru import logger
 from stats_core import get_timeframe_start_date, calculate_win_percentage, calculate_team_draft_win_percentage
 
+# Win/loss/percentage counters accumulated per timeframe. Values start as int
+# counts and gain float win-percentage entries as stats are computed.
+StatsDict = dict[str, int | float]
+
 async def get_player_statistics(user_id, time_frame=None, user_display_name=None, guild_id=None):
     """Get player statistics for a specific user and time frame, filtered by guild_id if provided."""
     try:
@@ -639,19 +643,19 @@ async def get_head_to_head_stats(user1_id, user2_id, user1_display_name=None, us
         month_ago = now - timedelta(days=30)
         
         # Default values
-        weekly_stats = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
-        monthly_stats = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
-        lifetime_stats = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
-        
+        weekly_stats: StatsDict = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
+        monthly_stats: StatsDict = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
+        lifetime_stats: StatsDict = {"matches_played": 0, "user1_wins": 0, "user2_wins": 0}
+
         # Stats for when users are on opposing teams
-        opposing_weekly = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
-        opposing_monthly = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
-        opposing_lifetime = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
-        
+        opposing_weekly: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+        opposing_monthly: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+        opposing_lifetime: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+
         # Stats for when users are on the same team
-        teammate_weekly = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
-        teammate_monthly = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
-        teammate_lifetime = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+        teammate_weekly: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+        teammate_monthly: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
+        teammate_lifetime: StatsDict = {"wins": 0, "losses": 0, "draws": 0, "win_percentage": 0}
         
         # Get display names if not provided
         if not user1_display_name or not user2_display_name:
@@ -1013,7 +1017,10 @@ async def create_head_to_head_embed(user1, user2, h2h_stats):
     
     return embed
 
-async def find_discord_id_by_display_name_fuzzy(display_name, guild_id=None):
+async def find_discord_id_by_display_name_fuzzy(
+    display_name: str,
+    guild_id: str | None = None,
+) -> tuple[str | list[tuple[str, str]] | None, str | None, bool]:
     """
     Find Discord user IDs by partial display name matching.
     

--- a/preference_service.py
+++ b/preference_service.py
@@ -236,7 +236,7 @@ async def update_player_dm_notification_preference(player_id, guild_id, enabled)
 
     return await execute_db_operation(_update, default_value=False, commit=True, error_message="Error updating DM notification preference")
 
-async def get_players_dm_notification_preferences(player_ids, guild_id):
+async def get_players_dm_notification_preferences(player_ids: list[str], guild_id: str) -> dict[str, bool]:
     """
     Get DM notification preferences for multiple players at once.
 
@@ -277,4 +277,7 @@ async def get_players_dm_notification_preferences(player_ids, guild_id):
         logger.info(f"Retrieved DM preferences for {len(player_ids)} players: {sum(preferences.values())} enabled")
         return preferences
 
-    return await execute_db_operation(_batch_query, default_value=default_preferences, error_message="Error getting DM notification preferences")
+    preferences = await execute_db_operation(_batch_query, default_value=default_preferences, error_message="Error getting DM notification preferences")
+    # execute_db_operation falls back to default_value on error, so this is always
+    # a dict at runtime; guard anyway to keep the return type non-optional.
+    return preferences if preferences is not None else default_preferences

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,21 @@
+preset = "default"
+
+project-includes = [
+    "**/*.py",
+]
+
+project-excludes = [
+    "alembic/versions/**",
+]
+
+# SQLAlchemy 1.x-style Column() declarations type column attributes as Column[T]
+# rather than T, causing false positives when accessing them on model instances.
+replace-imports-with-any = ["sqlalchemy"]
+
+# Resolve first-party imports from the project root.
+search-path = ["."]
+
+# Use the Python on PATH — run via `pipenv run pyrefly check` so this resolves
+# to the virtualenv Python and picks up all installed packages.
+python-interpreter-path = ".venv/bin/python3"
+

--- a/quiz_views_module/quiz_views.py
+++ b/quiz_views_module/quiz_views.py
@@ -1,5 +1,6 @@
 import discord
 import random
+from typing import cast
 from datetime import datetime
 from loguru import logger
 from sqlalchemy import select, update, and_
@@ -8,6 +9,7 @@ from models import QuizSession, QuizSubmission, QuizStats, DraftSession
 from services.draft_analysis import DraftAnalysis
 from models.draft_domain import PackTrace
 from helpers.display_names import get_display_name
+from helpers.utils import not_none
 
 
 # Quiz scoring constants
@@ -95,7 +97,7 @@ def _get_congratulatory_message(total_points: int, correct_count: int) -> str:
     return random.choice(messages)
 
 
-def _detect_bonus_type(correct_count: int, guesses: list, correct_answers: list) -> str:
+def _detect_bonus_type(correct_count: int, guesses: list, correct_answers: list) -> str | None:
     """
     Detect which bonus type was earned.
 
@@ -108,7 +110,7 @@ def _detect_bonus_type(correct_count: int, guesses: list, correct_answers: list)
     return None
 
 
-def _calculate_bonus_points(bonus_type: str) -> int:
+def _calculate_bonus_points(bonus_type: str | None) -> int:
     """Calculate bonus points for a given bonus type."""
     if bonus_type == "perfect":
         return PERFECT_BONUS
@@ -117,7 +119,7 @@ def _calculate_bonus_points(bonus_type: str) -> int:
     return 0
 
 
-def _format_quiz_title(total_points: int, display_id: int = None, is_existing: bool = False) -> str:
+def _format_quiz_title(total_points: int, display_id: int | None = None, is_existing: bool = False) -> str:
     """Format quiz result title with optional display ID."""
     prefix = "Your " if is_existing else ""
     quiz_num = f"#{display_id}" if display_id else ""
@@ -125,13 +127,13 @@ def _format_quiz_title(total_points: int, display_id: int = None, is_existing: b
     return f"{prefix}{quiz_ref}Results: {total_points} Points!"
 
 
-def _format_share_text(emoji_line: str, total_points: int, display_id: int = None) -> str:
+def _format_share_text(emoji_line: str, total_points: int, display_id: int | None = None) -> str:
     """Format shareable quiz result text."""
     quiz_num = f" #{display_id}" if display_id else ""
     return f"🎯 Draft Pick Quiz{quiz_num}\n{emoji_line} {total_points} pts"
 
 
-async def _format_quiz_reference(quiz_id: str = None, display_id: int = None) -> str:
+async def _format_quiz_reference(quiz_id: str | None = None, display_id: int | None = None) -> str:
     """
     Get formatted quiz reference with optional message link.
 
@@ -161,18 +163,18 @@ async def _format_quiz_reference(quiz_id: str = None, display_id: int = None) ->
 
 async def _display_results(
     interaction: discord.Interaction,
-    analysis: DraftAnalysis,
-    pack_trace: PackTrace,
+    analysis: DraftAnalysis | None,
+    pack_trace: PackTrace | None,
     guesses: list,
     correct_answers: list,
     pick_results: list,
     pick_points: list,
     total_points: int,
     correct_count: int,
-    stats: QuizStats = None,
+    stats: QuizStats | None = None,
     is_existing_submission: bool = False,
-    display_id: int = None,
-    quiz_id: str = None
+    display_id: int | None = None,
+    quiz_id: str | None = None
 ) -> None:
     """
     Unified function to display quiz results.
@@ -209,9 +211,9 @@ async def _display_results(
     for i, (guess_id, correct_id, is_correct, points) in enumerate(
         zip(guesses, correct_answers, pick_results, pick_points)
     ):
-        pick = pack_trace.picks[i]
-        guess_name = analysis.get_card(guess_id).name
-        correct_name = analysis.get_card(correct_id).name
+        pick = not_none(pack_trace).picks[i]
+        guess_name = not_none(analysis).get_card(guess_id).name
+        correct_name = not_none(analysis).get_card(correct_id).name
 
         if is_correct:
             icon = EMOJI_CORRECT
@@ -256,7 +258,7 @@ async def _display_results(
 
     # Add share button view
     share_view = ShareResultView(
-        user=interaction.user,
+        user=cast(discord.User, not_none(interaction.user)),
         emoji_line=emoji_line,
         total_points=total_points,
         correct_count=correct_count,
@@ -271,7 +273,7 @@ async def _display_results(
 class ShareResultView(discord.ui.View):
     """View with a button to share quiz results publicly."""
 
-    def __init__(self, user: discord.User, emoji_line: str, total_points: int, correct_count: int, display_id: int = None, quiz_id: str = None, bonus_type: str = None):
+    def __init__(self, user: discord.User, emoji_line: str, total_points: int, correct_count: int, display_id: int | None = None, quiz_id: str | None = None, bonus_type: str | None = None):
         super().__init__(timeout=300)  # 5 minute timeout
         self.user = user
         self.emoji_line = emoji_line
@@ -289,7 +291,7 @@ class ShareResultView(discord.ui.View):
     async def share_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Post results publicly to the channel."""
         # Ensure only the quiz taker can share their own results
-        if interaction.user.id != self.user.id:
+        if not_none(interaction.user).id != self.user.id:
             await interaction.response.send_message(
                 "You can only share your own results!",
                 ephemeral=True
@@ -361,7 +363,7 @@ class QuizCardSelect(discord.ui.Select):
         # Store the selected value in the parent view
         if self.values:
             self.parent_view.selections[self.pick_number] = self.values[0]
-            logger.debug(f"User {interaction.user.id} selected card for pick {self.pick_number + 1}: {self.values[0]}")
+            logger.debug(f"User {not_none(interaction.user).id} selected card for pick {self.pick_number + 1}: {self.values[0]}")
 
         await interaction.response.defer()
 
@@ -373,7 +375,7 @@ class QuizPublicView(discord.ui.View):
     Compatible with sticky message system.
     """
 
-    def __init__(self, quiz_id: str, analysis: DraftAnalysis = None, pack_trace: PackTrace = None):
+    def __init__(self, quiz_id: str, analysis: DraftAnalysis | None = None, pack_trace: PackTrace | None = None):
         super().__init__(timeout=None)  # Persistent across restarts
         self.quiz_id = quiz_id
         self.analysis = analysis
@@ -431,7 +433,7 @@ class QuizPublicView(discord.ui.View):
         Recreate QuizPublicView from stored metadata (sticky message system).
         Reloads quiz data from database and regenerates analysis/pack_trace.
         """
-        quiz_id = metadata.get("quiz_id")
+        quiz_id = str(metadata.get("quiz_id", ""))
         view = cls(quiz_id=quiz_id)
         await view._load_quiz_data()  # Load data (may fail silently)
         return view
@@ -471,7 +473,7 @@ class QuizPublicView(discord.ui.View):
             await interaction.followup.send("Quiz not found!", ephemeral=True)
             return
 
-        stats = await self._load_player_stats(str(interaction.user.id), quiz_session.guild_id)
+        stats = await self._load_player_stats(str(not_none(interaction.user).id), quiz_session.guild_id)
 
         # Use helper properties to get arrays from submission
         await _display_results(
@@ -497,7 +499,7 @@ class QuizPublicView(discord.ui.View):
     )
     async def make_guesses_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """User clicks to participate - show ephemeral guess view"""
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
 
         # Lazy load quiz data if not available (happens after sticky message repost)
         if not await self._load_quiz_data():
@@ -528,7 +530,7 @@ class QuizPublicView(discord.ui.View):
             quiz_id=self.quiz_id,
             analysis=self.analysis,
             pack_trace=self.pack_trace,
-            user=interaction.user
+            user=cast(discord.User, not_none(interaction.user))
         )
 
         await interaction.response.send_message(
@@ -544,7 +546,7 @@ class QuizGuessView(discord.ui.View):
     Contains 4 dropdowns (one per pick) and a Submit button.
     """
 
-    def __init__(self, quiz_id: str, analysis: DraftAnalysis, pack_trace: PackTrace, user: discord.User):
+    def __init__(self, quiz_id: str, analysis: DraftAnalysis | None, pack_trace: PackTrace | None, user: discord.User):
         super().__init__(timeout=300)  # 5 minute timeout
         self.quiz_id = quiz_id
         self.analysis = analysis
@@ -554,15 +556,15 @@ class QuizGuessView(discord.ui.View):
         logger.debug(f"Created new QuizGuessView for user {user.id} (quiz {quiz_id})")
 
         # Get card options (all 15 cards from first pick)
-        first_pick = pack_trace.picks[0]
+        first_pick = not_none(pack_trace).picks[0]
         card_options = sorted([
-            (cid, analysis.get_card(cid).name)
+            (cid, not_none(analysis).get_card(cid).name)
             for cid in first_pick.booster_ids
         ], key=lambda x: x[1])  # Sort by name
 
         # Create dropdowns, one for each pick
         for i in range(NUM_PICKS):
-            pick = pack_trace.picks[i]
+            pick = not_none(pack_trace).picks[i]
             select = QuizCardSelect(
                 pick_number=i,
                 pick_user_name=pick.user_name,
@@ -638,7 +640,7 @@ class QuizGuessView(discord.ui.View):
 
         # Check if view has any selections at all (detects stale/restarted views)
         if not self.selections:
-            logger.warning(f"User {interaction.user.id} submitted with no selections stored (possible bot restart or timeout)")
+            logger.warning(f"User {not_none(interaction.user).id} submitted with no selections stored (possible bot restart or timeout)")
             await interaction.followup.send(
                 "❌ Your quiz session has expired or was lost (possibly due to bot restart).\n\n"
                 "Please click **Make Your Guesses** again to start a fresh quiz!",
@@ -650,7 +652,7 @@ class QuizGuessView(discord.ui.View):
         guesses = []
         for i in range(NUM_PICKS):
             if i not in self.selections:
-                logger.warning(f"User {interaction.user.id} missing selection for pick {i+1} (has {len(self.selections)} selections)")
+                logger.warning(f"User {not_none(interaction.user).id} missing selection for pick {i+1} (has {len(self.selections)} selections)")
                 await interaction.followup.send(
                     f"Please select a card for Pick {i+1}!",
                     ephemeral=True
@@ -658,7 +660,7 @@ class QuizGuessView(discord.ui.View):
                 return
             guesses.append(self.selections[i])
 
-        logger.info(f"User {interaction.user.id} submitting guesses: {guesses}")
+        logger.info(f"User {not_none(interaction.user).id} submitting guesses: {guesses}")
 
         # Load correct answers from database
         async with db_session() as session:

--- a/ready_check.py
+++ b/ready_check.py
@@ -2,9 +2,10 @@ import asyncio
 
 import discord
 from loguru import logger
-from typing import Dict, Iterable, List, Literal, Optional
+from typing import Dict, Iterable, List, Literal, Optional, cast
 
 from helpers.display_names import get_display_name_by_id
+from helpers.utils import not_none
 from models import SignUpHistory
 from services.state_manager import state_manager
 from services.team_creator import create_and_display_teams
@@ -249,7 +250,7 @@ class ReadyCheckSession:
 
         state_manager.set_creating_teams(session_id, True)
         try:
-            await interaction.channel.send("✅ **All players ready!** Creating teams now...")
+            await not_none(interaction.channel).send("✅ **All players ready!** Creating teams now...")
 
             bot = interaction.client
             if not (draft_session and draft_session.message_id and draft_session.draft_channel_id):
@@ -259,7 +260,7 @@ class ReadyCheckSession:
             if not channel:
                 return
 
-            message = await channel.fetch_message(int(draft_session.message_id))
+            message = await cast(discord.TextChannel, channel).fetch_message(int(draft_session.message_id))
 
             # Deferred to avoid circular import: views -> ready_check -> views
             from views import PersistentView
@@ -289,12 +290,12 @@ class ReadyCheckSession:
             mock_interaction = _ChannelInteraction(interaction, message)
             success = await create_and_display_teams(bot, session_id, mock_interaction, persistent_view)
             if success:
-                await interaction.channel.send("✅ Teams created! Check the draft message above for teams and seating order.")
+                await not_none(interaction.channel).send("✅ Teams created! Check the draft message above for teams and seating order.")
             else:
-                await interaction.channel.send("❌ Error creating teams. You can try using the Create Teams button manually.")
+                await not_none(interaction.channel).send("❌ Error creating teams. You can try using the Create Teams button manually.")
         except Exception as e:
             logger.error(f"Error auto-creating teams after ready check: {e}")
-            await interaction.channel.send(f"❌ Error creating teams: {str(e)}\nYou can try using the Create Teams button manually.")
+            await not_none(interaction.channel).send(f"❌ Error creating teams: {str(e)}\nYou can try using the Create Teams button manually.")
         finally:
             state_manager.set_creating_teams(session_id, False)
 
@@ -319,7 +320,7 @@ class ReadyCheckView(discord.ui.View):
     async def cancel_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         await interaction.response.send_message(
             "Are you sure you want to cancel the ready check?",
-            view=ReadyCheckCancelConfirmView(self.draft_session_id, interaction.user.display_name),
+            view=ReadyCheckCancelConfirmView(self.draft_session_id, not_none(interaction.user).display_name),
             ephemeral=True,
         )
 
@@ -328,13 +329,13 @@ class ReadyCheckView(discord.ui.View):
         if not rc:
             logger.warning(
                 f"Ready click against missing session {self.draft_session_id} "
-                f"by user {interaction.user.id}; live checks: "
+                f"by user {not_none(interaction.user).id}; live checks: "
                 f"{list(state_manager.ready_checks.keys())}"
             )
             await interaction.response.send_message("Session data is missing.", ephemeral=True)
             return
 
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if not rc.has_player(user_id):
             logger.warning(
                 f"Unauthorized ready click on {self.draft_session_id} by user {user_id} (not a participant)"
@@ -354,7 +355,7 @@ class ReadyCheckView(discord.ui.View):
                 user_id=user_id,
                 display_name=(draft_session.sign_ups or {}).get(user_id, "Unknown user"),
                 action=status,
-                guild_id=str(interaction.guild.id),
+                guild_id=str(not_none(interaction.guild).id),
             )
         except Exception as e:
             logger.error(f"Failed to record ready event for {self.draft_session_id} user {user_id}: {e}")
@@ -380,7 +381,7 @@ class ReadyCheckCancelConfirmView(discord.ui.View):
     @discord.ui.button(label="Yes, Cancel", style=discord.ButtonStyle.danger)
     async def confirm_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         for child in self.children:
-            child.disabled = True
+            cast(discord.ui.Button, child).disabled = True
         await interaction.response.edit_message(view=self)
         await ReadyCheckSession.cancel(
             self.draft_session_id,
@@ -391,5 +392,5 @@ class ReadyCheckCancelConfirmView(discord.ui.View):
     @discord.ui.button(label="No, Keep Going", style=discord.ButtonStyle.secondary)
     async def deny_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         for child in self.children:
-            child.disabled = True
+            cast(discord.ui.Button, child).disabled = True
         await interaction.response.edit_message(content="Cancelled.", view=self)

--- a/scripts/backfill_perfect_streaks.py
+++ b/scripts/backfill_perfect_streaks.py
@@ -64,6 +64,7 @@ async def backfill_player_perfect_streaks(player_id, guild_id, session):
                     guild_id=guild_id,
                     streak_length=current_streak,
                     started_at=streak_start_date,
+                    # pyrefly: ignore [unbound-name]
                     ended_at=match_date
                 )
                 session.add(streak_record)

--- a/scripts/cleanup_test_channels.py
+++ b/scripts/cleanup_test_channels.py
@@ -271,9 +271,11 @@ async def main():
             )
             
             # Store result and close
+            # pyrefly: ignore [missing-attribute]
             client._cleanup_success = success
         except Exception as e:
             logger.error(f"Error during cleanup: {e}")
+            # pyrefly: ignore [missing-attribute]
             client._cleanup_success = False
         finally:
             await client.close()

--- a/scripts/delete_quiz_submission.py
+++ b/scripts/delete_quiz_submission.py
@@ -125,7 +125,7 @@ async def delete_submission(quiz_display_id: str, player_name: str, dry_run: boo
         # Find the submission
         submission, quiz_session = await find_submission(quiz_display_id, player_name, session)
 
-        if not submission:
+        if not submission or not quiz_session:
             logger.error(f"No submission found for quiz #{quiz_display_id} by player '{player_name}'")
             return False
 

--- a/scripts/reconnect_draft_script.py
+++ b/scripts/reconnect_draft_script.py
@@ -18,6 +18,7 @@ async def main():
     
     @bot.event
     async def on_ready():
+        # pyrefly: ignore [missing-attribute]
         logger.info(f"Temporary client {bot.user.name} is connected")
         
         try:
@@ -26,6 +27,7 @@ async def main():
             
             if tasks:
                 # Wait for all tasks to complete
+                # pyrefly: ignore [no-matching-overload]
                 await asyncio.gather(*tasks, return_exceptions=True)
                 logger.info("All draft session reconnection tasks have completed")
             else:

--- a/scripts/repost_embed.py
+++ b/scripts/repost_embed.py
@@ -268,6 +268,7 @@ async def repost_embed(draft_id, guild_id, cube_name, session_type):
         embed = await generate_magicprotools_embed(player_logs, cube_name, db_draft_id, session_type)
         
         # Send the embed
+        # pyrefly: ignore [missing-attribute]
         await draft_logs_channel.send(embed=embed)
         print(f"Successfully sent embed to #{draft_logs_channel.name} in {guild.name}")
         

--- a/scripts/retrigger_unposted_logs.py
+++ b/scripts/retrigger_unposted_logs.py
@@ -54,6 +54,7 @@ class LogRetrigger:
             
     async def find_draft_logs_channel(self, guild_id):
         """Find the draft-logs channel in the guild"""
+        # pyrefly: ignore [missing-attribute]
         guild = self.client.get_guild(int(guild_id))
         if not guild:
             print(f"Could not find guild {guild_id}")
@@ -137,7 +138,9 @@ class LogRetrigger:
                     session = self.Session()
                     try:
                         db_draft = session.query(DraftSession).filter_by(id=draft_session.id).first()
+                        # pyrefly: ignore [missing-attribute]
                         db_draft.logs_message_id = str(message.id)
+                        # pyrefly: ignore [missing-attribute]
                         db_draft.logs_channel_id = str(logs_channel.id)
                         session.commit()
                         print(f"  ✅ Posted logs and updated database")
@@ -190,6 +193,7 @@ class LogRetrigger:
             print(f"  Failed: {len(unposted_drafts) - success_count}")
             
         finally:
+            # pyrefly: ignore [missing-attribute]
             await self.client.close()
 
 async def main():

--- a/scripts/staketest.py
+++ b/scripts/staketest.py
@@ -264,6 +264,7 @@ def write_to_excel(players, cap_info, results, logs):
     
     # Remove default sheet
     default_sheet = wb.active
+    # pyrefly: ignore [bad-argument-type]
     wb.remove(default_sheet)
     
     # Add input sheet
@@ -402,6 +403,7 @@ def write_to_excel(players, cap_info, results, logs):
     for sheet in wb.worksheets:
         for column in sheet.columns:
             max_length = 0
+            # pyrefly: ignore [missing-attribute]
             column_letter = column[0].column_letter
             for cell in column:
                 try:

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -20,8 +20,8 @@ async def create_ledger_entries(
     amount: int,
     source_type: str,
     source_id: str,
-    notes: str = None,
-    created_by: str = None
+    notes: str | None = None,
+    created_by: str | None = None
 ) -> tuple[DebtLedger, DebtLedger]:
     """
     Create a pair of ledger entries for a debt.
@@ -90,7 +90,7 @@ async def get_balance_with(
     guild_id: str,
     player_id: str,
     counterparty_id: str,
-    exclude_session_id: str = None
+    exclude_session_id: str | None = None
 ) -> int:
     """
     Get the net balance between two players from player's perspective.
@@ -250,7 +250,7 @@ async def create_settlement(
     payee_id: str,
     amount: int,
     settled_by: str,
-    settlement_id: str = None
+    settlement_id: str | None = None
 ) -> tuple[DebtLedger, DebtLedger]:
     """
     Create settlement entries to record a payment between two players.
@@ -388,6 +388,7 @@ async def create_settlement(
                 retry_delay *= 2  # Exponential backoff
             else:
                 raise
+    raise RuntimeError("All retries exhausted without returning or raising")
 
 
 async def create_debt_entries_from_stakes(
@@ -631,7 +632,7 @@ async def create_debt_transfer(
     debtor_id: str,
     creditor_id: str,
     amount: int,
-    transfer_id: str = None
+    transfer_id: str | None = None
 ) -> tuple:
     """
     Transfer debt: A owes B, B owes C → A owes C.
@@ -801,6 +802,7 @@ async def create_debt_transfer(
                 retry_delay *= 2
             else:
                 raise
+    raise RuntimeError("All retries exhausted without returning or raising")
 
 
 async def get_guild_debt_stats(guild_id: str, timeframe: str = "all_time") -> dict:
@@ -939,9 +941,9 @@ async def get_guild_debt_stats(guild_id: str, timeframe: str = "all_time") -> di
 
 async def get_debt_history(
     guild_id: str,
-    player_id: str = None,
+    player_id: str | None = None,
     limit: int = 25,
-    older_than_days: int = None
+    older_than_days: int | None = None
 ) -> list[DebtLedger]:
     """
     Get history of all debt entries.

--- a/services/draft_analysis.py
+++ b/services/draft_analysis.py
@@ -93,7 +93,7 @@ class DraftAnalysis:
     # === Properties ===
 
     @property
-    def session_id(self) -> str:
+    def session_id(self) -> str | None:
         """Draftmancer session ID."""
         return self._indexer.session_id
 

--- a/services/draft_indexer.py
+++ b/services/draft_indexer.py
@@ -39,8 +39,9 @@ class DraftIndexer:
             draft_data: Raw draft data from Draftmancer/Spaces
             draft_session: Optional DraftSession for DB metadata and seating
         """
-        self._session_id = draft_data.get('sessionID')
-        self._draft_session = draft_session
+        self._session_id: str | None = draft_data.get('sessionID')
+        self._draft_session: Optional['DraftSession'] = draft_session
+        self._data: Dict = draft_data
 
         # Initialize index storage
         self._players: List[Player] = []
@@ -97,6 +98,15 @@ class DraftIndexer:
             user_picks = []
             for pick_data in user_data.get('picks', []):
                 pick = Pick.from_dict(user_id, player.user_name, pick_data)
+
+                # Skip malformed picks that lack pack/pick numbers - they can't
+                # be indexed and would otherwise create None-keyed entries.
+                if pick.pack_num is None or pick.pick_num is None:
+                    logger.warning(
+                        f"Skipping pick with missing pack/pick number for user "
+                        f"{user_id} (pack={pick.pack_num}, pick={pick.pick_num})"
+                    )
+                    continue
 
                 # Index by (pack, pick, user_id) tuple
                 key = (pick.pack_num, pick.pick_num, user_id)
@@ -201,7 +211,7 @@ class DraftIndexer:
         return getattr(self._draft_session, attr, default) if self._draft_session else default
 
     @property
-    def session_id(self) -> str:
+    def session_id(self) -> str | None:
         """Draftmancer session ID."""
         return self._session_id
 

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -16,6 +16,7 @@ from database.db_session import db_session
 from models.draft_session import DraftSession
 from models.match import MatchResult
 from bot_registry import get_bot
+from helpers.utils import not_none
 from session import AsyncSessionLocal
 from sqlalchemy import select
 from helpers.digital_ocean_helper import DigitalOceanHelper
@@ -144,7 +145,7 @@ class DraftSetupManager:
         self.logger.info(f"Disconnected from the websocket for draft_id: DB{self.draft_id}")
         self._is_connecting = False
 
-    def __init__(self, session_id: str, draft_id: str, cube_id: str, guild_id: str = None,
+    def __init__(self, session_id: str, draft_id: str, cube_id: str, guild_id: str | None = None,
                  packs_per_player: int = DEFAULT_PACKS_PER_PLAYER,
                  cards_per_pack: int = DEFAULT_CARDS_PER_PACK):
         self.session_id = session_id
@@ -273,9 +274,9 @@ class DraftSetupManager:
             self.draft_cancelled = False  # Reset the flag for future drafts
         else:
             logger.info("Draft completed naturally - creating rooms and scheduling log collection")
-            bot = get_bot()
-            guild = bot.get_guild(int(self.guild_id))
-            channel = bot.get_channel(int(self.draft_channel_id))
+            bot = not_none(get_bot())
+            guild = bot.get_guild(int(not_none(self.guild_id)))
+            channel = bot.get_channel(int(not_none(self.draft_channel_id)))
             from views import PersistentView
             if guild:
                 # Attempt to create rooms and pairings
@@ -422,7 +423,7 @@ class DraftSetupManager:
             self.logger.error(f"Error fetching draft session from database: {e}")
             return None
 
-    def _compute_user_status(self, sign_ups: dict = None):
+    def _compute_user_status(self, sign_ups: dict | None = None):
         """
         Compute present, missing, and unexpected users based on session users and sign-ups.
 
@@ -447,7 +448,7 @@ class DraftSetupManager:
             'unexpected': session_usernames - signup_usernames
         }
 
-    async def _update_or_send_message(self, channel, message_id: str, content=None, embed=None, view=None):
+    async def _update_or_send_message(self, channel, message_id: str | None, content=None, embed=None, view=None):
         """
         Try to update an existing message, fallback to sending a new one.
 
@@ -916,8 +917,8 @@ class DraftSetupManager:
         """Find draft-logs channel and send the embed if found."""
         try:
             # Find the guild
-            bot = get_bot()
-            guild = bot.get_guild(int(self.guild_id))
+            bot = not_none(get_bot())
+            guild = bot.get_guild(int(not_none(self.guild_id)))
             if not guild:
                 self.logger.warning(f"Could not find guild with ID {self.guild_id}")
                 return
@@ -1356,8 +1357,10 @@ class DraftSetupManager:
             # Instead of trying to get the current order (which times out),
             # always reset the seating order to ensure it's correct
             self.logger.info("Resetting seating order to ensure correctness")
-            success, remaining_missing = await self.set_seating_order(self.desired_seating_order)
-            
+            # @exponential_backoff returns False if all retries are exhausted
+            result = await self.set_seating_order(self.desired_seating_order)
+            success, remaining_missing = result if result else (False, [])
+
             if success:
                 self.logger.info("Successfully reset seating order")
                 return True, "Seating order verified and reset"
@@ -1604,7 +1607,7 @@ class DraftSetupManager:
                     
                     # Notify about the error
                     if hasattr(self, 'bot') and self.bot:
-                        channel = self.bot.get_channel(int(self.draft_channel_id))
+                        channel = self.bot.get_channel(int(not_none(self.draft_channel_id)))
                         if channel:
                             await channel.send(f"Error starting draft: {response['error']}")
                 else:
@@ -1698,7 +1701,9 @@ class DraftSetupManager:
             self.seating_attempts += 1
             self.logger.info(f"Attempt {self.seating_attempts}: Setting seating order with {self.users_count} users")
 
-            success, missing_users = await self.set_seating_order(desired_seating_order)
+            # @exponential_backoff returns False if all retries are exhausted
+            result = await self.set_seating_order(desired_seating_order)
+            success, missing_users = result if result else (False, [])
 
             if success:
                 self.logger.success(f"Successfully set seating order!")
@@ -1751,7 +1756,7 @@ class DraftSetupManager:
                     await self.notify_seating_failure(missing_users)
 
     @exponential_backoff(max_retries=10, base_delay=1)
-    async def set_seating_order(self, desired_username_order):
+    async def set_seating_order(self, desired_username_order) -> tuple[bool, list[str]]:
         """
         Sets the seating order for the draft based on usernames.
         Bot is a spectator and not included in seating order.
@@ -2078,8 +2083,8 @@ class DraftSetupManager:
         self.logger.warning("Bot lost ownership past point of no return, advancing to pairings")
         await self._notify_bot_no_longer_managing()
 
-        bot = get_bot()
-        guild = bot.get_guild(int(self.guild_id))
+        bot = not_none(get_bot())
+        guild = bot.get_guild(int(not_none(self.guild_id)))
         if not channel:
             channel = await self._get_draft_channel()
 

--- a/services/draft_socket_client.py
+++ b/services/draft_socket_client.py
@@ -17,7 +17,7 @@ class DraftSocketClient:
     def connected(self):
         return self.sio.connected
 
-    async def connect_with_retry(self, url: str, max_retries: int = 5, base_delay: int = 2):
+    async def connect_with_retry(self, url: str, max_retries: int = 5, base_delay: float = 2):
         """
         Attempts to connect to the given URL with exponential backoff.
         """

--- a/services/leaderboard_service.py
+++ b/services/leaderboard_service.py
@@ -207,12 +207,12 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
                             "completed_matches": 0,  # Only count matches with a result
                             "matches_won": 0,
                             "matches_lost": 0,
-                            "match_win_percentage": 0,
+                            "match_win_percentage": 0.0,
                             "team_drafts_played": 0,
                             "team_drafts_won": 0,
                             "team_drafts_tied": 0,
                             "team_drafts_lost": 0,
-                            "team_draft_win_percentage": 0,
+                            "team_draft_win_percentage": 0.0,
                             "teammate_win_rates": {}
                         }
                     else:
@@ -539,7 +539,7 @@ async def get_win_streak_leaderboard_data(guild_id, timeframe, limit, session):
             player_best_streaks[player_id] = entry
         else:
             # Keep the longer streak
-            if entry["longest_win_streak"] > player_best_streaks[player_id]["longest_win_streak"]:
+            if (entry["longest_win_streak"] or 0) > (player_best_streaks[player_id]["longest_win_streak"] or 0):
                 player_best_streaks[player_id] = entry
 
     # === Part 5: Sort by streak length, then win % ===
@@ -671,7 +671,7 @@ async def get_perfect_streak_leaderboard_data(guild_id, timeframe, limit, sessio
             player_best_streaks[player_id] = entry
         else:
             # Keep the longer streak
-            if entry["perfect_streak"] > player_best_streaks[player_id]["perfect_streak"]:
+            if (entry["perfect_streak"] or 0) > (player_best_streaks[player_id]["perfect_streak"] or 0):
                 player_best_streaks[player_id] = entry
 
     # === Part 5: Sort by streak length, then win % ===

--- a/services/ring_bearer_service.py
+++ b/services/ring_bearer_service.py
@@ -93,7 +93,7 @@ async def update_ring_bearer_for_guild(bot, guild_id: str, session_id: Optional[
                 if streak_extensions and session_id:
                     # Normal draft - check if any #1 leader extended in this draft
                     for leader_data in tied_leaders:
-                        leader_id = leader_data["player_id"]
+                        leader_id = str(leader_data["player_id"])
 
                         # Extract streak length for logging
                         if category == "longest_win_streak":
@@ -128,7 +128,7 @@ async def update_ring_bearer_for_guild(bot, guild_id: str, session_id: Optional[
                 else:
                     # Manual refresh - no streak info, transfer to first #1 leader
                     leader_data = tied_leaders[0]
-                    leader_id = leader_data["player_id"]
+                    leader_id = str(leader_data["player_id"])
 
                     if leader_id != current_bearer_id:
                         logger.info(f"[RING BEARER] TRANSFER (manual refresh): {leader_id} gets ring via {category}")
@@ -470,14 +470,14 @@ async def get_leaderboard_leaders_tied_for_first(guild_id: str, category: str, t
             return []
 
         # Find the highest streak value (the #1 position)
-        max_streak = players[0].get(streak_field, 0)
+        max_streak = players[0].get(streak_field, 0) or 0
 
         # Find ALL players who:
         # 1. Have the exact same streak value (tied for #1)
         # 2. Have ACTIVE streaks (not completed)
         tied_leaders = []
         for player in players:
-            player_streak = player.get(streak_field, 0)
+            player_streak = player.get(streak_field, 0) or 0
             is_active = player.get("is_active", False)
 
             # If streak is lower than max, we're past the tied leaders

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -97,6 +97,8 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                     session = updated_session
 
                 # Generate seating order based on session type
+                team_a_display_names: list[str] = []
+                team_b_display_names: list[str] = []
                 if session.session_type != "swiss":
                     sign_ups_list = list(session.sign_ups.keys())
                     if session.session_type == "premade":
@@ -313,7 +315,7 @@ async def _handle_staked_draft_completion(interaction, db_session, session, embe
                 label=item.label,
                 style=item.style,
                 custom_id=item.custom_id,
-                custom_callback=item.custom_callback
+                custom_callback=item.custom_callback  # pyrefly: ignore
             )
 
             if item.custom_id == f"create_rooms_pairings_{draft_session_id}":

--- a/sessions/base_session.py
+++ b/sessions/base_session.py
@@ -132,11 +132,11 @@ class BaseSession:
         """Add signup-related fields to the embed. Override in subclasses for custom behavior."""
         embed.add_field(name="Sign-Ups:", value="No players yet.", inline=False)
 
-    def get_session_type(self):
+    def get_session_type(self) -> str:
         """Implemented in subclasses."""
         raise NotImplementedError
 
-    def get_premade_match_id(self):
+    def get_premade_match_id(self) -> int | None:
         """Return None by default, overridden in subclasses if applicable."""
         return None
 

--- a/sessions/random_session.py
+++ b/sessions/random_session.py
@@ -16,5 +16,5 @@ class RandomSession(BaseSession):
         embed = Embed(title=title, description=description, color=Color.dark_magenta())
         return embed
 
-    def get_session_type(self):
+    def get_session_type(self) -> str:
         return "random"

--- a/stats_display.py
+++ b/stats_display.py
@@ -13,7 +13,7 @@ async def get_stats_embed_for_player(
     bot,
     player_id: str,
     guild_id: str,
-    display_name: str = None
+    display_name: str | None = None
 ) -> discord.Embed:
     """
     Get stats embed for any player by their ID.

--- a/teamfinder.py
+++ b/teamfinder.py
@@ -2,6 +2,7 @@ import discord
 from discord.ui import Button, View
 from sqlalchemy import select
 from session import AsyncSessionLocal, TeamFinder
+from helpers.utils import not_none
 
 TIMEZONES_AMERICAS = [
     ("Pacific Time (UTC-08:00)", "America/Los_Angeles"),
@@ -40,9 +41,10 @@ class TimezoneButton(Button):
         self.message_id = message_id
 
     async def callback(self, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user = not_none(interaction.user)
+        user_id = str(user.id)
         timezone = self.value
-        display_name = interaction.user.display_name
+        display_name = user.display_name
 
         async with AsyncSessionLocal() as session:
             stmt = select(TeamFinder).where(TeamFinder.user_id == user_id)

--- a/tests/test_abandon_draft.py
+++ b/tests/test_abandon_draft.py
@@ -5,8 +5,7 @@ from datetime import datetime
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from database.models_base import Base
 from models.draft_session import DraftSession
@@ -21,7 +20,7 @@ async def test_db():
     engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    factory = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
     yield factory
     await engine.dispose()
     os.unlink(temp_db.name)

--- a/tests/test_advanced_options_modal.py
+++ b/tests/test_advanced_options_modal.py
@@ -11,6 +11,7 @@ def test_pack_format_display_none_for_default():
 
 def test_pack_format_display_string_for_non_default():
     text = pack_format_display(4, 10)
+    assert text is not None
     assert "4" in text and "10" in text
 
 

--- a/tests/test_backfill_win_streaks.py
+++ b/tests/test_backfill_win_streaks.py
@@ -12,8 +12,7 @@ import os
 from datetime import datetime, timedelta
 
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy import select
 
 from database.models_base import Base
@@ -42,10 +41,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory

--- a/tests/test_draft_analysis_integration.py
+++ b/tests/test_draft_analysis_integration.py
@@ -48,9 +48,9 @@ async def test_draft_analysis_with_real_draft():
         if trace:
             print(f"  ✅ Found 4-pick sequence!")
             for i, pick in enumerate(trace.picks):
-                card = analysis.get_card(pick.picked_id)
+                card_name = analysis.get_card(pick.picked_id).name if pick.picked_id else "unknown"
                 print(f"     Pick {i+1}: {pick.user_name} (pickNum {pick.pick_num}, "
-                      f"{len(pick.booster_ids)} cards) → {card.name}")
+                      f"{len(pick.booster_ids)} cards) → {card_name}")
         else:
             print(f"  ❌ No 4-pick sequence found")
 
@@ -61,9 +61,9 @@ async def test_draft_analysis_with_real_draft():
             # Show first few picks to understand structure
             print(f"  First 5 picks:")
             for i, pick in enumerate(pack_picks[:5]):
-                card = analysis.get_card(pick.picked_id)
+                card_name = analysis.get_card(pick.picked_id).name if pick.picked_id else "unknown"
                 print(f"     {i+1}. {pick.user_name} pick# {pick.pick_num}: "
-                      f"{len(pick.booster_ids)} cards → {card.name}")
+                      f"{len(pick.booster_ids)} cards → {card_name}")
 
     print("")
     print(f"{'='*70}\n")

--- a/tests/test_draft_creation.py
+++ b/tests/test_draft_creation.py
@@ -35,8 +35,7 @@ from sessions.premade_session import PremadeSession
 @pytest_asyncio.fixture
 async def test_db():
     """Create a temporary test database and return a test session factory."""
-    from sqlalchemy.orm import sessionmaker
-    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.ext.asyncio import async_sessionmaker
 
     temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
     temp_db.close()
@@ -45,10 +44,9 @@ async def test_db():
         await conn.run_sync(Base.metadata.create_all)
 
     # Create test session factory for dependency injection
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory

--- a/tests/test_draft_settings_emit.py
+++ b/tests/test_draft_settings_emit.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 from services.draft_setup_manager import DraftSetupManager
@@ -28,7 +29,7 @@ async def test_update_draft_settings_emits_pack_settings():
     assert result is True
     emitted = {
         call.args[0]: (call.args[1] if len(call.args) > 1 else None)
-        for call in mgr.socket_client.emit.call_args_list
+        for call in cast(AsyncMock, mgr.socket_client.emit).call_args_list
     }
     assert emitted.get("boostersPerPlayer") == 4
     assert emitted.get("cardsPerBooster") == 10
@@ -45,7 +46,7 @@ async def test_update_pack_settings_emits_and_updates_attrs():
     assert mgr.cards_per_pack == 12
     emitted = {
         call.args[0]: (call.args[1] if len(call.args) > 1 else None)
-        for call in mgr.socket_client.emit.call_args_list
+        for call in cast(AsyncMock, mgr.socket_client.emit).call_args_list
     }
     assert emitted.get("boostersPerPlayer") == 6
     assert emitted.get("cardsPerBooster") == 12

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -16,8 +16,7 @@ import os
 from datetime import datetime, timedelta
 
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy import select
 
 from database.models_base import Base
@@ -40,10 +39,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory

--- a/tests/test_ready_check.py
+++ b/tests/test_ready_check.py
@@ -464,7 +464,9 @@ class TestHandleStatus:
 
         assert "1" in rc.ready
         sh.record_ready_event.assert_awaited_once()
-        assert sh.record_ready_event.await_args.kwargs["action"] == "ready"
+        await_args = sh.record_ready_event.await_args
+        assert await_args is not None
+        assert await_args.kwargs["action"] == "ready"
         i.response.edit_message.assert_awaited_once()
 
     async def test_missing_session_warns_and_skips(self):
@@ -537,12 +539,12 @@ class TestReadyCheckCancelConfirmView:
 
     async def test_confirm_button_is_danger(self):
         view = ReadyCheckCancelConfirmView("sid", "Alice")
-        confirm = next(c for c in view.children if "Yes" in c.label)
+        confirm = next(c for c in view.children if isinstance(c, discord.ui.Button) and c.label and "Yes" in c.label)
         assert confirm.style == discord.ButtonStyle.danger
 
     async def test_deny_button_is_secondary(self):
         view = ReadyCheckCancelConfirmView("sid", "Alice")
-        deny = next(c for c in view.children if "No" in c.label)
+        deny = next(c for c in view.children if isinstance(c, discord.ui.Button) and c.label and "No" in c.label)
         assert deny.style == discord.ButtonStyle.secondary
 
     async def test_stores_cancelled_by(self):

--- a/tests/test_ready_check_views.py
+++ b/tests/test_ready_check_views.py
@@ -64,18 +64,21 @@ def _mock_async_session():
     return MagicMock(return_value=outer), session
 
 
-def _make_create_task_stub():
+class _CreateTaskStub:
     """Stand-in for asyncio.create_task that records and safely closes coroutines."""
-    calls = []
 
-    def stub(coro):
-        calls.append(coro)
+    def __init__(self):
+        self.calls: list = []
+
+    def __call__(self, coro):
+        self.calls.append(coro)
         if asyncio.iscoroutine(coro):
             coro.close()
         return MagicMock()
 
-    stub.calls = calls
-    return stub
+
+def _make_create_task_stub():
+    return _CreateTaskStub()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ring_bearer.py
+++ b/tests/test_ring_bearer.py
@@ -19,8 +19,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy import select
 
 from database.models_base import Base
@@ -44,10 +43,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
     yield test_session_factory
 

--- a/tests/test_tournament_linked_draft.py
+++ b/tests/test_tournament_linked_draft.py
@@ -5,10 +5,11 @@ import tempfile
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 import pytest_asyncio
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from typing import cast
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from database.models_base import Base
 from models.session_details import SessionDetails
@@ -30,7 +31,7 @@ async def test_db():
     engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    factory = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
     yield factory
     await engine.dispose()
     os.unlink(temp_db.name)
@@ -220,7 +221,7 @@ async def test_play_match_view_has_one_button():
     view = PlayMatchView(5, "Alpha vs Bravo")
     assert view.timeout is None
     assert len(view.children) == 1
-    assert view.children[0].custom_id == "tournament_play:5"
+    assert cast(discord.ui.Button, view.children[0]).custom_id == "tournament_play:5"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tournament_models.py
+++ b/tests/test_tournament_models.py
@@ -6,8 +6,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from database.models_base import Base
 from models.tournament import (
@@ -27,10 +26,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -6,8 +6,7 @@ import tempfile
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from database.models_base import Base
 from models.team import Team
@@ -42,10 +41,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory
@@ -351,6 +349,7 @@ async def test_find_current_match_resolves_by_team_name(test_db):
         await session.commit()
 
         match = await find_current_match(session, tournament.id, "Team2")
+        assert match is not None
         participants = {match.team_a_participant_id, match.team_b_participant_id}
         team2 = (await session.execute(
             select(TournamentParticipant).where(TournamentParticipant.team_name == "Team2")
@@ -376,6 +375,7 @@ async def test_advance_round_gated_until_all_results_in(test_db):
 
         new_round = await advance_round(session, tournament.id, random.Random(7))
         await session.commit()
+        assert new_round is not None
         assert new_round.round_number == 2
         assert tournament.current_round == 2
 
@@ -542,6 +542,7 @@ async def test_finish_tournament_completes_and_returns_champion(test_db):
         await session.commit()
 
         assert tournament.status == "completed"
+        assert champion is not None
         assert champion.id == winner_id
         assert await get_active_tournament(session, "g1") is None
 

--- a/tests/test_tournament_standings_message.py
+++ b/tests/test_tournament_standings_message.py
@@ -8,8 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 import pytest_asyncio
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from database.models_base import Base
 from models.tournament import Tournament, TournamentParticipant
@@ -33,7 +32,7 @@ async def test_db():
     engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    factory = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
     yield factory
     await engine.dispose()
     os.unlink(temp_db.name)
@@ -74,6 +73,7 @@ def test_standings_embed_lists_teams_in_given_order():
         _participant("Bravo", 0, losses=1),
     ]
     embed = create_standings_embed(tournament, participants)
+    assert embed.title is not None
     assert "Spring Cup" in embed.title
     body = "\n".join(f.value for f in embed.fields)
     assert "Alpha" in body and "Bravo" in body

--- a/tests/test_vote_views.py
+++ b/tests/test_vote_views.py
@@ -114,7 +114,8 @@ async def test_timeout_embed(cls, spec):
 @pytest.mark.parametrize("cls", CLASSES)
 async def test_majority_threshold_even(cls):
     view = cls("s1", ["1", "2", "3", "4"])
-    view.votes = {"1": True, "2": True, "3": None, "4": None}
+    # constructor seeds all participants to None (dict[str, bool | None]); flip two to True
+    view.votes.update({"1": True, "2": True})
     passed, yes, total = view.get_vote_result()
     assert (yes, total) == (2, 4)
     assert not passed  # need 3 of 4

--- a/tests/test_win_streak.py
+++ b/tests/test_win_streak.py
@@ -17,8 +17,7 @@ import os
 from datetime import datetime, timedelta
 
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from sqlalchemy import select
 
 from database.models_base import Base
@@ -39,10 +38,9 @@ async def test_db():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    test_session_factory = sessionmaker(
+    test_session_factory = async_sessionmaker(
         engine,
         expire_on_commit=False,
-        class_=AsyncSession
     )
 
     yield test_session_factory

--- a/utils.py
+++ b/utils.py
@@ -811,6 +811,9 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
 
                         # Still update messages to add logs link if it wasn't there before
                         main_embed, bet_embed = await generate_draft_summary_embed(bot, draft_session_id)
+                        if main_embed is None:
+                            logger.error(f"Could not generate draft summary embed for session {draft_session_id}; skipping victory message update")
+                            return
                         three_zero_drafters = await calculate_three_zero_drafters(session, draft_session_id, guild)
                         main_embed.add_field(name="3-0 Drafters", value=three_zero_drafters or "None", inline=False)
                         if draft_session.data_received and hasattr(draft_session, 'logs_channel_id') and draft_session.logs_message_id:
@@ -868,6 +871,9 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
                     draft_session.session_stage = 'completed'
 
                     main_embed, bet_embed = await generate_draft_summary_embed(bot, draft_session_id)
+                    if main_embed is None:
+                        logger.error(f"Could not generate draft summary embed for session {draft_session_id}; skipping victory message posting")
+                        return
                     three_zero_drafters = await calculate_three_zero_drafters(session, draft_session_id, guild)
                     main_embed.add_field(name="3-0 Drafters", value=three_zero_drafters or "None", inline=False)
                     # Add logs link to the embed if available

--- a/views.py
+++ b/views.py
@@ -4,7 +4,7 @@ import random
 import pytz
 from datetime import datetime, timedelta
 from discord import SelectOption
-from discord.ui import Button, View, Select, select
+from discord.ui import Button, View, Select
 from config import is_test_mode, should_reset_on_signup, get_queue_inactivity_minutes
 from notification_service import send_ready_check_dms
 from ready_check import ReadyCheckView, ReadyCheckSession
@@ -14,7 +14,8 @@ from session import StakeInfo, AsyncSessionLocal, get_draft_session, DraftSessio
 from models import SignUpHistory
 from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
-from helpers.utils import get_cube_thumbnail_url
+from helpers.utils import get_cube_thumbnail_url, not_none
+from typing import cast
 from helpers.display_names import get_display_name, get_display_name_by_id
 from utils import (
     calculate_pairings,
@@ -199,7 +200,7 @@ class PersistentView(discord.ui.View):
         draft_session = await get_draft_session(self.draft_session_id)
         # update the button's label and style directly based on the new tracked_draft state
         # Find the specific button to update
-        track_draft_button = next((btn for btn in self.children if btn.custom_id == f"track_draft_{self.draft_session_id}"), None)
+        track_draft_button = next((cast(discord.ui.Button, btn) for btn in self.children if cast(discord.ui.Button, btn).custom_id == f"track_draft_{self.draft_session_id}"), None)
         if track_draft_button:
             track_draft_button.label = "League Draft: ON" if draft_session.tracked_draft else "League Draft: OFF"
             track_draft_button.style = discord.ButtonStyle.green if draft_session.tracked_draft else discord.ButtonStyle.red
@@ -214,10 +215,10 @@ class PersistentView(discord.ui.View):
     async def add_test_users_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         """Add test users to the draft for testing purposes, up to NUM_TEST_USERS_TO_ADD."""
         # Only allow admins to use this feature
-        if not interaction.user.guild_permissions.administrator:
+        if not cast(discord.Member, not_none(interaction.user)).guild_permissions.administrator:
             await interaction.response.send_message("Only server administrators can use this test feature.", ephemeral=True)
             return
-                    
+
         logger.info(f"Adding test users to draft {self.draft_session_id}")
         
         # Fetch the current draft session to ensure it's up to date
@@ -237,7 +238,7 @@ class PersistentView(discord.ui.View):
 
         # Use the bot's user ID for test users so they resolve to a valid Discord member
         # This helps test features like debt settlement that need guild.get_member() to work
-        bot_user_id = str(interaction.client.user.id)
+        bot_user_id = str(not_none(interaction.client.user).id)
 
         # Test names - prefixed with [TEST] and includes markdown characters to test escaping
         test_names = [
@@ -338,7 +339,7 @@ class PersistentView(discord.ui.View):
 
     async def add_test_users_premade_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         """TEST_MODE only: fill both premade teams to 3 players with test users."""
-        if not interaction.user.guild_permissions.administrator:
+        if not cast(discord.Member, not_none(interaction.user)).guild_permissions.administrator:
             await interaction.response.send_message("Only server administrators can use this test feature.", ephemeral=True)
             return
 
@@ -382,7 +383,7 @@ class PersistentView(discord.ui.View):
         )
 
     async def sign_up_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         
         # Get the guild config for the interaction's guild
         from config import get_config
@@ -391,7 +392,7 @@ class PersistentView(discord.ui.View):
         timeout_role_name = roles_config.get("timeout")
         
         # Check if the user has the timeout role
-        if timeout_role_name and discord.utils.get(interaction.user.roles, name=timeout_role_name):
+        if timeout_role_name and discord.utils.get(cast(discord.Member, not_none(interaction.user)).roles, name=timeout_role_name):
             await interaction.response.send_message(
                 "You are ineligible to join a queue due to an infraction (Leaving Draft Early/Unpaid Debts). Message a Mod for more details.",
                 ephemeral=True
@@ -399,7 +400,7 @@ class PersistentView(discord.ui.View):
             return
         
         # Check if user has Draftmancer role
-        has_draftmancer_role = discord.utils.get(interaction.user.roles, name="Draftmancer") is not None
+        has_draftmancer_role = discord.utils.get(cast(discord.Member, not_none(interaction.user)).roles, name="Draftmancer") is not None
         
         if self.session_type == "winston":
             now = datetime.now()
@@ -449,7 +450,7 @@ class PersistentView(discord.ui.View):
                 stake_options_view = StakeOptionsView(
                     draft_session_id=self.draft_session_id,
                     draft_link=draft_session.draft_link,
-                    user_display_name=interaction.user.display_name,
+                    user_display_name=not_none(interaction.user).display_name,
                     min_stake=draft_session.min_stake,
                     has_draftmancer_role=has_draftmancer_role  
                 )
@@ -461,8 +462,8 @@ class PersistentView(discord.ui.View):
                 return
             
             # For non-staked drafts, add them to sign_ups now        
-            sign_ups[user_id] = interaction.user.display_name
-            display_name = str(interaction.user.display_name)
+            sign_ups[user_id] = not_none(interaction.user).display_name
+            display_name = str(not_none(interaction.user).display_name)
             
             # Record the signup event in history
             await SignUpHistory.record_signup_event(
@@ -529,7 +530,7 @@ class PersistentView(discord.ui.View):
                 drafter_role_name = guild_config["roles"]["drafter"]
                 
                 # Find the role in the guild
-                guild = interaction.guild
+                guild = not_none(interaction.guild)
                 drafter_role = discord.utils.get(guild.roles, name=drafter_role_name)
                 
                 if drafter_role:
@@ -537,7 +538,7 @@ class PersistentView(discord.ui.View):
                     channel = await interaction.client.fetch_channel(draft_session_updated.draft_channel_id)
                     if channel:
                         player_count = len(sign_ups)
-                        await channel.send(f"{player_count} Players in queue! {drafter_role.mention}")
+                        await cast(discord.TextChannel, channel).send(f"{player_count} Players in queue! {drafter_role.mention}")
 
             # Update the draft message to reflect the new list of sign-ups
             await update_draft_message(interaction.client, self.draft_session_id)
@@ -548,14 +549,14 @@ class PersistentView(discord.ui.View):
             if self.session_type == "winston":
                 if len(sign_ups) == 2:
                     sign_up_tags = ' '.join([f"<@{user_id}>" for user_id in draft_session_updated.sign_ups.keys()])
-                    guild = self.bot.get_guild(int(interaction.guild_id))
+                    guild = not_none(self.bot.get_guild(not_none(interaction.guild_id)))
                     channel = discord.utils.get(guild.text_channels, name="winston-draft")
-                    await channel.send(f"Winston Draft Ready. Good luck in your match! {sign_up_tags}")
+                    await cast(discord.TextChannel, not_none(channel)).send(f"Winston Draft Ready. Good luck in your match! {sign_up_tags}")
                 else:
-                    guild = interaction.guild
+                    guild = not_none(interaction.guild)
                     message_link = f"https://discord.com/channels/{draft_session_updated.guild_id}/{draft_session_updated.draft_channel_id}/{draft_session_updated.message_id}"
                     channel = discord.utils.get(guild.text_channels, name="cube-draft-open-play")
-                    await channel.send(f"**{get_display_name(interaction.user, guild)}** is looking for an opponent for a **Winston Draft**. [Join Here!]({message_link})")
+                    await cast(discord.TextChannel, not_none(channel)).send(f"**{get_display_name(cast(discord.Member, not_none(interaction.user)), guild)}** is looking for an opponent for a **Winston Draft**. [Join Here!]({message_link})")
                     
     async def cancel_sign_up_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         draft_session = await get_draft_session(self.draft_session_id)
@@ -565,9 +566,9 @@ class PersistentView(discord.ui.View):
         
         sign_ups = draft_session.sign_ups or {}
         draftmancer_role_users = draft_session.draftmancer_role_users or []
-        user_id = str(interaction.user.id)
-        display_name = str(interaction.user.display_name)
-        
+        user_id = str(not_none(interaction.user).id)
+        display_name = not_none(interaction.user).display_name
+
         if user_id not in sign_ups:
             # User is not signed up; inform them
             await interaction.response.send_message("You are not signed up!", ephemeral=True)
@@ -707,7 +708,7 @@ class PersistentView(discord.ui.View):
             # (incl. Custom), Advanced Options, and a submit button.
             cube_selection = CubeUpdateSelectionView(
                 draft_session.session_type,
-                interaction.guild_id,
+                not_none(interaction.guild_id),
                 current_cube=draft_session.cube,
                 on_submit=apply_cube_update,
             )
@@ -760,7 +761,7 @@ class PersistentView(discord.ui.View):
         # Schedule the cooldown entry to be cleared once the window elapses.
         asyncio.create_task(self.remove_cooldown(self.draft_session_id))
 
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         if user_id not in session.sign_ups:
             await interaction.response.send_message("You are not registered in the draft session.", ephemeral=True)
             return
@@ -831,10 +832,10 @@ class PersistentView(discord.ui.View):
         await send_ready_check_dms(
             bot_or_client=interaction.client,
             draft_session=session,
-            guild_id=str(interaction.guild.id),
-            channel_id=str(interaction.channel.id),
-            channel_name=interaction.channel.name,
-            guild_name=interaction.guild.name
+            guild_id=str(not_none(interaction.guild).id),
+            channel_id=str(not_none(interaction.channel).id),
+            channel_name=cast(discord.TextChannel, not_none(interaction.channel)).name,
+            guild_name=not_none(interaction.guild).name
         )
 
         # In test mode all test users are pre-marked ready — skip waiting for button clicks
@@ -888,7 +889,7 @@ class PersistentView(discord.ui.View):
         missing_players = await get_missing_stake_players(session_id)
         if missing_players:
             # Get display names for the missing players
-            guild = interaction.client.get_guild(int(interaction.guild_id))
+            guild = not_none(interaction.client.get_guild(not_none(interaction.guild_id)))
             missing_names = []
             for pid in missing_players:
                 member = guild.get_member(int(pid))
@@ -908,7 +909,7 @@ class PersistentView(discord.ui.View):
     async def randomize_teams_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
         bot = interaction.client
         session_id = self.draft_session_id
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
 
         # Check for race condition - is someone already creating teams?
         if state_manager.is_creating_teams(session_id):
@@ -1073,9 +1074,9 @@ class PersistentView(discord.ui.View):
             await interaction.response.send_message("The draft session could not be found.", ephemeral=True)
             return
 
-        user_id = str(interaction.user.id)
-        custom_id = button.custom_id
-        user_name = get_display_name(interaction.user, interaction.guild)
+        user_id = str(not_none(interaction.user).id)
+        custom_id = not_none(button.custom_id)
+        user_name = get_display_name(cast(discord.Member, not_none(interaction.user)), not_none(interaction.guild))
 
         primary_team = secondary_team = primary_key = secondary_key = None
 
@@ -1088,7 +1089,7 @@ class PersistentView(discord.ui.View):
             primary_key, secondary_key = "team_b", "team_a"
 
         # Safety check if the button custom_id doesn't correctly specify a team
-        if primary_team is None or secondary_team is None:
+        if primary_team is None or secondary_team is None or primary_key is None or secondary_key is None:
             await interaction.response.send_message("An error occurred. Unable to determine the team.", ephemeral=True)
             return
 
@@ -1130,7 +1131,7 @@ class PersistentView(discord.ui.View):
         timeout_role_name = roles_config.get("timeout")
         
         # Check if the user has the timeout role
-        if timeout_role_name and discord.utils.get(interaction.user.roles, name=timeout_role_name):
+        if timeout_role_name and discord.utils.get(cast(discord.Member, not_none(interaction.user)).roles, name=timeout_role_name):
             await interaction.response.send_message(
                 "You are ineligible due to an infraction (Leaving Draft Early/Unpaid Debts). Message a Mod for more details.",
                 ephemeral=True
@@ -1143,7 +1144,7 @@ class PersistentView(discord.ui.View):
             return
 
         # Show confirmation dialog
-        confirm_view = CancelConfirmationView(self.bot, self.draft_session_id, get_display_name(interaction.user, interaction.guild))
+        confirm_view = CancelConfirmationView(self.bot, self.draft_session_id, get_display_name(cast(discord.Member, not_none(interaction.user)), not_none(interaction.guild)))
         await interaction.response.send_message("Are you sure you want to cancel this draft?", view=confirm_view, ephemeral=True)    
     
     async def start_draft_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -1198,7 +1199,7 @@ class PersistentView(discord.ui.View):
         embed = message.embeds[0]  # Assuming there's only one embed attached to the message
 
         # Get team names with crown icons
-        guild = interaction.guild
+        guild = not_none(interaction.guild)
         team_a_names = [get_display_name_by_id(str(user_id), guild, session.sign_ups.get(str(user_id), "Unknown User")) for user_id in (session.team_a or [])]
         team_b_names = [get_display_name_by_id(str(user_id), guild, session.sign_ups.get(str(user_id), "Unknown User")) for user_id in (session.team_b or [])]
 
@@ -1223,14 +1224,14 @@ class PersistentView(discord.ui.View):
             return
 
         # Check if the user initiating the remove action is in the sign_ups
-        if str(interaction.user.id) not in session.sign_ups:
+        if str(not_none(interaction.user).id) not in session.sign_ups:
             await interaction.response.send_message("You are not authorized to remove users.", ephemeral=True)
             return
 
         # If the session exists and has sign-ups, and the user is authorized, proceed
         if session.sign_ups:
             # Get display names with crown icons for the dropdown
-            guild = interaction.guild
+            guild = not_none(interaction.guild)
             options = [discord.SelectOption(label=get_display_name_by_id(user_id, guild, user_name), value=user_id)
                       for user_id, user_name in session.sign_ups.items()]
             view = UserRemovalView(session_id=session.session_id, options=options)
@@ -1562,7 +1563,7 @@ class UserRemovalSelect(Select):
         bot = interaction.client
         session = await get_draft_session(self.session_id)
 
-        user_id_to_remove = self.values[0]  
+        user_id_to_remove = str(self.values[0])
         if user_id_to_remove in session.sign_ups:
             removed_user_name = session.sign_ups.pop(user_id_to_remove)
             
@@ -1586,7 +1587,7 @@ class UserRemovalSelect(Select):
             if session.session_type != "premade":
                 await update_draft_message(bot, session_id=session.session_id)
             else:
-                await PersistentView.update_team_view(interaction)
+                await PersistentView.update_team_view(interaction)  # pyrefly: ignore
 
             await interaction.followup.send(f"Removed {removed_user_name} from the draft.")
             await ReadyCheckSession.sync_removed_player(self.session_id, user_id_to_remove, session, interaction)
@@ -1739,7 +1740,7 @@ class MatchResultSelect(Select):
         # Splitting the selected value to get the result details
         await interaction.response.defer()
         try:
-            player1_wins, player2_wins, winner_indicator = self.values[0].split('-')
+            player1_wins, player2_wins, winner_indicator = str(self.values[0]).split('-')
             player1_wins = int(player1_wins)
             player2_wins = int(player2_wins)
             winner_id = None  # Default to None in case of a draw
@@ -1992,7 +1993,7 @@ class PersonalizedCapStatusView(discord.ui.View):
         user_id = self.user_id
         
         # Only the owner of the view should be able to toggle
-        if str(interaction.user.id) != user_id:
+        if str(not_none(interaction.user).id) != user_id:
             await interaction.response.send_message("This button is not for you.", ephemeral=True)
             return
             
@@ -2304,10 +2305,10 @@ class CancelConfirmationView(discord.ui.View):
     @discord.ui.button(label="Yes, Cancel Draft", style=discord.ButtonStyle.danger)
     async def confirm_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         from services.draft_setup_manager import DraftSetupManager, ACTIVE_MANAGERS
-        
+
         # Disable buttons
         for child in self.children:
-            child.disabled = True
+            cast(discord.ui.Button, child).disabled = True
         await interaction.response.edit_message(view=self)
         
         # Get session to proceed with cancellation
@@ -2368,7 +2369,7 @@ class CancelConfirmationView(discord.ui.View):
     async def cancel_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         # Disable buttons
         for child in self.children:
-            child.disabled = True
+            cast(discord.ui.Button, child).disabled = True
         await interaction.response.edit_message(content="Draft cancellation aborted.", view=self)
 
 
@@ -2394,7 +2395,7 @@ class StakeOptionsSelect(discord.ui.Select):
         super().__init__(placeholder=f"Select your maximum bet... ", min_values=1, max_values=1, options=options)
         
     async def callback(self, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         
         # Load the user's saved preference
@@ -2412,20 +2413,20 @@ class StakeOptionsSelect(discord.ui.Select):
             stake_modal.has_draftmancer_role = self.has_draftmancer_role
             
             # IMPORTANT: Set the default value based on saved preference before showing the modal
-            stake_modal.default_cap_setting = is_capped
+            stake_modal.default_cap_setting = bool(is_capped)
             # Update the cap checkbox value based on the preference
             stake_modal.cap_checkbox.value = "yes" if is_capped else "no"
             
             await interaction.response.send_modal(stake_modal)
         else:
             # Process the selected preset stake amount with the saved preference
-            stake_amount = int(selected_value)
+            stake_amount = int(str(selected_value))
             
             # Add user to sign_ups and handle stake submission using saved preference
             await self.handle_stake_submission(interaction, stake_amount, is_capped=is_capped)
             
     async def handle_stake_submission(self, interaction, stake_amount, is_capped=True):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         display_name = str(interaction.user.display_name)
         
@@ -2528,7 +2529,7 @@ class StakeOptionsSelect(discord.ui.Select):
                 drafter_role_name = guild_config["roles"]["drafter"]
                 
                 # Find the role in the guild
-                guild = interaction.guild
+                guild = not_none(interaction.guild)
                 drafter_role = discord.utils.get(guild.roles, name=drafter_role_name)
                 
                 if drafter_role:
@@ -2536,7 +2537,7 @@ class StakeOptionsSelect(discord.ui.Select):
                     channel = await interaction.client.fetch_channel(draft_session_updated.draft_channel_id)
                     if channel:
                         player_count = len(sign_ups)
-                        await channel.send(f"{player_count} Players in queue! {drafter_role.mention}")
+                        await cast(discord.TextChannel, channel).send(f"{player_count} Players in queue! {drafter_role.mention}")
         
         # Confirm stake and provide draft link
         cap_status = "capped at the highest opponent bet" if is_capped else "NOT capped (full action)"
@@ -2595,12 +2596,12 @@ class StakeModal(discord.ui.Modal):
         self.user_display_name = None
 
     async def callback(self, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         
         try:
             # Parse the stake amount
-            max_stake = int(self.stake_input.value)
+            max_stake = int(not_none(self.stake_input.value))
         except ValueError:
             await interaction.response.send_message("Please enter a valid number.", ephemeral=True)
             return
@@ -2608,7 +2609,7 @@ class StakeModal(discord.ui.Modal):
         # Determine if bet should be capped
         is_capped = True  # Default for regular stakes
         if self.over_100:
-            cap_value = self.cap_checkbox.value.lower()
+            cap_value = not_none(self.cap_checkbox.value).lower()
             is_capped = cap_value in ('yes', 'y', 'true')
         
         # Validation for over 100 stakes
@@ -2648,7 +2649,7 @@ class StakeModal(discord.ui.Modal):
                     
                     # Only add to sign_ups if stake is valid
                     sign_ups = draft_session.sign_ups or {}
-                    display_name = self.user_display_name or interaction.user.display_name
+                    display_name = self.user_display_name or not_none(interaction.user).display_name
                     sign_ups[user_id] = display_name
                     
                     # Update draftmancer_role_users if user has the role
@@ -2732,11 +2733,11 @@ class PaginatedStakeExplanation(discord.ui.View):
         
     def update_button_states(self):
         # Disable previous button if we're on the first page
-        self.children[0].disabled = (self.current_page == 0)
+        cast(discord.ui.Button, self.children[0]).disabled = (self.current_page == 0)
         # Disable next button if we're on the last page
-        self.children[2].disabled = (self.current_page == len(self.embeds) - 1)
+        cast(discord.ui.Button, self.children[2]).disabled = (self.current_page == len(self.embeds) - 1)
         # Update page counter
-        self.children[1].label = f"Page {self.current_page + 1}/{len(self.embeds)}"
+        cast(discord.ui.Button, self.children[1]).label = f"Page {self.current_page + 1}/{len(self.embeds)}"
     
     @discord.ui.button(label="Previous", style=discord.ButtonStyle.secondary)
     async def previous_button(self, button, interaction):
@@ -2780,7 +2781,7 @@ class StakeCalculationButton(discord.ui.Button):
         
         try:
             # Create player ID to name mapping with crown icons
-            guild = interaction.guild
+            guild = not_none(interaction.guild)
             player_names = {player_id: get_display_name_by_id(player_id, guild, draft_session.sign_ups.get(player_id, "Unknown"))
                         for player_id in list(draft_session.team_a) + list(draft_session.team_b)}
             
@@ -3100,6 +3101,7 @@ class StakeCalculationButton(discord.ui.Button):
                     allocation_text.append(f"{player_name}: {allocated}/{stake} tix ({percentage:.1f}%)")
             
             # Max team low tier allocations
+            low_tier_total = 0
             if max_team_low_tier:
                 allocation_text.append(f"\n*{max_team_name} (Max Team ≤50 tix):*")
                 low_tier_total = 0
@@ -3341,7 +3343,7 @@ class PersonalizedCapStatusView(discord.ui.View):
         user_id = self.user_id
         
         # Only the owner of the view should be able to toggle
-        if str(interaction.user.id) != user_id:
+        if str(not_none(interaction.user).id) != user_id:
             await interaction.response.send_message("This button is not for you.", ephemeral=True)
             return
             
@@ -3465,7 +3467,7 @@ class BetCapToggleButton(CallbackButton):
         self.draft_session_id = draft_session_id
     
     async def bet_cap_callback(self, interaction: discord.Interaction, button: discord.ui.Button):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         
         # Check if user is registered in this draft
@@ -3524,7 +3526,7 @@ class BetCapToggleButton(CallbackButton):
                 stake_select = CombinedStakeSelect(
                     draft_session_id=self.draft_session_id,
                     draft_link=draft_session.draft_link,
-                    user_display_name=interaction.user.display_name,
+                    user_display_name=not_none(interaction.user).display_name,
                     min_stake=min_stake,
                     current_stake=current_stake,
                     options=options
@@ -3547,15 +3549,15 @@ class BetCapToggleButton(CallbackButton):
                     custom_id=f"cap_yes_{self.draft_session_id}"
                 )
                 
-                async def yes_callback(yes_interaction):
-                    if yes_interaction.user.id != interaction.user.id:
+                async def yes_callback(yes_interaction: discord.Interaction):
+                    if not_none(yes_interaction.user).id != not_none(interaction.user).id:
                         await yes_interaction.response.send_message("This button is not for you.", ephemeral=True)
                         return
-                    
+
                     # Update cap status
                     await self.update_cap_status(yes_interaction, user_id, guild_id, is_capped=True)
                 
-                yes_button.callback = yes_callback
+                yes_button.callback = yes_callback  # pyrefly: ignore
                 combined_view.add_item(yes_button)
                 
                 # Create OFF button with its callback
@@ -3565,15 +3567,15 @@ class BetCapToggleButton(CallbackButton):
                     custom_id=f"cap_no_{self.draft_session_id}"
                 )
                 
-                async def no_callback(no_interaction):
-                    if no_interaction.user.id != interaction.user.id:
+                async def no_callback(no_interaction: discord.Interaction):
+                    if not_none(no_interaction.user).id != not_none(interaction.user).id:
                         await no_interaction.response.send_message("This button is not for you.", ephemeral=True)
                         return
-                    
+
                     # Update cap status
                     await self.update_cap_status(no_interaction, user_id, guild_id, is_capped=False)
-                
-                no_button.callback = no_callback
+
+                no_button.callback = no_callback  # pyrefly: ignore
                 combined_view.add_item(no_button)
                 
                 # Send the ephemeral message with the combined view
@@ -3638,7 +3640,7 @@ class CombinedStakeSelect(discord.ui.Select):
         super().__init__(placeholder=placeholder, min_values=1, max_values=1, options=options)
         
     async def callback(self, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         
         # Load the user's saved preference
@@ -3655,20 +3657,20 @@ class CombinedStakeSelect(discord.ui.Select):
             stake_modal.user_display_name = self.user_display_name
             
             # IMPORTANT: Set the default value based on saved preference before showing the modal
-            stake_modal.default_cap_setting = is_capped
+            stake_modal.default_cap_setting = bool(is_capped)
             # Update the cap checkbox value based on the preference
             stake_modal.cap_checkbox.value = "yes" if is_capped else "no"
             
             await interaction.response.send_modal(stake_modal)
         else:
             # Process the selected preset stake amount with the saved preference
-            stake_amount = int(selected_value)
+            stake_amount = int(str(selected_value))
             
             # Add user to sign_ups and handle stake submission using saved preference
             await self.handle_stake_submission(interaction, stake_amount, is_capped=is_capped)
             
     async def handle_stake_submission(self, interaction, stake_amount, is_capped=True):
-        user_id = str(interaction.user.id)
+        user_id = str(not_none(interaction.user).id)
         guild_id = str(interaction.guild_id)
         
         # Only proceed if this is different from current stake


### PR DESCRIPTION
## Summary

Adds the [pyrefly](https://github.com/facebook/pyrefly) type checker at default strictness and fixes all resulting type errors to reach **0 errors**.


## Why
1. type checkers help both claude/llms and devs work with less context
2. Claud/devs were adding types already, but a lot of places the types were actually *wrong* (mostly we init something as None but give it a non-nullable type)
3. pyrefly is very fast with good IDE integration so not much of a drag

## Why not
1. Obnoxiously have to move the venv into the folder to help the tooling locate site packages
2. pycord interactions and options and some other objects are a bit awkward to type we are often assuming they happen with guild/user available but the types don't guarantee this and we have to add some patches

## What was done
1. Enabled pyrefly (type checker) and config
2. Used claude to mechanically fix all the existing type errors
3. iterated with human review on the fixes to make sure they were reasonable and not overusing pyrefly-ignore and so on

## Testing
ran tests, did a basic draft on my test server
