### PR TITLE
fix(results): post victory to the postable channel when names collide

### DIFF
--- a/tests/test_results_channel_resolution.py
+++ b/tests/test_results_channel_resolution.py
@@ -1,0 +1,58 @@
+"""Tests for utils.find_postable_results_channel — duplicate-named channel handling."""
+from utils import find_postable_results_channel
+
+
+class _Perms:
+    def __init__(self, view=True, send=True):
+        self.view_channel = view
+        self.send_messages = send
+
+
+class _Channel:
+    def __init__(self, cid, name, perms):
+        self.id = cid
+        self.name = name
+        self._perms = perms
+
+    def permissions_for(self, _member):
+        return self._perms
+
+
+class _Guild:
+    def __init__(self, channels):
+        self.text_channels = channels
+        self.me = object()
+
+
+def test_single_postable_channel_is_returned():
+    ch = _Channel(1, "league-draft-results", _Perms(view=True, send=True))
+    guild = _Guild([ch])
+    assert find_postable_results_channel(guild, "league-draft-results") is ch
+
+
+def test_no_matching_name_returns_none():
+    guild = _Guild([_Channel(1, "general", _Perms())])
+    assert find_postable_results_channel(guild, "league-draft-results") is None
+
+
+def test_prefers_postable_channel_among_duplicates():
+    # First by position is the stale one the bot can't post in; correct one is second.
+    stale = _Channel(1220, "league-draft-results", _Perms(view=False, send=False))
+    live = _Channel(1518, "league-draft-results", _Perms(view=True, send=True))
+    guild = _Guild([stale, live])
+    assert find_postable_results_channel(guild, "league-draft-results") is live
+
+
+def test_skips_channel_with_view_but_no_send():
+    view_only = _Channel(1, "league-draft-results", _Perms(view=True, send=False))
+    full = _Channel(2, "league-draft-results", _Perms(view=True, send=True))
+    guild = _Guild([view_only, full])
+    assert find_postable_results_channel(guild, "league-draft-results") is full
+
+
+def test_falls_back_to_first_match_when_none_postable():
+    a = _Channel(1, "league-draft-results", _Perms(view=False, send=False))
+    b = _Channel(2, "league-draft-results", _Perms(view=True, send=False))
+    guild = _Guild([a, b])
+    # No postable channel exists; preserve prior behavior (first match).
+    assert find_postable_results_channel(guild, "league-draft-results") is a

--- a/utils.py
+++ b/utils.py
@@ -635,6 +635,38 @@ async def update_draft_summary_message(bot, draft_session_id):
             print(f"Failed to update draft summary message: {e}")
 
 
+def find_postable_results_channel(guild, name):
+    """Resolve a results channel by name, tolerating duplicate-named channels.
+
+    A guild can end up with more than one channel sharing a name (e.g. a stale
+    'league-draft-results' the bot lost access to, alongside the live one). A
+    plain name lookup returns whichever comes first, which may be one the bot
+    can't post in (→ 403). Among all same-named channels, prefer one the bot can
+    actually post in (view + send). Falls back to the first match when none are
+    postable, so behavior is unchanged for the normal single-channel case.
+    """
+    matches = [c for c in guild.text_channels if c.name == name]
+    if not matches:
+        return None
+    postable = [
+        c for c in matches
+        if c.permissions_for(guild.me).view_channel
+        and c.permissions_for(guild.me).send_messages
+    ]
+    if postable:
+        if len(matches) > 1:
+            logger.info(
+                f"Multiple channels named '{name}' ({len(matches)}); posting to "
+                f"the one the bot can access (id={postable[0].id})."
+            )
+        return postable[0]
+    logger.warning(
+        f"No postable channel named '{name}' (found {len(matches)}); "
+        f"falling back to id={matches[0].id}, which the bot may not be able to post in."
+    )
+    return matches[0]
+
+
 async def check_and_post_victory_or_draw(bot, draft_session_id):
     draft_manager = DraftSetupManager.get_active_manager(draft_session_id)
     async with AsyncSessionLocal() as session:
@@ -839,7 +871,7 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
                             await post_or_update_victory_message(bot, session, draft_chat_channel, embeds, draft_session, 'victory_message_id_draft_chat', view=settle_view)
 
                         results_channel_name = "team-draft-results" if draft_session.session_type == "random" or draft_session.session_type == "staked" else "league-draft-results"
-                        results_channel = discord.utils.get(guild.text_channels, name=results_channel_name)
+                        results_channel = find_postable_results_channel(guild, results_channel_name)
                         if results_channel:
                             await post_or_update_victory_message(bot, session, results_channel, embeds, draft_session, 'victory_message_id_results_channel', view=settle_view)
 
@@ -898,7 +930,7 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
 
                     # Determine the correct results channel
                     results_channel_name = "team-draft-results" if draft_session.session_type == "random" or draft_session.session_type == "staked" else "league-draft-results"
-                    results_channel = discord.utils.get(guild.text_channels, name=results_channel_name)
+                    results_channel = find_postable_results_channel(guild, results_channel_name)
                     if results_channel:
                         await post_or_update_victory_message(bot, session, results_channel, embeds, draft_session, 'victory_message_id_results_channel', view=settle_view)
                     else:


### PR DESCRIPTION
The league/team results channel is resolved purely by name
(discord.utils.get by name), which returns the first match. When a guild has
more than one channel sharing that name (e.g. a stale 'league-draft-results'
the bot can no longer post in alongside the live one), it can resolve to the
unpostable one and the victory post fails with 403 Missing Access.

Add find_postable_results_channel: among all same-named channels, prefer one
the bot can actually view+send in; fall back to the first match when none are
postable (unchanged single-channel behavior). Wire it into both victory call
sites in check_and_post_victory_or_draw.

Note: only helps when the correct channel shares the same name; a
differently-named channel would need ID-based config instead.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>