### PR TITLE
refactor: extract pairing_button_style helper from re_register_views

### DIFF
--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -533,6 +533,63 @@ class TournamentCog(commands.Cog):
         logger.info(f"Standings message refreshed for tournament {tournament_id} by {ctx.author.id}")
         await ctx.followup.send("✅ Standings refreshed.", ephemeral=True)
 
+    @tournament.command(name="recover_draft", description="Admin: recreate channels for a reaped in-progress match draft")
+    @has_bot_manager_role()
+    async def recover_draft(
+        self,
+        ctx,
+        match_id: discord.Option(int, "Tournament match id to recover"),
+    ):
+        if not await self._check_enabled(ctx):
+            return
+        await ctx.defer(ephemeral=True)
+        from models.draft_session import DraftSession
+        from utils import recover_draft_channels
+
+        async with db_session() as session:
+            match = await session.get(TournamentMatch, match_id)
+            if match is None:
+                await ctx.followup.send(f"❌ No tournament match `{match_id}`.", ephemeral=True)
+                return
+            if match.team_a_wins is not None:
+                await ctx.followup.send(
+                    f"❌ Match `{match_id}` already has a result — nothing to recover.",
+                    ephemeral=True,
+                )
+                return
+            ds = (await session.execute(
+                select(DraftSession).where(DraftSession.tournament_match_id == match_id)
+            )).scalars().first()
+            if ds is None:
+                await ctx.followup.send(
+                    f"❌ No draft session is linked to match `{match_id}`.", ephemeral=True
+                )
+                return
+            session_id = ds.session_id
+            existing_chat = ds.draft_chat_channel
+
+        # Idempotency: refuse if the current draft-chat still resolves to a live channel.
+        if existing_chat and ctx.guild.get_channel(int(existing_chat)):
+            await ctx.followup.send(
+                f"❌ Match `{match_id}`'s draft-chat (<#{existing_chat}>) still exists — "
+                f"nothing to recover.",
+                ephemeral=True,
+            )
+            return
+
+        new_channel_id = await recover_draft_channels(self.bot, ctx.guild, session_id)
+        if new_channel_id is None:
+            await ctx.followup.send("❌ Recovery failed — see logs.", ephemeral=True)
+            return
+        logger.info(
+            f"Recovered draft for match {match_id} (session {session_id}) in guild "
+            f"{ctx.guild.id} by {ctx.author.id} -> channel {new_channel_id}"
+        )
+        await ctx.followup.send(
+            f"✅ Recovered match `{match_id}`. New draft-chat: <#{new_channel_id}>.",
+            ephemeral=True,
+        )
+
     @tournament.command(name="status", description="Show the current tournament and its teams")
     async def status(self, ctx):
         if not await self._check_enabled(ctx):

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -494,3 +494,24 @@ async def get_standings_data(session, tournament_id):
         .where(TournamentRound.tournament_id == tournament_id)
     )).scalars().all()
     return rank_standings(participants, matches)
+
+
+async def tournament_match_is_unfinished(session, match_id):
+    """True iff the tournament match exists, isn't a bye, and has no result yet."""
+    if not match_id:
+        return False
+    match = await session.get(TournamentMatch, int(match_id))
+    if match is None or match.is_bye:
+        return False
+    return match.team_a_wins is None
+
+
+async def extend_deletion_if_unfinished(session, draft_session, now):
+    """Cleanup guard: if the draft's tournament match is still unfinished, push its
+    deletion_time out (7 days) so cleanup won't reap it mid-match. Returns True when
+    the session should be skipped by cleanup, False otherwise."""
+    from datetime import timedelta
+    if await tournament_match_is_unfinished(session, draft_session.tournament_match_id):
+        draft_session.deletion_time = now + timedelta(days=7)
+        return True
+    return False

--- a/tests/test_cleanup_tournament_guard.py
+++ b/tests/test_cleanup_tournament_guard.py
@@ -1,0 +1,108 @@
+"""Cleanup guard: don't reap drafts whose tournament match is still unfinished."""
+import os
+import random
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.models_base import Base
+import models  # noqa: F401  register all tables
+from models.tournament import TournamentMatch
+from services.tournament_service import (
+    create_tournament,
+    extend_deletion_if_unfinished,
+    register_team,
+    set_result,
+    start_tournament,
+    tournament_match_is_unfinished,
+)
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    temp_db.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    yield factory
+    await engine.dispose()
+    os.unlink(temp_db.name)
+
+
+class _DS:
+    """Stand-in for a DraftSession row (only the fields the guard touches)."""
+    def __init__(self, tournament_match_id):
+        self.tournament_match_id = tournament_match_id
+        self.deletion_time = None
+
+
+async def _one_match(session):
+    t = await create_tournament(session, "g1", "RR", 0, format="round_robin")
+    await session.commit()
+    await register_team(session, t.id, "Alpha", "1")
+    await register_team(session, t.id, "Bravo", "2")
+    await session.commit()
+    matches = await start_tournament(session, t.id, random.Random(7))
+    await session.commit()
+    return matches[0]
+
+
+@pytest.mark.asyncio
+async def test_unfinished_match_is_unfinished(test_db):
+    async with test_db() as session:
+        m = await _one_match(session)
+        assert await tournament_match_is_unfinished(session, m.id) is True
+
+
+@pytest.mark.asyncio
+async def test_finished_match_is_not_unfinished(test_db):
+    async with test_db() as session:
+        m = await _one_match(session)
+        await set_result(session, m.id, 2, 1)
+        await session.commit()
+        assert await tournament_match_is_unfinished(session, m.id) is False
+
+
+@pytest.mark.asyncio
+async def test_bye_and_missing_and_none_are_not_unfinished(test_db):
+    async with test_db() as session:
+        m = await _one_match(session)
+        m.is_bye = True
+        await session.commit()
+        assert await tournament_match_is_unfinished(session, m.id) is False
+        assert await tournament_match_is_unfinished(session, 999999) is False
+        assert await tournament_match_is_unfinished(session, None) is False
+
+
+@pytest.mark.asyncio
+async def test_guard_extends_and_skips_unfinished(test_db):
+    async with test_db() as session:
+        m = await _one_match(session)
+        now = datetime(2026, 7, 1, 12, 0, 0)
+        ds = _DS(m.id)
+        skipped = await extend_deletion_if_unfinished(session, ds, now)
+        assert skipped is True
+        assert ds.deletion_time == now + timedelta(days=7)
+
+
+@pytest.mark.asyncio
+async def test_guard_leaves_finished_and_plain_sessions(test_db):
+    async with test_db() as session:
+        m = await _one_match(session)
+        await set_result(session, m.id, 2, 1)
+        await session.commit()
+        now = datetime(2026, 7, 1, 12, 0, 0)
+
+        finished = _DS(m.id)
+        assert await extend_deletion_if_unfinished(session, finished, now) is False
+        assert finished.deletion_time is None
+
+        plain = _DS(None)
+        assert await extend_deletion_if_unfinished(session, plain, now) is False
+        assert plain.deletion_time is None

--- a/tests/test_create_pairings_view.py
+++ b/tests/test_create_pairings_view.py
@@ -1,0 +1,40 @@
+"""create_pairings_view colors buttons by stored result."""
+import discord
+import pytest
+
+from views import create_pairings_view
+
+
+class _MR:
+    def __init__(self, id, match_number, winner_id):
+        self.id = id
+        self.match_number = match_number
+        self.winner_id = winner_id
+
+
+@pytest.mark.asyncio
+async def test_buttons_colored_by_result():
+    match_results = [
+        _MR(1, 1, "2"),    # team A winner -> red
+        _MR(2, 2, "5"),    # team B winner -> blurple
+        _MR(3, 3, None),   # unreported -> grey
+    ]
+    view = await create_pairings_view(
+        bot=None, guild=None, session_id="s", match_results=match_results,
+        team_a=["1", "2", "3"], team_b=["4", "5", "6"],
+    )
+    styles = [child.style for child in view.children]
+    assert styles == [
+        discord.ButtonStyle.danger,
+        discord.ButtonStyle.primary,
+        discord.ButtonStyle.secondary,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_defaults_to_grey_without_teams():
+    view = await create_pairings_view(
+        bot=None, guild=None, session_id="s",
+        match_results=[_MR(1, 1, "2")],
+    )
+    assert view.children[0].style == discord.ButtonStyle.secondary

--- a/tests/test_pairing_button_style.py
+++ b/tests/test_pairing_button_style.py
@@ -1,0 +1,29 @@
+"""Unit tests for the pairing-button coloring helper."""
+import discord
+
+from views import pairing_button_style
+
+
+class _MR:
+    def __init__(self, winner_id):
+        self.winner_id = winner_id
+
+
+TEAM_A = ["1", "2", "3"]
+TEAM_B = ["4", "5", "6"]
+
+
+def test_team_a_winner_is_red():
+    assert pairing_button_style(_MR("2"), TEAM_A, TEAM_B) == discord.ButtonStyle.danger
+
+
+def test_team_b_winner_is_blurple():
+    assert pairing_button_style(_MR("5"), TEAM_A, TEAM_B) == discord.ButtonStyle.primary
+
+
+def test_unreported_is_grey():
+    assert pairing_button_style(_MR(None), TEAM_A, TEAM_B) == discord.ButtonStyle.secondary
+
+
+def test_winner_not_on_either_team_is_grey():
+    assert pairing_button_style(_MR("99"), TEAM_A, TEAM_B) == discord.ButtonStyle.secondary

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -19,14 +19,16 @@ def test_tournament_group_has_slice_one_and_two_commands():
     subcommands = {cmd.name for cmd in TournamentCog.tournament.subcommands}
     assert {"create", "register", "status",
             "start", "set_result", "next_round", "finish",
-            "add_team", "remove_team", "add_match", "refresh_standings"} <= subcommands
+            "add_team", "remove_team", "add_match", "refresh_standings",
+            "recover_draft"} <= subcommands
 
 
 def test_admin_commands_are_gated_by_bot_manager_check():
     from cogs.tournament_commands import TournamentCog
 
     for command in ("create", "start", "set_result", "next_round", "finish",
-                    "add_team", "remove_team", "add_match", "refresh_standings"):
+                    "add_team", "remove_team", "add_match", "refresh_standings",
+                    "recover_draft"):
         assert is_bot_manager in getattr(TournamentCog, command).checks, command
 
 

--- a/utils.py
+++ b/utils.py
@@ -1451,6 +1451,15 @@ async def cleanup_sessions_task(bot):
 
                 # Original cleanup code for regular sessions
                 for session in sessions_to_cleanup:
+                    # Never reap a draft whose tournament match is still unfinished —
+                    # extend its lifespan instead so the pairing buttons stay alive.
+                    from services.tournament_service import extend_deletion_if_unfinished
+                    if await extend_deletion_if_unfinished(db_session, session, current_time):
+                        logger.info(
+                            f"Skipped cleanup for session {session.session_id}: tournament "
+                            f"match {session.tournament_match_id} unfinished; deletion_time extended"
+                        )
+                        continue
                     # Check if channel_ids is not None and is iterable before attempting to iterate
                     if session.channel_ids:
                         for channel_id in session.channel_ids:

--- a/utils.py
+++ b/utils.py
@@ -353,8 +353,9 @@ async def post_pairings(bot, guild, session_id):
 
             for round_number, match_results in match_results_by_round.items():
                 embed = discord.Embed(title=f"Round {round_number} Pairings", color=discord.Color.blue())
-                from views import create_pairings_view  
-                view = await create_pairings_view(bot, guild, session_id, match_results)
+                from views import create_pairings_view
+                view = await create_pairings_view(bot, guild, session_id, match_results,
+                                                  draft_session.team_a, draft_session.team_b)
 
                 for match_result in match_results:
                     player_name = get_display_name_by_id(match_result.player1_id, guild)
@@ -383,7 +384,8 @@ async def post_pairings(bot, guild, session_id):
             for round_number, match_results in match_results_by_round.items():
                 embed = discord.Embed(title=f"Round {round_number} Pairings", color=discord.Color.blue())
                 from views import create_pairings_view
-                view = await create_pairings_view(bot, guild, session_id, match_results)
+                view = await create_pairings_view(bot, guild, session_id, match_results,
+                                                  draft_session.team_a, draft_session.team_b)
 
                 for match_result in match_results:
                     player_name = get_display_name_by_id(match_result.player1_id, guild)

--- a/utils.py
+++ b/utils.py
@@ -405,6 +405,74 @@ async def post_pairings(bot, guild, session_id):
         await db_session.commit()
 
 
+async def recover_draft_channels(bot, guild, session_id):
+    """Recreate the Discord rooms for a reaped premade draft and re-post its pairing
+    messages with buttons coloured by current results, then extend the draft's
+    lifespan. Returns the new draft-chat channel id, or None if the session is gone.
+
+    Used to recover a tournament match whose channels the cleanup task deleted while
+    the match was still in progress.
+    """
+    from views import PersistentView
+
+    async with AsyncSessionLocal() as db_session:
+        result = await db_session.execute(
+            select(DraftSession).filter(DraftSession.session_id == session_id)
+        )
+        draft_session = result.scalar_one_or_none()
+        if not draft_session:
+            logger.warning(f"recover_draft_channels: session {session_id} not found")
+            return None
+        team_a = list(draft_session.team_a or [])
+        team_b = list(draft_session.team_b or [])
+        session_type = draft_session.session_type
+
+    def _members(ids):
+        found = []
+        for uid in ids:
+            member = guild.get_member(int(uid))
+            if member:
+                found.append(member)
+            else:
+                logger.warning(f"recover_draft_channels: member {uid} not in guild")
+        return found
+
+    team_a_members = _members(team_a)
+    team_b_members = _members(team_b)
+    all_members = team_a_members + team_b_members
+
+    # create_team_channel persists channel_ids/draft_chat_channel and sets stage=pairings.
+    temp_view = PersistentView(bot, session_id, session_type)
+    draft_channel_id = await temp_view.create_team_channel(
+        guild, "Draft", all_members, team_a, team_b
+    )
+    await temp_view.create_team_channel(guild, "Red-Team", team_a_members, team_a, team_b)
+    await temp_view.create_team_channel(guild, "Blue-Team", team_b_members, team_a, team_b)
+
+    # Re-post the pairing messages (now coloured by stored results) into the new chat.
+    await post_pairings(bot, guild, session_id)
+
+    # Extend lifespan so the guard/cleanup won't reap it again before it's finished.
+    async with AsyncSessionLocal() as db_session:
+        async with db_session.begin():
+            await db_session.execute(
+                update(DraftSession)
+                .where(DraftSession.session_id == session_id)
+                .values(deletion_time=datetime.now() + timedelta(days=7))
+            )
+
+    chat = guild.get_channel(int(draft_channel_id)) if draft_channel_id else None
+    if chat:
+        mentions = " ".join(f"<@{uid}>" for uid in team_a + team_b)
+        await chat.send(
+            f"{mentions} — this match's channels were restored. Please report any "
+            f"remaining results with the buttons above; the tournament will update "
+            f"automatically. Good luck!"
+        )
+    logger.info(f"recover_draft_channels: recovered {session_id} into channel {draft_channel_id}")
+    return draft_channel_id
+
+
 async def calculate_team_wins(draft_session_id):
     team_a_wins = 0
     team_b_wins = 0

--- a/utils.py
+++ b/utils.py
@@ -2085,15 +2085,10 @@ async def re_register_views(bot):
                                 for match_result in match_results:
                                     from views import MatchResultButton
                                     
-                                    # Determine button style based on match result
-                                    button_style = discord.ButtonStyle.secondary  # Default for no result
-                                    
-                                    if match_result.winner_id:
-                                        # Check if winner is in team A or team B
-                                        if match_result.winner_id in draft_session.team_a:
-                                            button_style = discord.ButtonStyle.danger  # Red for Team A
-                                        elif match_result.winner_id in draft_session.team_b:
-                                            button_style = discord.ButtonStyle.primary  # Blurple for Team B
+                                    from views import pairing_button_style
+                                    button_style = pairing_button_style(
+                                        match_result, draft_session.team_a, draft_session.team_b
+                                    )
                                     
                                     button = MatchResultButton(
                                         bot=bot,

--- a/views.py
+++ b/views.py
@@ -1676,19 +1676,21 @@ def pairing_button_style(match_result, team_a, team_b):
     return discord.ButtonStyle.secondary
 
 
-async def create_pairings_view(bot, guild, session_id, match_results):
+async def create_pairings_view(bot, guild, session_id, match_results, team_a=None, team_b=None):
     view = View(timeout=None)
+    team_a = team_a or []
+    team_b = team_b or []
     for match_result in match_results:
-        
-        # Initialize a MatchResultButton for each match
+
+        # Initialize a MatchResultButton for each match, coloured by its result
         button = MatchResultButton(
             bot=bot,
             session_id=session_id,
-            match_id=match_result.id,  
+            match_id=match_result.id,
             match_number=match_result.match_number,
             label=f"Match {match_result.match_number} Results",
-            style=discord.ButtonStyle.secondary,
-            row=None  
+            style=pairing_button_style(match_result, team_a, team_b),
+            row=None
         )
         view.add_item(button)
     return view

--- a/views.py
+++ b/views.py
@@ -1665,6 +1665,17 @@ async def update_last_draft_timestamp(session_id, guild, bot):
             await db_session.commit()
 
 
+def pairing_button_style(match_result, team_a, team_b):
+    """Colour a pairing button by its stored result: red = Team A won,
+    blurple = Team B won, grey = not yet reported."""
+    if match_result.winner_id:
+        if match_result.winner_id in team_a:
+            return discord.ButtonStyle.danger
+        if match_result.winner_id in team_b:
+            return discord.ButtonStyle.primary
+    return discord.ButtonStyle.secondary
+
+
 async def create_pairings_view(bot, guild, session_id, match_results):
     view = View(timeout=None)
     for match_result in match_results:


### PR DESCRIPTION
refactor: extract pairing_button_style helper from re_register_views

feat: colour pairing buttons by result in create_pairings_view

feat: tournament cleanup-guard helpers (unfinished detection + deletion extend)

feat: guard cleanup task against reaping unfinished tournament drafts

feat: /tournament recover_draft to rebuild reaped in-progress match channels

Adds utils.recover_draft_channels(bot, guild, session_id), which recreates
the Draft/Red-Team/Blue-Team rooms via PersistentView.create_team_channel,
re-posts colored pairings via post_pairings, bumps deletion_time by 7 days,
and pings the players. Wires it up behind a bot-manager-gated
/tournament recover_draft match_id command with refusal guards for a
missing match, an already-recorded result, no linked draft session, or a
still-live draft-chat channel.