### PR TITLE
 Ready check: debounce instead of disable, plus stall robustness4

### DIFF
--- a/alembic/versions/a1c2t3i4on32_widen_signup_history_action.py
+++ b/alembic/versions/a1c2t3i4on32_widen_signup_history_action.py
@@ -1,0 +1,40 @@
+"""widen sign_up_history.action to 32 chars
+
+Revision ID: a1c2t3i4on32
+Revises: 935bb3b19df1
+Create Date: 2026-06-20 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1c2t3i4on32'
+down_revision: Union[str, Sequence[str], None] = '935bb3b19df1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('sign_up_history', schema=None) as batch_op:
+        batch_op.alter_column(
+            'action',
+            existing_type=sa.String(length=16),
+            type_=sa.String(length=32),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('sign_up_history', schema=None) as batch_op:
+        batch_op.alter_column(
+            'action',
+            existing_type=sa.String(length=32),
+            type_=sa.String(length=16),
+            existing_nullable=False,
+        )

--- a/alembic/versions/l0bby1rc2msg3_add_lobby_ready_check_message_id.py
+++ b/alembic/versions/l0bby1rc2msg3_add_lobby_ready_check_message_id.py
@@ -1,0 +1,30 @@
+"""add lobby_ready_check_message_id to draft_sessions
+
+Revision ID: l0bby1rc2msg3
+Revises: a1c2t3i4on32
+Create Date: 2026-06-20 12:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'l0bby1rc2msg3'
+down_revision: Union[str, Sequence[str], None] = 'a1c2t3i4on32'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('draft_sessions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('lobby_ready_check_message_id', sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('draft_sessions', schema=None) as batch_op:
+        batch_op.drop_column('lobby_ready_check_message_id')

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -15,6 +15,7 @@ class DraftSession(Base):
     draft_channel_id = Column(String(64))
     true_skill_draft = Column(Boolean, default=False)
     ready_check_message_id = Column(String(64))
+    lobby_ready_check_message_id = Column(String(64))  # lobby ReadyCheckView message; stripped on restart
     draft_link = Column(String(256))
     ready_check_status = Column(JSON) # deprecated
     draft_start_time = Column(DateTime, default=datetime.now)

--- a/models/sign_up_history.py
+++ b/models/sign_up_history.py
@@ -13,7 +13,7 @@ class SignUpHistory(Base):
     session_id = Column(String(64), ForeignKey('draft_sessions.session_id', ondelete='CASCADE'), nullable=False)
     user_id = Column(String(64), nullable=False)
     user_display_name = Column(String(128))
-    action = Column(String(16), nullable=False)  # 'join' or 'leave'
+    action = Column(String(32), nullable=False)  # join | leave | ready | not_ready | ready_timeout
     timestamp = Column(DateTime, default=datetime.now, server_default=text('CURRENT_TIMESTAMP'), nullable=False)
     guild_id = Column(String(64), nullable=False)
     
@@ -50,4 +50,30 @@ class SignUpHistory(Base):
         
         async with db_session() as session:
             session.add(signup_record)
+            await session.commit()
+
+    @classmethod
+    async def record_ready_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
+        """
+        Record a ready-check response event for a draft session.
+
+        Args:
+            session_id (str): The draft session ID
+            user_id (str): The Discord user ID
+            display_name (str): The user's display name
+            action (str): One of 'ready', 'not_ready', 'ready_timeout'
+            guild_id (str): The Discord guild ID
+        """
+        record = cls(
+            id=str(uuid.uuid4()),
+            session_id=session_id,
+            user_id=user_id,
+            user_display_name=display_name,
+            action=action,
+            timestamp=datetime.now(),
+            guild_id=guild_id,
+        )
+
+        async with db_session() as session:
+            session.add(record)
             await session.commit()

--- a/ready_check.py
+++ b/ready_check.py
@@ -1,13 +1,21 @@
+import asyncio
+
 import discord
 from loguru import logger
 from typing import Dict, Iterable, List, Literal, Optional
 
 from helpers.display_names import get_display_name_by_id
+from models import SignUpHistory
 from services.state_manager import state_manager
 from services.team_creator import create_and_display_teams
 from session import get_draft_session
 
 PlayerStatus = Literal['ready', 'not_ready', 'no_response']
+
+# After this long with no response and no re-fire, a stalled lobby ready check is
+# auto-cleaned and a notice is posted. Must exceed the re-fire debounce in views.py
+# so a host can re-trigger (which cleans up silently) before this fires.
+READY_CHECK_TIMEOUT_SECONDS = 300
 
 
 class ReadyCheckSession:
@@ -46,6 +54,14 @@ class ReadyCheckSession:
             len(self._players) > 0
             and all(s == 'ready' for s in self._players.values())
         )
+
+    def counts(self) -> Dict[str, int]:
+        """Return the number of players in each ready-check bucket (for logging)."""
+        return {
+            "ready": len(self.ready),
+            "not_ready": len(self.not_ready),
+            "no_response": len(self.no_response),
+        }
 
     @property
     def ready(self) -> List[str]:
@@ -115,6 +131,58 @@ class ReadyCheckSession:
             logger.error(f"Error refreshing ready check embed: {e}")
             return False
 
+    async def run_timeout(self, session_id: str, channel, guild) -> None:
+        """After READY_CHECK_TIMEOUT_SECONDS, if THIS check is still the active one
+        and stalled (some players never responded), audit the non-responders, delete
+        the stale message, drop the state, and post a notice.
+
+        No-op if the check completed, everyone responded, or it was superseded by a
+        re-fire (the re-fire cleans up the old message silently, so no notice here).
+        """
+        await asyncio.sleep(READY_CHECK_TIMEOUT_SECONDS)
+
+        # Superseded by a re-fire or already torn down -> the other path handled it.
+        if state_manager.get_ready_check(session_id) is not self:
+            return
+        # Completed (handle_all_ready in flight) -> leave it alone.
+        if self.all_ready():
+            return
+
+        non_responders = self.no_response
+        if not non_responders:
+            # Everyone responded (some Not Ready); not a silent stall, nothing to flag.
+            return
+
+        guild_id = str(guild.id) if guild else "unknown"
+        draft_session = await get_draft_session(session_id)
+        sign_ups = (draft_session.sign_ups or {}) if draft_session else {}
+
+        logger.warning(
+            f"⏰ Ready check {session_id} timed out after {READY_CHECK_TIMEOUT_SECONDS}s; "
+            f"{len(non_responders)} non-responder(s): {non_responders}"
+        )
+
+        for user_id in non_responders:
+            await SignUpHistory.record_ready_event(
+                session_id=session_id,
+                user_id=user_id,
+                display_name=sign_ups.get(user_id, "Unknown user"),
+                action="ready_timeout",
+                guild_id=guild_id,
+            )
+
+        await self.delete_message(channel)
+        state_manager.remove_ready_check(session_id)
+
+        names = ", ".join(sign_ups.get(uid, "Unknown user") for uid in non_responders)
+        try:
+            await channel.send(
+                f"⏰ **Ready check timed out.** {len(non_responders)} player(s) did not respond "
+                f"({names}). Press **Ready Check** to start a new one when everyone's around."
+            )
+        except discord.HTTPException as e:
+            logger.error(f"Failed to send ready-check timeout notice for {session_id}: {e}")
+
     # --- class-level entry points (fetch session from state, delegate to instance) ---
 
     @classmethod
@@ -126,31 +194,14 @@ class ReadyCheckSession:
         state_manager.remove_ready_check(session_id)
 
     @classmethod
-    async def cancel(cls, session_id: str, bot, channel, cancelled_by: str) -> None:
-        """Abort the ready check, clean up, announce, and re-enable the Ready Check button."""
-        # Deferred to avoid circular import: ready_check -> views
-        from views import PersistentView
+    async def cancel(cls, session_id: str, channel, cancelled_by: str) -> None:
+        """Abort the ready check: delete the message, drop the state, and announce it.
 
-        draft_session = await get_draft_session(session_id)
+        The draft message's Ready Check button is never disabled (the debounce in
+        views.py prevents spam instead), so there is nothing to re-enable here.
+        """
         await cls.cleanup(session_id, channel)
         await channel.send(f"**{cancelled_by}** cancelled the ready check.")
-
-        if not (draft_session and draft_session.message_id):
-            return
-        try:
-            draft_message = await channel.fetch_message(int(draft_session.message_id))
-            restored_view = PersistentView(
-                bot=bot,
-                draft_session_id=session_id,
-                session_type=draft_session.session_type,
-                team_a_name=draft_session.team_a_name,
-                team_b_name=draft_session.team_b_name
-            )
-            await draft_message.edit(view=restored_view)
-        except discord.NotFound:
-            pass
-        except Exception as e:
-            logger.error(f"Error restoring draft message after ready check cancel: {e}")
 
     @classmethod
     async def sync_added_player(cls, session_id: str, user_id: str, draft_session, interaction: discord.Interaction) -> None:
@@ -267,17 +318,44 @@ class ReadyCheckView(discord.ui.View):
     async def _handle_status(self, interaction: discord.Interaction, status: PlayerStatus) -> None:
         rc = state_manager.get_ready_check(self.draft_session_id)
         if not rc:
+            logger.warning(
+                f"Ready click against missing session {self.draft_session_id} "
+                f"by user {interaction.user.id}; live checks: "
+                f"{list(state_manager.ready_checks.keys())}"
+            )
             await interaction.response.send_message("Session data is missing.", ephemeral=True)
             return
 
         user_id = str(interaction.user.id)
         if not rc.has_player(user_id):
+            logger.warning(
+                f"Unauthorized ready click on {self.draft_session_id} by user {user_id} (not a participant)"
+            )
             await interaction.response.send_message("You are not authorized to interact with this button.", ephemeral=True)
             return
 
         rc.set_status(user_id, status)
 
         draft_session = await get_draft_session(self.draft_session_id)
+
+        # Record the response in the audit trail. Auditing is best-effort: a DB/audit
+        # failure must not break the user's ready click, so swallow and log it.
+        try:
+            await SignUpHistory.record_ready_event(
+                session_id=self.draft_session_id,
+                user_id=user_id,
+                display_name=(draft_session.sign_ups or {}).get(user_id, "Unknown user"),
+                action=status,
+                guild_id=str(interaction.guild.id),
+            )
+        except Exception as e:
+            logger.error(f"Failed to record ready event for {self.draft_session_id} user {user_id}: {e}")
+
+        logger.info(
+            f"Ready click on {self.draft_session_id}: user {user_id} -> {status}; "
+            f"counts={rc.counts()}; complete={rc.all_ready()}"
+        )
+
         embed = await rc.build_embed(draft_session.sign_ups, guild=interaction.guild)
         await interaction.response.edit_message(embed=embed, view=self)
 
@@ -298,7 +376,6 @@ class ReadyCheckCancelConfirmView(discord.ui.View):
         await interaction.response.edit_message(view=self)
         await ReadyCheckSession.cancel(
             self.draft_session_id,
-            interaction.client,
             interaction.channel,
             cancelled_by=self.cancelled_by,
         )

--- a/tests/test_ready_check.py
+++ b/tests/test_ready_check.py
@@ -10,7 +10,24 @@ import discord
 from ready_check import (
     ReadyCheckCancelConfirmView,
     ReadyCheckSession,
+    ReadyCheckView,
 )
+
+
+# ---------------------------------------------------------------------------
+# counts
+# ---------------------------------------------------------------------------
+
+class TestCounts:
+    def test_counts_per_bucket(self):
+        rc = ReadyCheckSession(player_ids=["1", "2", "3", "4", "5"])
+        rc.set_status("1", "ready")
+        rc.set_status("2", "ready")
+        rc.set_status("3", "not_ready")
+        assert rc.counts() == {"ready": 2, "not_ready": 1, "no_response": 2}
+
+    def test_counts_empty(self):
+        assert ReadyCheckSession(player_ids=[]).counts() == {"ready": 0, "not_ready": 0, "no_response": 0}
 
 
 # ---------------------------------------------------------------------------
@@ -168,72 +185,27 @@ class TestCleanup:
 
 @pytest.mark.asyncio
 class TestCancel:
-    def _make_channel(self, draft_msg=None):
+    def _make_channel(self):
         channel = MagicMock()
         channel.send = AsyncMock()
-        msg = draft_msg or MagicMock()
-        msg.edit = AsyncMock()
-        channel.fetch_message = AsyncMock(return_value=msg)
         return channel
-
-    def _make_session(self, message_id="777", channel_id="888"):
-        s = MagicMock()
-        s.message_id = message_id
-        s.draft_channel_id = channel_id
-        s.session_type = "random"
-        s.team_a_name = "Team A"
-        s.team_b_name = "Team B"
-        return s
 
     async def test_posts_cancellation_message(self):
         channel = self._make_channel()
-        bot = MagicMock()
-        with patch("ready_check.get_draft_session", AsyncMock(return_value=self._make_session())), \
-             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
-             patch("ready_check.state_manager"), \
-             patch("views.PersistentView", MagicMock()):
-            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Alice")
+        with patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+             patch("ready_check.state_manager"):
+            await ReadyCheckSession.cancel("sid", channel, cancelled_by="Alice")
 
         channel.send.assert_awaited_once()
         assert "Alice" in channel.send.call_args.args[0]
 
-    async def test_restores_draft_message_view(self):
+    async def test_delegates_to_cleanup(self):
         channel = self._make_channel()
-        bot = MagicMock()
-        session = self._make_session()
-        mock_persistent_view = MagicMock()
-
-        with patch("ready_check.get_draft_session", AsyncMock(return_value=session)), \
-             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
-             patch("ready_check.state_manager"), \
-             patch("views.PersistentView", return_value=mock_persistent_view):
-            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Bob")
-
-        channel.fetch_message.assert_awaited_once_with(int(session.message_id))
-        channel.fetch_message.return_value.edit.assert_awaited_once()
-
-    async def test_no_session_skips_draft_message_edit(self):
-        channel = self._make_channel()
-        bot = MagicMock()
-        with patch("ready_check.get_draft_session", AsyncMock(return_value=None)), \
-             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
+        with patch.object(ReadyCheckSession, "cleanup", AsyncMock()) as mock_cleanup, \
              patch("ready_check.state_manager"):
-            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Eve")
+            await ReadyCheckSession.cancel("sid", channel, cancelled_by="Bob")
 
-        channel.fetch_message.assert_not_awaited()
-
-    async def test_draft_message_not_found_is_swallowed(self):
-        channel = self._make_channel()
-        channel.fetch_message = AsyncMock(
-            side_effect=discord.NotFound(MagicMock(), "gone")
-        )
-        bot = MagicMock()
-        with patch("ready_check.get_draft_session", AsyncMock(return_value=self._make_session())), \
-             patch.object(ReadyCheckSession, "cleanup", AsyncMock()), \
-             patch("ready_check.state_manager"), \
-             patch("views.PersistentView", MagicMock()):
-            # Should not raise
-            await ReadyCheckSession.cancel("sid", bot, channel, cancelled_by="Eve")
+        mock_cleanup.assert_awaited_once_with("sid", channel)
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +350,178 @@ class TestSyncAddedPlayer:
             await ReadyCheckSession.sync_added_player("sid", "2", _make_draft_session(), interaction)
 
         assert rc.message_id is None
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckSession.run_timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestRunTimeout:
+    def _make_channel(self):
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        msg = MagicMock()
+        msg.delete = AsyncMock()
+        channel.fetch_message = AsyncMock(return_value=msg)
+        return channel
+
+    def _guild(self, gid="42"):
+        guild = MagicMock()
+        guild.id = gid
+        return guild
+
+    async def test_superseded_is_noop(self):
+        """A re-fire replaced this check -> timeout does nothing (the re-fire cleaned up)."""
+        rc = _make_rc(ready=["1"], no_response=["2"])
+        channel = self._make_channel()
+        with patch("ready_check.asyncio.sleep", AsyncMock()), \
+             patch("ready_check.state_manager") as sm, \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = object()  # not `rc`
+            await rc.run_timeout("sid", channel, self._guild())
+
+        sh.record_ready_event.assert_not_called()
+        channel.send.assert_not_awaited()
+        sm.remove_ready_check.assert_not_called()
+
+    async def test_all_ready_is_noop(self):
+        rc = _make_rc(ready=["1", "2"])
+        channel = self._make_channel()
+        with patch("ready_check.asyncio.sleep", AsyncMock()), \
+             patch("ready_check.state_manager") as sm, \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = rc
+            await rc.run_timeout("sid", channel, self._guild())
+
+        sh.record_ready_event.assert_not_called()
+        channel.send.assert_not_awaited()
+
+    async def test_no_non_responders_is_noop(self):
+        """Everyone responded (some Not Ready) -> not a silent stall, no notice."""
+        rc = _make_rc(ready=["1"], not_ready=["2"])
+        channel = self._make_channel()
+        with patch("ready_check.asyncio.sleep", AsyncMock()), \
+             patch("ready_check.state_manager") as sm, \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = rc
+            await rc.run_timeout("sid", channel, self._guild())
+
+        sh.record_ready_event.assert_not_called()
+        channel.send.assert_not_awaited()
+
+    async def test_genuine_stall_audits_cleans_and_notifies(self):
+        rc = _make_rc(ready=["1"], no_response=["2", "3"], message_id=55)
+        channel = self._make_channel()
+        ds = MagicMock()
+        ds.sign_ups = {"1": "Alice", "2": "Bob", "3": "Carol"}
+        with patch("ready_check.asyncio.sleep", AsyncMock()), \
+             patch("ready_check.state_manager") as sm, \
+             patch("ready_check.get_draft_session", AsyncMock(return_value=ds)), \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = rc
+            sh.record_ready_event = AsyncMock()
+            await rc.run_timeout("sid", channel, self._guild())
+
+        # One audit row per non-responder, all tagged ready_timeout.
+        assert sh.record_ready_event.await_count == 2
+        for call in sh.record_ready_event.await_args_list:
+            assert call.kwargs["action"] == "ready_timeout"
+        # Stale message deleted, state dropped, notice posted naming the non-responders.
+        channel.fetch_message.assert_awaited_once_with(55)
+        channel.fetch_message.return_value.delete.assert_awaited_once()
+        sm.remove_ready_check.assert_called_once_with("sid")
+        channel.send.assert_awaited_once()
+        notice = channel.send.call_args.args[0]
+        assert "Bob" in notice and "Carol" in notice
+
+
+# ---------------------------------------------------------------------------
+# ReadyCheckView._handle_status (the click handler)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestHandleStatus:
+    def _interaction(self, user_id="1", guild_id="42"):
+        i = MagicMock()
+        i.user.id = user_id
+        i.guild.id = guild_id
+        i.response.send_message = AsyncMock()
+        i.response.edit_message = AsyncMock()
+        return i
+
+    async def test_records_audit_and_updates_embed(self):
+        rc = _make_rc(no_response=["1", "2"])  # readying "1" leaves "2" pending
+        view = ReadyCheckView("sid")
+        i = self._interaction(user_id="1")
+        with patch("ready_check.state_manager") as sm, \
+             patch("ready_check.get_draft_session", AsyncMock(return_value=_make_draft_session())), \
+             patch("ready_check.SignUpHistory") as sh, \
+             patch.object(ReadyCheckSession, "build_embed", AsyncMock(return_value=MagicMock())):
+            sm.get_ready_check.return_value = rc
+            sh.record_ready_event = AsyncMock()
+            await view._handle_status(i, "ready")
+
+        assert "1" in rc.ready
+        sh.record_ready_event.assert_awaited_once()
+        assert sh.record_ready_event.await_args.kwargs["action"] == "ready"
+        i.response.edit_message.assert_awaited_once()
+
+    async def test_missing_session_warns_and_skips(self):
+        view = ReadyCheckView("sid")
+        i = self._interaction()
+        with patch("ready_check.state_manager") as sm, \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = None
+            await view._handle_status(i, "ready")
+
+        i.response.send_message.assert_awaited_once()
+        assert i.response.send_message.call_args.kwargs.get("ephemeral") is True
+        sh.record_ready_event.assert_not_called()
+        i.response.edit_message.assert_not_awaited()
+
+    async def test_unauthorized_user_no_state_change(self):
+        rc = _make_rc(no_response=["1"])  # only player "1" is in the check
+        view = ReadyCheckView("sid")
+        i = self._interaction(user_id="999")  # not a participant
+        with patch("ready_check.state_manager") as sm, \
+             patch("ready_check.SignUpHistory") as sh:
+            sm.get_ready_check.return_value = rc
+            await view._handle_status(i, "ready")
+
+        i.response.send_message.assert_awaited_once()
+        sh.record_ready_event.assert_not_called()
+        assert rc.no_response == ["1"]  # unchanged
+
+    async def test_last_ready_triggers_handle_all_ready(self):
+        rc = _make_rc(no_response=["1"])  # single player; readying completes the check
+        view = ReadyCheckView("sid")
+        with patch("ready_check.state_manager") as sm, \
+             patch("ready_check.get_draft_session", AsyncMock(return_value=_make_draft_session())), \
+             patch("ready_check.SignUpHistory") as sh, \
+             patch.object(ReadyCheckSession, "build_embed", AsyncMock(return_value=MagicMock())), \
+             patch.object(ReadyCheckSession, "handle_all_ready", AsyncMock()) as hac:
+            sm.get_ready_check.return_value = rc
+            sh.record_ready_event = AsyncMock()
+            await view._handle_status(self._interaction(user_id="1"), "ready")
+
+        hac.assert_awaited_once()
+
+    async def test_audit_failure_does_not_break_click(self):
+        """A failing audit write must not abort the user's ready click."""
+        rc = _make_rc(no_response=["1", "2"])
+        view = ReadyCheckView("sid")
+        i = self._interaction(user_id="1")
+        with patch("ready_check.state_manager") as sm, \
+             patch("ready_check.get_draft_session", AsyncMock(return_value=_make_draft_session())), \
+             patch("ready_check.SignUpHistory") as sh, \
+             patch.object(ReadyCheckSession, "build_embed", AsyncMock(return_value=MagicMock())):
+            sm.get_ready_check.return_value = rc
+            sh.record_ready_event = AsyncMock(side_effect=RuntimeError("db down"))
+            await view._handle_status(i, "ready")  # must not raise
+
+        assert "1" in rc.ready                       # state still applied
+        i.response.edit_message.assert_awaited_once()  # click still completed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ready_check_views.py
+++ b/tests/test_ready_check_views.py
@@ -1,0 +1,242 @@
+"""Tests for the view/utility wiring around the lobby ready check.
+
+Covers PersistentView.ready_check_callback (guards + happy path + re-fire),
+the startup button-strip helper, and the timeout/debounce ordering invariant.
+All Discord/DB I/O is mocked — no live bot or database needed.
+"""
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import utils
+import views
+from ready_check import ReadyCheckSession
+from views import PersistentView, READY_CHECK_DEBOUNCE_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _view(session_id="sid"):
+    """A PersistentView without running __init__ (skips real button construction)."""
+    v = PersistentView.__new__(PersistentView)
+    v.draft_session_id = session_id
+    return v
+
+
+def _interaction(user_id="0"):
+    i = MagicMock()
+    i.user.id = user_id
+    i.response.send_message = AsyncMock()
+    i.response.defer = AsyncMock()
+    i.followup.send = AsyncMock(return_value=MagicMock(id=12345))
+    i.channel = MagicMock()
+    i.channel.id = "100"
+    i.channel.name = "draft-chan"
+    i.guild = MagicMock()
+    i.guild.id = "42"
+    i.guild.name = "Guild"
+    i.client = MagicMock()
+    return i
+
+
+def _session(n_signups=6):
+    s = MagicMock()
+    s.sign_ups = {str(i): f"P{i}" for i in range(n_signups)}
+    return s
+
+
+def _mock_async_session():
+    """Mimics `async with AsyncSessionLocal() as s: async with s.begin(): await s.execute(...)`."""
+    session = MagicMock()
+    session.execute = AsyncMock()
+    begin = MagicMock()
+    begin.__aenter__ = AsyncMock(return_value=session)
+    begin.__aexit__ = AsyncMock(return_value=None)
+    session.begin = MagicMock(return_value=begin)
+    outer = MagicMock()
+    outer.__aenter__ = AsyncMock(return_value=session)
+    outer.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=outer), session
+
+
+def _make_create_task_stub():
+    """Stand-in for asyncio.create_task that records and safely closes coroutines."""
+    calls = []
+
+    def stub(coro):
+        calls.append(coro)
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    stub.calls = calls
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# ready_check_callback — guard clauses (B1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestReadyCheckCallbackGuards:
+    async def test_cooldown_blocks_and_does_not_start(self):
+        view = _view()
+        i = _interaction()
+        with patch("views.state_manager") as sm, \
+             patch("views.get_draft_session", AsyncMock(return_value=_session(6))):
+            sm.get_cooldown.return_value = datetime.now() + timedelta(seconds=90)
+            await view.ready_check_callback(i, MagicMock())
+
+        sm.set_ready_check.assert_not_called()
+        sm.set_cooldown.assert_not_called()
+        i.response.send_message.assert_awaited_once()
+        assert "cooldown" in i.response.send_message.call_args.args[0].lower()
+
+    async def test_under_six_players_rejected(self):
+        view = _view()
+        i = _interaction()
+        with patch("views.state_manager") as sm, \
+             patch("views.get_draft_session", AsyncMock(return_value=_session(3))):
+            sm.get_cooldown.return_value = None
+            await view.ready_check_callback(i, MagicMock())
+
+        sm.set_ready_check.assert_not_called()
+        assert "6 or more" in i.response.send_message.call_args.args[0]
+
+    async def test_non_participant_rejected(self):
+        view = _view()
+        i = _interaction(user_id="999")  # not among sign_ups 0..5
+        with patch("views.state_manager") as sm, \
+             patch("views.get_draft_session", AsyncMock(return_value=_session(6))), \
+             patch("views.asyncio.create_task", _make_create_task_stub()):
+            sm.get_cooldown.return_value = None
+            await view.ready_check_callback(i, MagicMock())
+
+        sm.set_ready_check.assert_not_called()
+        assert "not registered" in i.response.send_message.call_args.args[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# ready_check_callback — happy path + re-fire (B2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestReadyCheckCallbackStart:
+    async def test_happy_path_starts_check_without_disabling_button(self):
+        view = _view()
+        i = _interaction(user_id="0")
+        factory, db_sess = _mock_async_session()
+        stub = _make_create_task_stub()
+        with patch("views.state_manager") as sm, \
+             patch("views.get_draft_session", AsyncMock(return_value=_session(6))), \
+             patch("views.AsyncSessionLocal", factory), \
+             patch("views.send_ready_check_dms", AsyncMock()), \
+             patch("views.asyncio.create_task", stub), \
+             patch("ready_check.get_display_name_by_id", lambda uid, g, fb: fb), \
+             patch.object(ReadyCheckSession, "handle_all_ready", AsyncMock()) as hac:
+            sm.get_cooldown.return_value = None
+            sm.has_ready_check.return_value = False
+            await view.ready_check_callback(i, MagicMock())
+
+        sm.set_ready_check.assert_called_once()          # the check started
+        i.message.edit.assert_not_called()               # button NOT disabled
+        db_sess.execute.assert_awaited()                 # message id persisted
+        i.followup.send.assert_awaited()                 # ready-check message sent
+        assert len(stub.calls) == 2                      # remove_cooldown + run_timeout scheduled
+        hac.assert_not_awaited()                          # 6 players, only initiator ready
+
+    async def test_refire_cleans_up_previous_check_silently(self):
+        view = _view()
+        i = _interaction(user_id="0")
+        factory, _ = _mock_async_session()
+        with patch("views.state_manager") as sm, \
+             patch("views.get_draft_session", AsyncMock(return_value=_session(6))), \
+             patch("views.AsyncSessionLocal", factory), \
+             patch("views.send_ready_check_dms", AsyncMock()), \
+             patch("views.asyncio.create_task", _make_create_task_stub()), \
+             patch("ready_check.get_display_name_by_id", lambda uid, g, fb: fb), \
+             patch.object(ReadyCheckSession, "handle_all_ready", AsyncMock()), \
+             patch.object(ReadyCheckSession, "cleanup", AsyncMock()) as cleanup:
+            sm.get_cooldown.return_value = None
+            sm.has_ready_check.return_value = True  # a previous check is still active
+            await view.ready_check_callback(i, MagicMock())
+
+        cleanup.assert_awaited_once_with("sid", i.channel)
+
+
+# ---------------------------------------------------------------------------
+# utils.strip_stale_lobby_ready_checks (C)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestStripStaleLobbyReadyChecks:
+    def _stale(self, sid="s1", chan="100", msg="555"):
+        s = MagicMock()
+        s.session_id = sid
+        s.draft_channel_id = chan
+        s.lobby_ready_check_message_id = msg
+        return s
+
+    def _db(self, stale_list):
+        session = MagicMock()
+        select_result = MagicMock()
+        select_result.scalars.return_value.all.return_value = stale_list
+        session.execute = AsyncMock(return_value=select_result)
+        begin = MagicMock()
+        begin.__aenter__ = AsyncMock(return_value=session)
+        begin.__aexit__ = AsyncMock(return_value=None)
+        session.begin = MagicMock(return_value=begin)
+        outer = MagicMock()
+        outer.__aenter__ = AsyncMock(return_value=session)
+        outer.__aexit__ = AsyncMock(return_value=None)
+        return MagicMock(return_value=outer), session
+
+    async def test_strips_buttons_and_clears_column(self):
+        factory, session = self._db([self._stale()])
+        msg = MagicMock()
+        msg.edit = AsyncMock()
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(return_value=msg)
+        bot = MagicMock()
+        bot.get_channel.return_value = channel
+        with patch("utils.AsyncSessionLocal", factory):
+            await utils.strip_stale_lobby_ready_checks(bot)
+
+        channel.fetch_message.assert_awaited_once_with(555)
+        msg.edit.assert_awaited_once_with(view=None)
+        assert session.execute.await_count >= 2  # SELECT + UPDATE(clear)
+
+    async def test_message_not_found_still_clears_column(self):
+        factory, session = self._db([self._stale()])
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "gone"))
+        bot = MagicMock()
+        bot.get_channel.return_value = channel
+        with patch("utils.AsyncSessionLocal", factory):
+            await utils.strip_stale_lobby_ready_checks(bot)  # must not raise
+
+        assert session.execute.await_count >= 2  # clear still ran
+
+    async def test_no_stale_sessions_is_noop(self):
+        factory, session = self._db([])
+        bot = MagicMock()
+        with patch("utils.AsyncSessionLocal", factory):
+            await utils.strip_stale_lobby_ready_checks(bot)
+
+        bot.get_channel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timeout / debounce ordering invariant (D)
+# ---------------------------------------------------------------------------
+
+def test_timeout_exceeds_debounce():
+    """The stall timeout must outlast the debounce so a host can re-fire (which
+    cleans up silently) before the timeout would fire and post a notice."""
+    from ready_check import READY_CHECK_TIMEOUT_SECONDS
+    assert READY_CHECK_TIMEOUT_SECONDS > READY_CHECK_DEBOUNCE_SECONDS

--- a/tests/test_signup_history.py
+++ b/tests/test_signup_history.py
@@ -202,6 +202,52 @@ async def test_repr_method(test_db):
         assert action in repr_str
 
 
+@pytest.mark.asyncio
+async def test_record_ready_event(test_db):
+    """Recording a ready-check response writes the expected row."""
+    session_id = "rc_session_1"
+    user_id = "user_ready_1"
+    display_name = "ReadyUser"
+    guild_id = "guild_rc"
+
+    await SignUpHistory.record_ready_event(
+        session_id=session_id,
+        user_id=user_id,
+        display_name=display_name,
+        action="ready",
+        guild_id=guild_id,
+    )
+
+    async with AsyncSessionLocal() as session:
+        query = select(SignUpHistory).where(SignUpHistory.session_id == session_id)
+        result = await session.execute(query)
+        record = result.scalar_one()
+
+        assert record.user_id == user_id
+        assert record.user_display_name == display_name
+        assert record.action == "ready"
+        assert record.guild_id == guild_id
+        assert record.timestamp is not None
+
+
+@pytest.mark.asyncio
+async def test_record_ready_event_timeout_action(test_db):
+    """The ready_timeout action value (longer than the old 16-char limit) is stored intact."""
+    await SignUpHistory.record_ready_event(
+        session_id="rc_session_2",
+        user_id="user_to_1",
+        display_name="TimedOutUser",
+        action="ready_timeout",
+        guild_id="guild_rc",
+    )
+
+    async with AsyncSessionLocal() as session:
+        query = select(SignUpHistory).where(SignUpHistory.session_id == "rc_session_2")
+        result = await session.execute(query)
+        record = result.scalar_one()
+        assert record.action == "ready_timeout"
+
+
 async def run_model_tests():
     """Run all SignUpHistory model tests."""
     from sqlalchemy.ext.asyncio import create_async_engine

--- a/utils.py
+++ b/utils.py
@@ -2210,6 +2210,48 @@ async def re_register_views(bot):
                         except Exception as e:
                             logger.error(f"Failed to re-register settle view for results channel {staked_session.session_id}: {e}")
 
+    # Strip stale lobby ready-check buttons left over from a restart mid-check.
+    await strip_stale_lobby_ready_checks(bot)
+
+
+async def strip_stale_lobby_ready_checks(bot):
+    """Remove Ready/Not-Ready buttons from lobby ready-check messages left in-flight
+    by a restart, and clear the persisted message id.
+
+    In-memory ready-check state is not restored across restarts, so those buttons
+    would only error if clicked. We strip them (keeping the embed) and null the
+    column. Missing messages are tolerated — the column is cleared either way, so
+    the cleanup is self-healing.
+    """
+    async with AsyncSessionLocal() as db_session:
+        async with db_session.begin():
+            stmt = select(DraftSession).where(
+                DraftSession.lobby_ready_check_message_id.isnot(None)
+            )
+            result = await db_session.execute(stmt)
+            stale_rc_sessions = result.scalars().all()
+
+        for stale_session in stale_rc_sessions:
+            if stale_session.draft_channel_id:
+                channel = bot.get_channel(int(stale_session.draft_channel_id))
+                if channel:
+                    try:
+                        message = await channel.fetch_message(int(stale_session.lobby_ready_check_message_id))
+                        await message.edit(view=None)  # Strip Ready/Not-Ready buttons; keep the embed.
+                        logger.info(f"Stripped stale lobby ready-check buttons for session: {stale_session.session_id}")
+                    except discord.NotFound:
+                        logger.debug(f"Stale lobby ready-check message not found for session: {stale_session.session_id}")
+                    except Exception as e:
+                        logger.error(f"Failed to strip lobby ready-check buttons for {stale_session.session_id}: {e}")
+
+            async with db_session.begin():
+                await db_session.execute(
+                    update(DraftSession)
+                    .where(DraftSession.session_id == stale_session.session_id)
+                    .values(lobby_ready_check_message_id=None)
+                )
+
+
 async def calculate_player_standings(limit=None):
     time = datetime.now()
     async with AsyncSessionLocal() as db_session:

--- a/views.py
+++ b/views.py
@@ -44,6 +44,11 @@ from services.state_manager import state_manager
 from services.stake_service import calculate_and_store_stakes
 from preference_service import get_players_bet_capping_preferences
 
+# Minimum gap between successive lobby ready checks on the same draft. The Ready
+# Check button stays enabled; this debounce (not a disabled button) is what
+# prevents spamming multiple checks in quick succession.
+READY_CHECK_DEBOUNCE_SECONDS = 120
+
 
 
 
@@ -752,11 +757,11 @@ class PersistentView(discord.ui.View):
                 ephemeral=True
             )
             return
-        
-        # Set a new cooldown for this draft session (60 seconds)
-        state_manager.set_cooldown(self.draft_session_id, current_time + timedelta(seconds=60))
-        
-        # Schedule the cooldown to be removed after 60 seconds
+
+        # Debounce: block another ready check on this draft for the cooldown window.
+        state_manager.set_cooldown(self.draft_session_id, current_time + timedelta(seconds=READY_CHECK_DEBOUNCE_SECONDS))
+
+        # Schedule the cooldown entry to be cleared once the window elapses.
         asyncio.create_task(self.remove_cooldown(self.draft_session_id))
         
 
@@ -770,6 +775,13 @@ class PersistentView(discord.ui.View):
         # We'll use followup.send() later to send the actual message
         await interaction.response.defer()
 
+        # If a previous ready check is still active (host re-fires a stalled check
+        # after the debounce), clean it up silently first — no timeout notice, just
+        # remove the orphaned message so the new check is the only live one.
+        if state_manager.has_ready_check(self.draft_session_id):
+            logger.info(f"Re-firing ready check for {self.draft_session_id}; cleaning up the previous one")
+            await ReadyCheckSession.cleanup(self.draft_session_id, interaction.channel)
+
         # Build the initial ready check state.
         # All players start as no_response; initiator and test users are marked ready immediately.
         TEST_USER_ID_START = 900000000000000000
@@ -782,18 +794,14 @@ class PersistentView(discord.ui.View):
                 logger.debug(f"Auto-marked test user {uid} as ready")
 
         state_manager.set_ready_check(self.draft_session_id, rc)
-        logger.info(f"✅ Ready check initiated - registered session ID {self.draft_session_id}")
+        logger.info(
+            f"✅ Ready check initiated for {self.draft_session_id} by user {user_id}; "
+            f"initial counts={rc.counts()}"
+        )
 
-
-        # Disable the "Ready Check" button and persist it to the draft message
-        for item in self.children:
-            if isinstance(item, discord.ui.Button) and item.custom_id == f"ready_check_{self.draft_session_id}":
-                item.disabled = True
-                break
-        try:
-            await interaction.message.edit(view=self)
-        except Exception as e:
-            logger.error(f"Failed to disable ready check button in draft message: {e}")
+        # The Ready Check button is intentionally left enabled — the per-session
+        # debounce above (READY_CHECK_DEBOUNCE_SECONDS) prevents spamming, while
+        # keeping the button live so a stalled check can be re-fired once it lapses.
 
         # Generate the initial embed with personalized links
         embed = await rc.build_embed(session.sign_ups, guild=interaction.guild)
@@ -804,6 +812,19 @@ class PersistentView(discord.ui.View):
         # Send the initial ready check message (using followup since we deferred)
         main_message = await interaction.followup.send(embed=embed, view=view)
         rc.message_id = main_message.id
+
+        # Persist the message id so stale Ready/Not-Ready buttons can be stripped on
+        # restart (in-memory state is not restored across restarts).
+        async with AsyncSessionLocal() as db_sess:
+            async with db_sess.begin():
+                await db_sess.execute(
+                    update(DraftSession)
+                    .where(DraftSession.session_id == self.draft_session_id)
+                    .values(lobby_ready_check_message_id=str(main_message.id))
+                )
+
+        # Schedule the stall timeout (notify-only; re-fire cleans up silently before this).
+        asyncio.create_task(rc.run_timeout(self.draft_session_id, interaction.channel, interaction.guild))
 
         # Construct a message that mentions all users who need to respond to the ready check
         user_mentions = ' '.join([f"<@{user_id}>" for user_id in session.sign_ups.keys()])
@@ -827,8 +848,8 @@ class PersistentView(discord.ui.View):
             await ReadyCheckSession.handle_all_ready(self.draft_session_id, session, interaction)
 
     async def remove_cooldown(self, draft_session_id):
-        await asyncio.sleep(60)  # Wait for 60 seconds
-        # Reset cooldown on successful full ready
+        await asyncio.sleep(READY_CHECK_DEBOUNCE_SECONDS)
+        # Clear the debounce entry once the window has elapsed.
         state_manager.remove_cooldown(draft_session_id)
 
 


### PR DESCRIPTION
Follow-up fixes on top of #313 (now merged). Builds on its `ReadyCheckSession` refactor and `is_test_mode()` env-var switch.

## Why

#313 made the Ready Check button actually disable on use, but removed the old stall-cleanup without a replacement — so a stalled check left the button disabled with no recovery except a manual cancel or a bot restart. This swaps the disable for a debounce and adds a stall-robustness layer so a single dropped ready click can no longer wedge a draft.

## What changed

- **Debounce instead of disable.** The Ready Check button stays enabled; the per-session cooldown is the anti-spam guard (60s → 120s, `READY_CHECK_DEBOUNCE_SECONDS`). A stalled check is self-recoverable — re-fire once the window lapses.
- **Silent re-fire cleanup.** Re-firing while a check is still active deletes the previous ready-check message first, with no timeout notice.
- **5-minute stall timeout** (`ReadyCheckSession.run_timeout`): if a check is still active and has non-responders, audit them, delete the stale message, drop state, and post a notice. No-op if completed or superseded by a re-fire.
- **Per-click logging** on ready/not-ready, missing-session, and unauthorized clicks, plus initiation counts.
- **Audit trail**: ready / not_ready / ready_timeout events recorded to `SignUpHistory` (`record_ready_event`; `action` column widened 16 → 32). Audit writes are best-effort — a failure can't break a ready click.
- **Startup button-strip**: persist the lobby ready-check message id and, on restart, strip stale Ready/Not-Ready buttons off in-flight check messages (new `lobby_ready_check_message_id` column; `strip_stale_lobby_ready_checks`).
- **Simplified `cancel`**: no longer re-attaches a `PersistentView` (the button is never disabled), dropping the `bot` param and the `ready_check → views` circular import.

## Migrations

- `a1c2t3i4on32` — widen `sign_up_history.action` to 32 chars
- `l0bby1rc2msg3` — add `draft_sessions.lobby_ready_check_message_id`

## Test plan

- [x] Full suite: 474 passed, 9 skipped
- [ ] Fire a check → button stays enabled
- [ ] Re-fire within 2 min → cooldown message
- [ ] Let a check stall 5 min → timeout notice + `ready_timeout` rows in `sign_up_history`
- [ ] Re-fire after 2 min → previous message removed silently (no timeout notice)
- [ ] Restart mid-check → stale Ready/Not-Ready buttons stripped on startup
- [ ] Cancel Check → confirmation → message deleted, cancellation announced

New automated coverage: `TestHandleStatus`, `TestRunTimeout`, `TestReadyCheckCallbackGuards`/`TestReadyCheckCallbackStart`, `TestStripStaleLobbyReadyChecks`, the timeout > debounce invariant, and `record_ready_event` model tests.
