### PR TITLE
feat: add publish_draft_log (post captured log, optional release)

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -869,6 +869,63 @@ class DraftSetupManager:
             self.logger.exception(f"Error capturing draft log: {e}")
             return False
 
+    async def publish_draft_log(self, release=False):
+        """Post the captured draft log to Discord and mark it published.
+
+        Reads the already-captured `draft_data` from the DB (capture runs at
+        draft-end), posts the MagicProTools embed, and sets `data_received`.
+        Works without a live socket — it operates on the saved data. Idempotent:
+        a session already published (`data_received`) is skipped.
+
+        When `release=True` (manual early release) and the socket is still
+        connected, the Draftmancer log is unlocked first via `shareDraftLog`; the
+        timer-driven path does not release (Draftmancer auto-unlocks on its own).
+        """
+        try:
+            async with db_session() as session:
+                draft_session = (await session.execute(
+                    select(DraftSession).filter(DraftSession.session_id == self.session_id)
+                )).scalar_one_or_none()
+                if not draft_session:
+                    self.logger.warning(f"No draft session for {self.session_id}; cannot publish")
+                    return False
+                if draft_session.data_received:
+                    self.logger.info(f"Draft log already published for {self.session_id}; skipping")
+                    return True
+                draft_data = draft_session.draft_data
+
+            if not draft_data:
+                self.logger.warning(f"No captured draft_data for {self.session_id}; nothing to publish")
+                return False
+
+            # Manual early release: unlock the Draftmancer log now (best-effort).
+            if release and self.socket_client.connected and self.current_draft_log:
+                try:
+                    log_copy = self.current_draft_log.copy()
+                    log_copy['delayed'] = False
+                    await self.socket_client.emit('shareDraftLog', log_copy)
+                    self.logger.info(f"Released Draftmancer log for {self.session_id} (manual early)")
+                except Exception as e:
+                    self.logger.error(f"Failed to release Draftmancer log for {self.session_id}: {e}")
+
+            # Post the MagicProTools embed/links to Discord.
+            if self.guild_id:
+                await self.send_magicprotools_embed(draft_data)
+
+            async with db_session() as session:
+                draft_session = (await session.execute(
+                    select(DraftSession).filter(DraftSession.session_id == self.session_id)
+                )).scalar_one_or_none()
+                if draft_session:
+                    draft_session.data_received = True
+                    await session.commit()
+
+            self.logger.info(f"Published draft log for {self.session_id} (release={release})")
+            return True
+        except Exception as e:
+            self.logger.exception(f"Error publishing draft log: {e}")
+            return False
+
     async def save_draft_log_data(self, draft_data):
         """Save draft log data to database and process it"""
         try:

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -213,10 +213,6 @@ class DraftSetupManager:
         self.removing_unexpected_user = False
         self.timeout_message_id = None
 
-        # Draft logs variables
-        self.logs_collection_attempted = False
-        self.logs_collection_in_progress = False
-        self.logs_collection_success = False
         self.session_type = "team"  # Default to team drafts
 
         
@@ -250,10 +246,6 @@ class DraftSetupManager:
         self.session_users_received = False
         self.ready_check_in_progress = False
         self.settings_updated = False
-        self.log_collection_task = None
-        self.log_collection_retry_count = 0 
-        self.MAX_LOG_COLLECTION_RETRIES = 5
-        self.log_release_vote_active = False
         
     # Add a listener to capture draft logs
     async def _on_draft_log(self, draft_log):
@@ -729,81 +721,6 @@ class DraftSetupManager:
             self.logger.error(f"Error connecting to new session: {e}")
             return False
 
-    async def collect_draft_logs(self):
-        """Collect draft logs and process them"""
-        if self.logs_collection_attempted or self.logs_collection_in_progress:
-            self.logger.info("Log collection already attempted or in progress, skipping")
-            return
-        
-        self.logs_collection_in_progress = True
-        self.logger.info("Starting draft log collection")
-        
-        try:
-            # Get session type information from database
-            await self.fetch_draft_info()
-            
-            # Attempt to fetch draft log data
-            for attempt in range(36):  # Try up to 36 times (3 hours)
-                data_fetched = await self.fetch_draft_log_data()
-                if data_fetched:
-                    self.logs_collection_success = True
-                    self.logger.info(f"Successfully collected draft logs on attempt {attempt+1}")
-                    break
-                
-                self.logger.info(f"Draft log data not available on attempt {attempt+1}, waiting 5 minutes before retrying")
-                await asyncio.sleep(300)  # Wait 5 minutes before retrying
-            
-            if not self.logs_collection_success:
-                self.logger.warning("Failed to collect draft logs after multiple attempts")
-        
-        except Exception as e:
-            self.logger.exception(f"Error collecting draft logs: {e}")
-        
-        finally:
-            self.logs_collection_attempted = True
-            self.logs_collection_in_progress = False
-            
-            # If we collected logs successfully, check victory status before disconnect
-            if self.logs_collection_success:
-                self.logger.info("Log collection successful, checking victory status before disconnect")
-                await self._handle_victory_aware_disconnect()
-            else:
-                self.logger.info("Log collection failed, bot will remain connected")
-
-    async def fetch_draft_log_data(self):
-        """Fetch draft log data from the Draftmancer API"""
-        base_url = get_draftmancer_base_url()
-        url = f"{base_url}/getDraftLog/DB{self.draft_id}"
-        
-        self.logger.info(f"Fetching draft log data from {url}")
-        
-        async with aiohttp.ClientSession() as session:
-            try:
-                async with session.get(url) as response:
-                    if response.status == 200:
-                        draft_data = await response.json()
-                        
-                        # Check if we have user picks
-                        has_picks = False
-                        for user_data in draft_data.get("users", {}).values():
-                            if user_data.get("picks") and len(user_data.get("picks")) > 0:
-                                has_picks = True
-                                break
-                        
-                        if not has_picks:
-                            self.logger.info(f"Draft log data for {self.draft_id} has no picks yet")
-                            return False
-                        
-                        # Save the data
-                        await self.save_draft_log_data(draft_data)
-                        return True
-                    else:
-                        self.logger.warning(f"Failed to fetch draft log data: status code {response.status}")
-                        return False
-            except Exception as e:
-                self.logger.error(f"Exception while fetching draft log data: {e}")
-                return False
-
     async def capture_draft_log(self, draft_data):
         """Persist the draft log as soon as the draft ends, WITHOUT posting it.
 
@@ -939,73 +856,6 @@ class DraftSetupManager:
             await self.publish_draft_log()
         except Exception as e:
             self.logger.exception(f"Error in scheduled publish for {self.session_id}: {e}")
-
-    async def save_draft_log_data(self, draft_data):
-        """Save draft log data to database and process it"""
-        try:
-
-            # Save to DigitalOcean Spaces
-            upload_successful = await self.save_to_digitalocean_spaces(draft_data)
-            
-            # Extract and store first picks for each user and pack
-            draftmancer_user_picks = {}
-            for user_id, user_data in draft_data["users"].items():
-                user_pack_picks = self.get_pack_first_picks(draft_data, user_id)
-                draftmancer_user_picks[user_id] = user_pack_picks
-            
-            # We need to convert Draftmancer user IDs to Discord user IDs
-            discord_user_pack_picks = {}
-            
-            # Use a fresh database session for this operation
-            async with db_session() as session:
-                # Get the draft session within this session context
-                stmt = select(DraftSession).filter(DraftSession.session_id == self.session_id)
-                result = await session.execute(stmt)
-                draft_session = result.scalar_one_or_none()
-                
-                if not draft_session:
-                    self.logger.warning(f"No draft session found for session_id: {self.session_id}")
-                    return False
-
-                # Get Discord IDs from sign_ups
-                if draft_session.sign_ups:
-                    # Get list of Discord user IDs from sign_ups
-                    discord_ids = list(draft_session.sign_ups.keys())
-                    
-                    # Sort users by seat number
-                    sorted_users = sorted(
-                        [(user_id, user_data) for user_id, user_data in draft_data["users"].items()],
-                        key=lambda item: item[1].get("seatNum", 999)
-                    )
-                    
-                    # Map Draftmancer user IDs to Discord user IDs based on draft seat order
-                    for idx, (draft_user_id, _) in enumerate(sorted_users):
-                        if idx < len(discord_ids):
-                            discord_id = discord_ids[idx]
-                            if draft_user_id in draftmancer_user_picks:
-                                discord_user_pack_picks[discord_id] = draftmancer_user_picks[draft_user_id]
-                
-                # Update draft session directly in this session context
-                if upload_successful:
-                    draft_session.data_received = True
-                    draft_session.pack_first_picks = discord_user_pack_picks
-                    self.logger.info(f"Stored first picks for {len(discord_user_pack_picks)} users with Discord IDs as keys")
-                else:
-                    draft_session.draft_data = draft_data
-                    self.logger.info(f"Draft log data saved in database for {self.draft_id}")
-                
-                # Commit changes
-                await session.commit()
-            
-            # Send MagicProTools embed to Discord if bot is available
-            if self.guild_id:
-                await self.send_magicprotools_embed(draft_data)
-            
-            return upload_successful
-                
-        except Exception as e:
-            self.logger.exception(f"Error saving draft log data: {e}")
-            return False
 
     async def save_to_digitalocean_spaces(self, draft_data):
         """Upload draft log data to DigitalOcean Spaces"""
@@ -1979,9 +1829,6 @@ class DraftSetupManager:
         """Mark that the draft is being cancelled manually, skip log collection"""
         self.logger.info(f"Marking draft {self.draft_id} as manually cancelled")
         self.draft_cancelled = True
-        # Set these flags to prevent log collection attempts for cancelled drafts
-        self.logs_collection_attempted = True
-        self.logs_collection_success = False
         
     async def disconnect_safely(self):
         """
@@ -2548,71 +2395,14 @@ class DraftSetupManager:
     # NOTE: connect_with_retry is now handled by self.socket_client.connect_with_retry()
 
     async def manually_unlock_draft_logs(self):
-        """
-        Manually unlock draft logs for the currently connected Draftmancer session.
-        """
-        try:
-            self.logger.info("Attempting to unlock draft logs for the connected Draftmancer session")
-            
-            # First, try to request the current draft log if we don't have it
-            if not self.current_draft_log:
-                self.logger.info("No draft log captured yet, attempting to request it")
-                
-                # Try to get the current draft log by requesting it
-                callback_future = asyncio.Future()
-                
-                def on_draft_log_response(draft_log):
-                    if draft_log:
-                        self.logger.info("Received draft log from request")
-                        self.current_draft_log = draft_log
-                    callback_future.set_result(draft_log is not None)
-                
-                # Request the current draft log
-                await self.socket_client.emit('getCurrentDraftLog', callback=on_draft_log_response)
-                
-                # Wait for response with timeout
-                try:
-                    success = await asyncio.wait_for(callback_future, timeout=5)
-                    if not success:
-                        self.logger.warning("Failed to get current draft log")
-                except asyncio.TimeoutError:
-                    self.logger.warning("Timeout waiting for draft log")
-            
-            # Now try to unlock the logs
-            if self.current_draft_log:
-                # Create a copy of the log to modify
-                draft_log = self.current_draft_log.copy()
-                
-                # Set delayed to false to make it public
-                draft_log['delayed'] = False
-                
-                # Emit the modified log
-                self.logger.info(f"Sharing draft log with delayed=false")
-                await self.socket_client.emit('shareDraftLog', draft_log)
-                
-                self.logger.info("Logs unlocked using captured draft log")
-            else:
-                # Fallback: try to create a minimal log with just the essential information
-                self.logger.warning("No draft log available, further improvement required")
-            
-            # Continue with log collection as before
-            if not self.logs_collection_attempted and not self.logs_collection_in_progress:
-                asyncio.create_task(self.schedule_log_collection(60))
-            
-            return True
-        except Exception as e:
-            self.logger.error(f"Error unlocking draft logs: {e}")
-            return False
+        """Manually release + publish the draft log now (early, before the timer).
 
-    async def schedule_log_collection(self, delay_seconds):
-        """Schedule log collection after a delay to ensure all data is available"""
-        try:
-            self.logger.info(f"Scheduling log collection in {delay_seconds} seconds")
-            await asyncio.sleep(delay_seconds)
-            await self.collect_draft_logs()
-        except Exception as e:
-            self.logger.exception(f"Error scheduling log collection: {e}")
-                
+        Used by the manual 'release logs' vote. Delegates to publish_draft_log
+        with release=True, which unlocks the Draftmancer log (shareDraftLog) when
+        still connected and posts the captured log to Discord.
+        """
+        return await self.publish_draft_log(release=True)
+
     async def update_cube(self, new_cube_id: str) -> bool:
         """
         Updates the cube ID and imports the new cube.

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -11,7 +11,7 @@ import urllib.parse
 import discord
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
-from config import get_draftmancer_websocket_url, get_draftmancer_base_url, get_draftmancer_session_url
+from config import get_draftmancer_websocket_url, get_draftmancer_base_url, get_draftmancer_session_url, is_test_mode
 from database.db_session import db_session
 from models.draft_session import DraftSession
 from models.match import MatchResult
@@ -45,7 +45,17 @@ MAX_USER_ID_LOOKUP_ATTEMPTS = 5  # Max attempts to find bot's userID in session
 USER_ID_LOOKUP_RETRY_DELAY = 0.5  # Seconds between userID lookup attempts
 DRAFT_LOG_WAIT_ATTEMPTS = 20    # Poll for the draftLog push after endDraft (10s total)
 DRAFT_LOG_WAIT_INTERVAL = 0.5   # Seconds between draftLog availability checks
-PUBLISH_DELAY_SECONDS = 180 * 60   # Post logs when Draftmancer auto-unlocks them (matches setDraftLogUnlockTimer(180))
+# Draft-setup timings. In test mode (TEST_MODE=true) these are shortened so an
+# end-to-end draft completes and publishes in seconds; production uses the real
+# durations. PUBLISH_DELAY_SECONDS aligns with the Draftmancer unlock timer in prod.
+if is_test_mode():
+    PUBLISH_DELAY_SECONDS = 30            # publish ~30s after draft-end (prod: 3h)
+    DRAFT_PICK_TIMER_SECONDS = 3          # fast auto-pick so test drafts finish quickly (prod: 60s)
+    DRAFT_LOG_UNLOCK_TIMER_MINUTES = 1    # Draftmancer public unlock (prod: 180 min)
+else:
+    PUBLISH_DELAY_SECONDS = 180 * 60      # post logs when Draftmancer auto-unlocks (matches setDraftLogUnlockTimer)
+    DRAFT_PICK_TIMER_SECONDS = 60
+    DRAFT_LOG_UNLOCK_TIMER_MINUTES = 180
 OWNERSHIP_CLAIM_TIMEOUT = 3.0  # Seconds to wait for ownership claim confirmation
 SOCKET_OPERATION_DELAY = 0.5  # Seconds between socket operations
 CONNECTION_CHECK_INTERVAL = 10  # Seconds between connection check iterations
@@ -2004,11 +2014,11 @@ class DraftSetupManager:
             self.logger.debug("Updating draft settings...")
             await self.socket_client.emit('setColorBalance', False)
             await self.socket_client.emit('setMaxPlayers', 10)
-            await self.socket_client.emit('setDraftLogUnlockTimer', 180)
+            await self.socket_client.emit('setDraftLogUnlockTimer', DRAFT_LOG_UNLOCK_TIMER_MINUTES)
             await self.socket_client.emit('setDraftLogRecipients', "delayed")
             await self.socket_client.emit('setPersonalLogs', True)
             await self.socket_client.emit('teamDraft', True)  # Added teamDraft setting
-            await self.socket_client.emit('setPickTimer', 60)
+            await self.socket_client.emit('setPickTimer', DRAFT_PICK_TIMER_SECONDS)
             await self.socket_client.emit('setOwnerIsPlayer', False)
             await self.socket_client.emit('boostersPerPlayer', self.packs_per_player)
             await self.socket_client.emit('cardsPerBooster', self.cards_per_pack)

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -45,6 +45,7 @@ MAX_USER_ID_LOOKUP_ATTEMPTS = 5  # Max attempts to find bot's userID in session
 USER_ID_LOOKUP_RETRY_DELAY = 0.5  # Seconds between userID lookup attempts
 DRAFT_LOG_WAIT_ATTEMPTS = 20    # Poll for the draftLog push after endDraft (10s total)
 DRAFT_LOG_WAIT_INTERVAL = 0.5   # Seconds between draftLog availability checks
+PUBLISH_DELAY_SECONDS = 180 * 60   # Post logs when Draftmancer auto-unlocks them (matches setDraftLogUnlockTimer(180))
 OWNERSHIP_CLAIM_TIMEOUT = 3.0  # Seconds to wait for ownership claim confirmation
 SOCKET_OPERATION_DELAY = 0.5  # Seconds between socket operations
 CONNECTION_CHECK_INTERVAL = 10  # Seconds between connection check iterations
@@ -308,6 +309,9 @@ class DraftSetupManager:
                 await self.capture_draft_log(self.current_draft_log)
             else:
                 self.logger.warning(f"No draft log available to capture for {self.session_id}")
+            # Schedule the publish (post links) for when Draftmancer makes the log
+            # public (~180 min). Posting is decoupled from match completion.
+            asyncio.create_task(self.schedule_publish(PUBLISH_DELAY_SECONDS))
 
     # Listen for Pause or Unpause (Resume)
     async def _on_draft_paused(self, data):
@@ -925,6 +929,16 @@ class DraftSetupManager:
         except Exception as e:
             self.logger.exception(f"Error publishing draft log: {e}")
             return False
+
+    async def schedule_publish(self, delay_seconds):
+        """Wait `delay_seconds`, then publish the captured log (the single
+        ~180-min timer aligned to Draftmancer's auto-unlock)."""
+        try:
+            self.logger.info(f"Scheduled publish in {delay_seconds}s for {self.session_id}")
+            await asyncio.sleep(delay_seconds)
+            await self.publish_draft_log()
+        except Exception as e:
+            self.logger.exception(f"Error in scheduled publish for {self.session_id}: {e}")
 
     async def save_draft_log_data(self, draft_data):
         """Save draft log data to database and process it"""

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -258,3 +258,12 @@ async def test_on_end_draft_schedules_publish():
          patch("services.draft_setup_manager.asyncio.create_task", _stub_create_task):
         await m._on_end_draft()
     sched.assert_called_once_with(PUBLISH_DELAY_SECONDS)
+
+
+@pytest.mark.asyncio
+async def test_manually_unlock_delegates_to_publish_with_release():
+    m = _manager()
+    with patch.object(DraftSetupManager, "publish_draft_log", AsyncMock(return_value=True)) as pub:
+        result = await m.manually_unlock_draft_logs()
+    assert result is True
+    pub.assert_awaited_once_with(release=True)

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -1,4 +1,5 @@
 """Unit tests for DraftSetupManager.capture_draft_log (Slice 1)."""
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -223,3 +224,37 @@ async def test_publish_release_skips_when_disconnected():
     m.socket_client.emit.assert_not_called()
     embed.assert_awaited_once()
     assert ds.data_received is True
+
+
+@pytest.mark.asyncio
+async def test_schedule_publish_calls_publish_after_delay():
+    m = _manager()
+    with patch("services.draft_setup_manager.asyncio.sleep", AsyncMock()) as sleep, \
+         patch.object(DraftSetupManager, "publish_draft_log", AsyncMock()) as pub:
+        await m.schedule_publish(123)
+    sleep.assert_awaited_once_with(123)
+    pub.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_end_draft_schedules_publish():
+    from services.draft_setup_manager import PUBLISH_DELAY_SECONDS
+    m = _manager()
+    m.draft_cancelled = False
+    m.draft_channel_id = "999"
+    m.current_draft_log = _draft_data()
+    bot = MagicMock()
+    bot.get_guild.return_value = None
+    bot.get_channel.return_value = None
+
+    def _stub_create_task(coro):
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        return MagicMock()
+
+    with patch("services.draft_setup_manager.get_bot", return_value=bot), \
+         patch.object(DraftSetupManager, "capture_draft_log", AsyncMock()), \
+         patch.object(DraftSetupManager, "schedule_publish", MagicMock(return_value=None)) as sched, \
+         patch("services.draft_setup_manager.asyncio.create_task", _stub_create_task):
+        await m._on_end_draft()
+    sched.assert_called_once_with(PUBLISH_DELAY_SECONDS)

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -150,3 +150,76 @@ async def test_on_end_draft_warns_when_no_log_arrives():
     cap.assert_not_awaited()
     assert sleep.await_count == DRAFT_LOG_WAIT_ATTEMPTS
     m.logger.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_posts_and_marks_received():
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", draft_data=_draft_data(), data_received=False)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.publish_draft_log()
+    assert ok is True
+    embed.assert_awaited_once()
+    assert ds.data_received is True
+
+
+@pytest.mark.asyncio
+async def test_publish_idempotent_when_already_received():
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", draft_data=_draft_data(), data_received=True)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.publish_draft_log()
+    assert ok is True
+    embed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_no_data_returns_false():
+    m = _manager()
+    ds = SimpleNamespace(session_id="sid", draft_data=None, data_received=False)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.publish_draft_log()
+    assert ok is False
+    embed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_release_emits_sharedraftlog_when_connected():
+    m = _manager()
+    m.current_draft_log = _draft_data()
+    m.socket_client = MagicMock()
+    m.socket_client.connected = True
+    m.socket_client.emit = AsyncMock()
+    ds = SimpleNamespace(session_id="sid", draft_data=_draft_data(), data_received=False)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()):
+        ok = await m.publish_draft_log(release=True)
+    assert ok is True
+    m.socket_client.emit.assert_awaited_once()
+    assert m.socket_client.emit.await_args.args[0] == "shareDraftLog"
+    assert m.socket_client.emit.await_args.args[1].get("delayed") is False
+
+
+@pytest.mark.asyncio
+async def test_publish_release_skips_when_disconnected():
+    m = _manager()
+    m.current_draft_log = _draft_data()
+    m.socket_client = MagicMock()
+    m.socket_client.connected = False
+    m.socket_client.emit = AsyncMock()
+    ds = SimpleNamespace(session_id="sid", draft_data=_draft_data(), data_received=False)
+    db_factory, _ = _mock_db_session(ds)
+    with patch("services.draft_setup_manager.db_session", db_factory), \
+         patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
+        ok = await m.publish_draft_log(release=True)
+    assert ok is True
+    m.socket_client.emit.assert_not_called()
+    embed.assert_awaited_once()
+    assert ds.data_received is True

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,6 @@ from quiz_views_module.quiz_views import QuizPublicView
 from services.draft_analysis import DraftAnalysis
 from cogs.leaderboard import create_leaderboard_embed, TimeframeView
 from draft_organization.tournament import Tournament
-from services.draft_setup_manager import DraftSetupManager
 from services.debt_service import create_debt_entries_from_stakes, get_guild_debt_rows, get_balance_with
 from debt_views import SettleDebtsView
 from debt_views.settle_views import PublicSettleDebtsView
@@ -668,7 +667,6 @@ def find_postable_results_channel(guild, name):
 
 
 async def check_and_post_victory_or_draw(bot, draft_session_id):
-    draft_manager = DraftSetupManager.get_active_manager(draft_session_id)
     async with AsyncSessionLocal() as session:
         async with session.begin():
             draft_session = await get_draft_session(draft_session_id)
@@ -936,15 +934,9 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
                     else:
                         print(f"Results channel '{results_channel_name}' not found.")
 
-                    # Unlock logs for posting
-                    if draft_manager:
-                        logger.info(f"Victory/draw determined - unlocking logs for session {draft_session_id}")
-                        await draft_manager.manually_unlock_draft_logs()
-
-                        # Small delay to allow logs to process
-                        await asyncio.sleep(2)
-                    else:
-                        logger.warning(f"No active manager found for session {draft_session_id} - logs may remain locked")
+                    # Logs are posted by the deferred-capture publish timer (~180 min,
+                    # set at draft-end) or the manual release vote — no longer unlocked
+                    # at victory. See docs/superpowers/specs/2026-06-22-deferred-draft-log-capture-design.md
 
                     # Update draft win streaks (Order of the White Lotus) and collect extension info
                     draft_streak_extensions = {}


### PR DESCRIPTION
feat: add publish_draft_log (post captured log, optional release)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: schedule publish on a single 180-min timer at draft-end

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: drive posting via publish timer + manual release; drop dead log chain

manually_unlock_draft_logs now delegates to publish_draft_log(release=True) and
the victory-path unlock is removed from utils.py. That orphaned the old
schedule_log_collection -> collect_draft_logs -> fetch_draft_log_data ->
save_draft_log_data chain in draft_setup_manager.py, removed here so the slice
leaves no dead code. (datacollections.py keeps its own copies for the legacy
reconnect path.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

feat: test-mode-gated draft-setup durations for fast e2e testing

In TEST_MODE, shorten the publish delay (30s), Draftmancer pick timer (3s),
and draft-log unlock timer (1 min) so an end-to-end draft completes and
publishes in seconds. Production keeps the real durations (3h / 60s / 180 min).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>