### PR TITLE
tournament-refresh-standings

### DIFF
--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -491,6 +491,26 @@ class TournamentCog(commands.Cog):
             tournament.standings_channel_id = str(message.channel.id)
             tournament.standings_message_id = str(message.id)
 
+    @tournament.command(name="refresh_standings", description="Admin: re-render the standings message from current results")
+    @has_bot_manager_role()
+    async def refresh_standings(self, ctx):
+        if not await self._check_enabled(ctx):
+            return
+        await ctx.defer(ephemeral=True)
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no active tournament.", ephemeral=True)
+                return
+            tournament_id = tournament.id
+            has_message = tournament.standings_message_id is not None
+        if has_message:
+            await update_standings_message(self.bot, tournament_id)
+        else:
+            await self._post_standings(ctx, tournament_id)
+        logger.info(f"Standings message refreshed for tournament {tournament_id} by {ctx.author.id}")
+        await ctx.followup.send("✅ Standings refreshed.", ephemeral=True)
+
     @tournament.command(name="status", description="Show the current tournament and its teams")
     async def status(self, ctx):
         if not await self._check_enabled(ctx):

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -19,14 +19,14 @@ def test_tournament_group_has_slice_one_and_two_commands():
     subcommands = {cmd.name for cmd in TournamentCog.tournament.subcommands}
     assert {"create", "register", "status",
             "start", "set_result", "next_round", "finish",
-            "add_team", "remove_team", "add_match"} <= subcommands
+            "add_team", "remove_team", "add_match", "refresh_standings"} <= subcommands
 
 
 def test_admin_commands_are_gated_by_bot_manager_check():
     from cogs.tournament_commands import TournamentCog
 
     for command in ("create", "start", "set_result", "next_round", "finish",
-                    "add_team", "remove_team", "add_match"):
+                    "add_team", "remove_team", "add_match", "refresh_standings"):
         assert is_bot_manager in getattr(TournamentCog, command).checks, command
 
 


### PR DESCRIPTION
Re-renders the standings message from current participant results: edits
the existing standings message in place, or posts a fresh one if it was
never posted. Useful when standings drift from the live data — e.g. after
a result is recorded out-of-band (backfill) without going through a command
that calls update_standings_message (set_result/finish/next_round).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>