### PR TITLE
docs: design for deferred draft log capture

### DIFF
--- a/alembic/versions/c4pture10g5at_add_logs_captured_at.py
+++ b/alembic/versions/c4pture10g5at_add_logs_captured_at.py
@@ -1,0 +1,27 @@
+"""add logs_captured_at to draft_sessions
+
+Revision ID: c4pture10g5at
+Revises: l0bby1rc2msg3
+Create Date: 2026-06-22 02:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c4pture10g5at'
+down_revision: Union[str, Sequence[str], None] = 'l0bby1rc2msg3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('draft_sessions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('logs_captured_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('draft_sessions', schema=None) as batch_op:
+        batch_op.drop_column('logs_captured_at')

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -46,6 +46,7 @@ class DraftSession(Base):
     swiss_matches = Column(JSON)
     draft_data = Column(JSON)
     data_received = Column(Boolean, default=False)
+    logs_captured_at = Column(DateTime)  # set when the log is captured to DB/Spaces (pre-publish)
     spaces_object_key = Column(String(256), nullable=True)  # DigitalOcean Spaces object path
     cube = Column(String(128))
     live_draft_message_id = Column(String(64))

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -788,6 +788,75 @@ class DraftSetupManager:
                 self.logger.error(f"Exception while fetching draft log data: {e}")
                 return False
 
+    async def capture_draft_log(self, draft_data):
+        """Persist the draft log as soon as the draft ends, WITHOUT posting it.
+
+        Saves the raw log to the DB (`draft_data`) and DigitalOcean Spaces (raw
+        JSON + per-player MagicProTools files via save_to_digitalocean_spaces),
+        records pack first-picks, and stamps `logs_captured_at`. Does NOT post the
+        Discord embed or set `data_received` — that happens at publish.
+
+        The raw log is always written to the DB so it is never lost (publish can
+        post from `draft_data` even if Spaces failed). `logs_captured_at` /
+        `pack_first_picks` are only set when the Spaces upload succeeds, so a
+        failed upload stays retryable (logs_captured_at stays NULL -> reconnect
+        re-captures). Idempotent: a session already captured is skipped.
+        """
+        if not draft_data:
+            self.logger.warning("capture_draft_log called with no draft_data; skipping")
+            return False
+        try:
+            # Idempotency guard.
+            async with db_session() as session:
+                existing = (await session.execute(
+                    select(DraftSession).filter(DraftSession.session_id == self.session_id)
+                )).scalar_one_or_none()
+                if existing is None:
+                    self.logger.warning(f"No draft session for {self.session_id}; skipping capture")
+                    return False
+                if existing.logs_captured_at is not None:
+                    self.logger.info(f"Draft log already captured for {self.session_id}; skipping")
+                    return True
+
+            # Upload raw JSON + per-player MPT files to Spaces.
+            upload_successful = await self.save_to_digitalocean_spaces(draft_data)
+
+            async with db_session() as session:
+                draft_session = (await session.execute(
+                    select(DraftSession).filter(DraftSession.session_id == self.session_id)
+                )).scalar_one_or_none()
+                if not draft_session:
+                    # Spaces upload may already have happened; only the DB write failed.
+                    self.logger.warning(f"No draft session for {self.session_id} (spaces_upload={upload_successful})")
+                    return False
+
+                # Always persist the raw log so the data is never lost.
+                draft_session.draft_data = draft_data
+
+                # Only mark fully captured when Spaces succeeded, so a failed
+                # upload stays retryable (logs_captured_at stays NULL).
+                if upload_successful:
+                    discord_user_pack_picks = {}
+                    if draft_session.sign_ups:
+                        discord_ids = list(draft_session.sign_ups.keys())
+                        sorted_users = sorted(
+                            draft_data["users"].items(),
+                            key=lambda item: item[1].get("seatNum", 999),
+                        )
+                        for idx, (draft_user_id, _) in enumerate(sorted_users):
+                            if idx < len(discord_ids):
+                                discord_user_pack_picks[discord_ids[idx]] = self.get_pack_first_picks(draft_data, draft_user_id)
+                    draft_session.pack_first_picks = discord_user_pack_picks
+                    draft_session.logs_captured_at = datetime.now()
+
+                await session.commit()
+
+            self.logger.info(f"Captured draft log for {self.session_id} (spaces_upload={upload_successful})")
+            return upload_successful
+        except Exception as e:
+            self.logger.exception(f"Error capturing draft log: {e}")
+            return False
+
     async def save_draft_log_data(self, draft_data):
         """Save draft log data to database and process it"""
         try:

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -43,6 +43,8 @@ SESSION_STAGE_PAIRINGS = "pairings"
 # Connection and retry settings
 MAX_USER_ID_LOOKUP_ATTEMPTS = 5  # Max attempts to find bot's userID in session
 USER_ID_LOOKUP_RETRY_DELAY = 0.5  # Seconds between userID lookup attempts
+DRAFT_LOG_WAIT_ATTEMPTS = 20    # Poll for the draftLog push after endDraft (10s total)
+DRAFT_LOG_WAIT_INTERVAL = 0.5   # Seconds between draftLog availability checks
 OWNERSHIP_CLAIM_TIMEOUT = 3.0  # Seconds to wait for ownership claim confirmation
 SOCKET_OPERATION_DELAY = 0.5  # Seconds between socket operations
 CONNECTION_CHECK_INTERVAL = 10  # Seconds between connection check iterations
@@ -296,6 +298,16 @@ class DraftSetupManager:
                                 await channel.send("Failed to create rooms and pairings. Check logs for details.")
             else:
                 self.logger.info("Could not find guild")
+            # Capture the draft log immediately so it is never lost (Slice 1).
+            # The draftLog push may land just after endDraft; wait briefly for it.
+            for _ in range(DRAFT_LOG_WAIT_ATTEMPTS):
+                if self.current_draft_log:
+                    break
+                await asyncio.sleep(DRAFT_LOG_WAIT_INTERVAL)
+            if self.current_draft_log:
+                await self.capture_draft_log(self.current_draft_log)
+            else:
+                self.logger.warning(f"No draft log available to capture for {self.session_id}")
 
     # Listen for Pause or Unpause (Resume)
     async def _on_draft_paused(self, data):

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -111,3 +111,42 @@ async def test_capture_spaces_failure_keeps_db_copy_without_stamp():
     embed.assert_not_called()
     assert ds.draft_data is not None        # raw log still saved (data safety)
     assert ds.logs_captured_at is None      # NOT stamped -> retryable
+
+
+@pytest.mark.asyncio
+async def test_on_end_draft_captures_log():
+    """A naturally-completed draft triggers capture_draft_log with the pushed log."""
+    m = _manager()
+    m.draft_cancelled = False
+    m.drafting = True
+    m.draftPaused = False
+    m.draft_channel_id = "999"
+    m.current_draft_log = _draft_data()
+    bot = MagicMock()
+    bot.get_guild.return_value = None      # skip the rooms-creation branch
+    bot.get_channel.return_value = None
+    with patch("services.draft_setup_manager.get_bot", return_value=bot), \
+         patch.object(DraftSetupManager, "capture_draft_log", AsyncMock()) as cap:
+        await m._on_end_draft()
+    cap.assert_awaited_once_with(m.current_draft_log)
+
+
+@pytest.mark.asyncio
+async def test_on_end_draft_warns_when_no_log_arrives():
+    """If the draftLog push never lands, the wait loop times out, logs a warning,
+    and does NOT call capture (no data to capture)."""
+    from services.draft_setup_manager import DRAFT_LOG_WAIT_ATTEMPTS
+    m = _manager()
+    m.draft_cancelled = False
+    m.draft_channel_id = "999"
+    m.current_draft_log = None
+    bot = MagicMock()
+    bot.get_guild.return_value = None
+    bot.get_channel.return_value = None
+    with patch("services.draft_setup_manager.get_bot", return_value=bot), \
+         patch("services.draft_setup_manager.asyncio.sleep", AsyncMock()) as sleep, \
+         patch.object(DraftSetupManager, "capture_draft_log", AsyncMock()) as cap:
+        await m._on_end_draft()
+    cap.assert_not_awaited()
+    assert sleep.await_count == DRAFT_LOG_WAIT_ATTEMPTS
+    m.logger.warning.assert_called()

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -1,0 +1,113 @@
+"""Unit tests for DraftSetupManager.capture_draft_log (Slice 1)."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.draft_setup_manager import DraftSetupManager
+
+
+def _manager():
+    """A DraftSetupManager without running __init__ (skips socket setup)."""
+    m = DraftSetupManager.__new__(DraftSetupManager)
+    m.session_id = "sid"
+    m.draft_id = "ABC123"
+    m.cube_id = "MyCube"
+    m.session_type = "premade"
+    m.guild_id = "42"
+    m.logger = MagicMock()
+    return m
+
+
+def _draft_data():
+    return {
+        "sessionID": "DBABC123",
+        "time": 1700000000000,
+        "users": {
+            "u1": {"userName": "Alice", "seatNum": 0, "picks": [{"booster": [1]}]},
+            "u2": {"userName": "Bob", "seatNum": 1, "picks": [{"booster": [2]}]},
+        },
+    }
+
+
+def _mock_db_session(draft_session):
+    """Patch target for `db_session()` -> async ctx mgr yielding a session whose
+    execute().scalar_one_or_none() returns `draft_session`."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = draft_session
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=ctx), session
+
+
+@pytest.mark.asyncio
+async def test_capture_stores_data_and_stamps_without_publishing():
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", sign_ups={"d1": "Alice", "d2": "Bob"},
+                         draft_data=None, pack_first_picks=None, logs_captured_at=None,
+                         data_received=False)
+    db_factory, session = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=True)) as spaces, \
+         patch.object(DraftSetupManager, "get_pack_first_picks", MagicMock(return_value={})), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.capture_draft_log(_draft_data())
+
+    assert ok is True
+    spaces.assert_awaited_once()
+    embed.assert_not_called()
+    assert ds.data_received is False
+    assert ds.draft_data is not None
+    assert ds.logs_captured_at is not None
+    session.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capture_is_idempotent():
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", sign_ups={}, draft_data=None,
+                         pack_first_picks=None, logs_captured_at=datetime.now(),
+                         data_received=False)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=True)) as spaces:
+        ok = await m.capture_draft_log(_draft_data())
+
+    assert ok is True
+    spaces.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_capture_no_data_is_noop():
+    m = _manager()
+    with patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock()) as spaces:
+        ok = await m.capture_draft_log(None)
+    assert ok is False
+    spaces.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_capture_spaces_failure_keeps_db_copy_without_stamp():
+    """If the Spaces upload fails, the raw log is still saved to the DB, but
+    logs_captured_at stays NULL so the capture is retryable."""
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", sign_ups={"d1": "Alice", "d2": "Bob"},
+                         draft_data=None, pack_first_picks=None, logs_captured_at=None,
+                         data_received=False)
+    db_factory, session = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=False)) as spaces, \
+         patch.object(DraftSetupManager, "get_pack_first_picks", MagicMock(return_value={})), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.capture_draft_log(_draft_data())
+
+    assert ok is False                      # upload failed
+    spaces.assert_awaited_once()
+    embed.assert_not_called()
+    assert ds.draft_data is not None        # raw log still saved (data safety)
+    assert ds.logs_captured_at is None      # NOT stamped -> retryable


### PR DESCRIPTION
docs: design for deferred draft log capture

Capture the Draftmancer log when the draft ends (private, to DB + Spaces),
decoupled from posting which stays gated on match completion. Fixes premade
drafts losing logs because collection was gated on victory + a live manager.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

docs: vertical-slice implementation plan for deferred draft log capture

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

docs: merge publish/trigger slices, drop data_received audit slice

Slice 2+3 combined (timer + trigger rewiring as one consistency change);
data_received consumer audit resolved inline (only readers mean 'posted',
which the design preserves) rather than as a slice.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: add logs_captured_at column for deferred draft log capture

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: add capture_draft_log (save log to DB+Spaces without posting)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: capture draft log on draft-end (_on_end_draft)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>