### PR TITLE
feat(tournament): self-heal Play button into a recorded line on a played match

### DIFF
--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -45,6 +45,11 @@ def _cube_picker_for_match(interaction, match_id, a_name, b_name):
     )
 
 
+def _recorded_result_line(a_name, b_name, a_wins, b_wins):
+    """The 'result recorded' line that replaces a played match's Play button."""
+    return f"✅ Result recorded: **{a_name}** {a_wins}–{b_wins} **{b_name}**"
+
+
 async def launch_tournament_match(interaction, match_id):
     """'Play this match' button: run the draft lobby in a per-match thread.
 
@@ -59,11 +64,28 @@ async def launch_tournament_match(interaction, match_id):
             await interaction.response.send_message("This match no longer exists.", ephemeral=True)
             return
         if match.team_a_wins is not None:
-            await interaction.response.send_message(
-                "This match already has a recorded result and can't be replayed. "
-                "Ask an admin if it needs correcting.",
-                ephemeral=True,
-            )
+            # Self-heal the stale button: replace it on the public pairing message
+            # with a recorded-result line, so it's gone for everyone (not just an
+            # ephemeral notice to the clicker).
+            part_a = await session.get(TournamentParticipant, match.team_a_participant_id)
+            part_b = await session.get(TournamentParticipant, match.team_b_participant_id)
+            result_line = _recorded_result_line(
+                part_a.team_name, part_b.team_name, match.team_a_wins, match.team_b_wins)
+            edited = False
+            if interaction.message is not None:
+                try:
+                    existing = interaction.message.content or ""
+                    new_content = f"{existing}\n{result_line}" if existing else result_line
+                    await interaction.response.edit_message(content=new_content, view=None)
+                    edited = True
+                except discord.HTTPException:
+                    edited = False
+            if not edited:
+                await interaction.response.send_message(
+                    "This match already has a recorded result and can't be replayed. "
+                    "Ask an admin if it needs correcting.",
+                    ephemeral=True,
+                )
             return
         part_a = await session.get(TournamentParticipant, match.team_a_participant_id)
         part_b = await session.get(TournamentParticipant, match.team_b_participant_id)

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -35,3 +35,10 @@ def test_register_and_status_are_open_to_everyone():
 
     assert is_bot_manager not in TournamentCog.register.checks
     assert is_bot_manager not in TournamentCog.status.checks
+
+
+def test_recorded_result_line_formats_score():
+    from cogs.tournament_commands import _recorded_result_line
+
+    line = _recorded_result_line("Latecomers", "Strixhaven Dropouts", 5, 4)
+    assert line == "✅ Result recorded: **Latecomers** 5–4 **Strixhaven Dropouts**"

--- a/tests/test_tournament_linked_draft.py
+++ b/tests/test_tournament_linked_draft.py
@@ -309,12 +309,17 @@ async def test_launch_refuses_already_reported_match(test_db):
             await inner.commit()
 
     interaction = MagicMock()
+    interaction.message.content = "Round 1 pairing"
+    interaction.response.edit_message = AsyncMock()
     interaction.response.send_message = AsyncMock()
     with patch("cogs.tournament_commands.db_session", fake_db_session):
         await launch_tournament_match(interaction, match_id)
 
-    interaction.response.send_message.assert_awaited_once()
-    msg = interaction.response.send_message.call_args.args[0]
-    assert "already" in msg.lower() and "result" in msg.lower()
-    # must NOT have launched a draft (no view passed)
-    assert "view" not in interaction.response.send_message.call_args.kwargs
+    # Stale Play button self-heals: the public pairing message is edited to drop
+    # the button (view=None) and show the recorded result; no draft is launched.
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.call_args.kwargs
+    assert kwargs.get("view") is None
+    assert "result recorded" in kwargs["content"].lower()
+    assert "2–0" in kwargs["content"]
+    interaction.response.send_message.assert_not_awaited()


### PR DESCRIPTION
Clicking ▶ Play this match on a match that already has a result now edits the
public pairing message to drop the button and append a recorded-result line
(e.g. '✅ Result recorded: A 5–4 B'), so the stale control disappears for
everyone instead of only showing an ephemeral notice to the clicker. Falls
back to the prior ephemeral message if the pairing message can't be edited.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>