### PR TITLE
Simplify ready-check code (cleanup follow-up)

### DIFF
--- a/models/sign_up_history.py
+++ b/models/sign_up_history.py
@@ -24,46 +24,8 @@ class SignUpHistory(Base):
         )
     
     @classmethod
-    async def record_signup_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
-        """
-        Record a signup event (join or leave) for a draft session.
-        
-        Args:
-            session_id (str): The draft session ID
-            user_id (str): The Discord user ID
-            display_name (str): The user's display name
-            action (str): Either 'join' or 'leave'
-            guild_id (str): The Discord guild ID
-        """
-        # Generate unique UUID for this record
-        record_id = str(uuid.uuid4())
-        
-        signup_record = cls(
-            id=record_id,
-            session_id=session_id,
-            user_id=user_id,
-            user_display_name=display_name,
-            action=action,
-            timestamp=datetime.now(),
-            guild_id=guild_id
-        )
-        
-        async with db_session() as session:
-            session.add(signup_record)
-            await session.commit()
-
-    @classmethod
-    async def record_ready_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
-        """
-        Record a ready-check response event for a draft session.
-
-        Args:
-            session_id (str): The draft session ID
-            user_id (str): The Discord user ID
-            display_name (str): The user's display name
-            action (str): One of 'ready', 'not_ready', 'ready_timeout'
-            guild_id (str): The Discord guild ID
-        """
+    async def _record_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
+        """Persist a single history row. Shared by the signup and ready-check recorders."""
         record = cls(
             id=str(uuid.uuid4()),
             session_id=session_id,
@@ -77,3 +39,13 @@ class SignUpHistory(Base):
         async with db_session() as session:
             session.add(record)
             await session.commit()
+
+    @classmethod
+    async def record_signup_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
+        """Record a signup event (action: 'join' or 'leave') for a draft session."""
+        await cls._record_event(session_id, user_id, display_name, action, guild_id)
+
+    @classmethod
+    async def record_ready_event(cls, session_id: str, user_id: str, display_name: str, action: str, guild_id: str):
+        """Record a ready-check response event (action: 'ready', 'not_ready', 'ready_timeout')."""
+        await cls._record_event(session_id, user_id, display_name, action, guild_id)

--- a/ready_check.py
+++ b/ready_check.py
@@ -12,10 +12,18 @@ from session import get_draft_session
 
 PlayerStatus = Literal['ready', 'not_ready', 'no_response']
 
+# Minimum gap between successive lobby ready checks on the same draft. The Ready
+# Check button stays enabled; this debounce (not a disabled button) is what
+# prevents spamming multiple checks in quick succession.
+READY_CHECK_DEBOUNCE_SECONDS = 120
+
 # After this long with no response and no re-fire, a stalled lobby ready check is
-# auto-cleaned and a notice is posted. Must exceed the re-fire debounce in views.py
-# so a host can re-trigger (which cleans up silently) before this fires.
+# auto-cleaned and a notice is posted.
 READY_CHECK_TIMEOUT_SECONDS = 300
+
+# The timeout must outlast the debounce so a host can re-fire a stalled check
+# (which cleans up silently) before the timeout fires and posts a notice.
+assert READY_CHECK_TIMEOUT_SECONDS > READY_CHECK_DEBOUNCE_SECONDS
 
 
 class ReadyCheckSession:

--- a/utils.py
+++ b/utils.py
@@ -2232,24 +2232,28 @@ async def strip_stale_lobby_ready_checks(bot):
             stale_rc_sessions = result.scalars().all()
 
         for stale_session in stale_rc_sessions:
-            if stale_session.draft_channel_id:
-                channel = bot.get_channel(int(stale_session.draft_channel_id))
-                if channel:
-                    try:
-                        message = await channel.fetch_message(int(stale_session.lobby_ready_check_message_id))
-                        await message.edit(view=None)  # Strip Ready/Not-Ready buttons; keep the embed.
-                        logger.info(f"Stripped stale lobby ready-check buttons for session: {stale_session.session_id}")
-                    except discord.NotFound:
-                        logger.debug(f"Stale lobby ready-check message not found for session: {stale_session.session_id}")
-                    except Exception as e:
-                        logger.error(f"Failed to strip lobby ready-check buttons for {stale_session.session_id}: {e}")
+            if not stale_session.draft_channel_id:
+                continue
+            channel = bot.get_channel(int(stale_session.draft_channel_id))
+            if not channel:
+                continue
+            try:
+                message = await channel.fetch_message(int(stale_session.lobby_ready_check_message_id))
+                await message.edit(view=None)  # Strip Ready/Not-Ready buttons; keep the embed.
+                logger.info(f"Stripped stale lobby ready-check buttons for session: {stale_session.session_id}")
+            except discord.NotFound:
+                logger.debug(f"Stale lobby ready-check message not found for session: {stale_session.session_id}")
+            except Exception as e:
+                logger.error(f"Failed to strip lobby ready-check buttons for {stale_session.session_id}: {e}")
 
-            async with db_session.begin():
-                await db_session.execute(
-                    update(DraftSession)
-                    .where(DraftSession.session_id == stale_session.session_id)
-                    .values(lobby_ready_check_message_id=None)
-                )
+        # Clear every persisted id in one statement — the cleanup is self-healing,
+        # so clearing all rows at once (rather than one UPDATE per session) is correct.
+        async with db_session.begin():
+            await db_session.execute(
+                update(DraftSession)
+                .where(DraftSession.lobby_ready_check_message_id.isnot(None))
+                .values(lobby_ready_check_message_id=None)
+            )
 
 
 async def calculate_player_standings(limit=None):

--- a/views.py
+++ b/views.py
@@ -43,13 +43,9 @@ from loguru import logger
 from services.state_manager import state_manager
 from services.stake_service import calculate_and_store_stakes
 from preference_service import get_players_bet_capping_preferences
-
-# Minimum gap between successive lobby ready checks on the same draft. The Ready
-# Check button stays enabled; this debounce (not a disabled button) is what
-# prevents spamming multiple checks in quick succession.
-READY_CHECK_DEBOUNCE_SECONDS = 120
-
-
+# Debounce/timeout constants live in ready_check.py so the ordering invariant
+# between them is asserted in one place; re-exported here for the cooldown logic.
+from ready_check import READY_CHECK_DEBOUNCE_SECONDS
 
 
 class PersistentView(discord.ui.View):
@@ -763,8 +759,6 @@ class PersistentView(discord.ui.View):
 
         # Schedule the cooldown entry to be cleared once the window elapses.
         asyncio.create_task(self.remove_cooldown(self.draft_session_id))
-        
-
 
         user_id = str(interaction.user.id)
         if user_id not in session.sign_ups:


### PR DESCRIPTION
- Extract shared SignUpHistory._record_event; record_signup_event and
  record_ready_event now delegate to it instead of duplicating the body.
- Flatten strip_stale_lobby_ready_checks with early-continue and clear all
  persisted ids in one UPDATE instead of one transaction per session.
- Co-locate READY_CHECK_DEBOUNCE_SECONDS with READY_CHECK_TIMEOUT_SECONDS in
  ready_check.py and assert the timeout > debounce invariant at import.
- Drop stray whitespace in ready_check_callback's debounce block.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>