### PR TITLE
/add_sub: grant substitute players draft channel access

### DIFF
--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -257,10 +257,15 @@ class DraftCommands(commands.Cog):
         draft_chat = next(
             (c for c in granted if str(c.id) == draft_chat_id), None)
         if draft_chat:
-            await draft_chat.send(
-                f"{user.mention} was added as a substitute for "
-                f"**{decision.team_display_name}** by "
-                f"{get_display_name(ctx.author, ctx.guild)}.")
+            try:
+                await draft_chat.send(
+                    f"{user.mention} was added as a substitute for "
+                    f"**{decision.team_display_name}** by "
+                    f"{get_display_name(ctx.author, ctx.guild)}.")
+            except discord.HTTPException:
+                logger.warning(
+                    f"add_sub: grant succeeded but the public announcement "
+                    f"failed in channel {draft_chat.id}", exc_info=True)
 
 def setup(bot):
     bot.add_cog(DraftCommands(bot))

--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -242,6 +242,10 @@ class DraftCommands(commands.Cog):
         if failed:
             summary += ("\n⚠️ Failed (Discord error): "
                         + ", ".join(c.mention for c in failed))
+            if any(str(c.id) == str(draft_session.draft_chat_channel)
+                   for c in failed):
+                summary += ("\n⚠️ Skipped the public announcement because "
+                            "the draft chat grant failed.")
         await ctx.followup.send(summary, ephemeral=True)
         logger.success(f"add_sub: granted {user.id} access to "
                        f"{[c.id for c in granted]} in draft "

--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -237,8 +237,11 @@ class DraftCommands(commands.Cog):
                 "they may have been deleted already.", ephemeral=True)
             return
 
-        summary = (f"Granted {user.display_name} access to: "
-                   + ", ".join(c.mention for c in granted))
+        if granted:
+            summary = (f"Granted {user.display_name} access to: "
+                       + ", ".join(c.mention for c in granted))
+        else:
+            summary = f"Could not grant {user.display_name} access to any channels."
         if failed:
             summary += ("\n⚠️ Failed (Discord error): "
                         + ", ".join(c.mention for c in failed))

--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -8,6 +8,8 @@ from views import MatchResultSelect
 from config import is_money_server
 from preference_service import get_player_dm_notification_preference, update_player_dm_notification_preference
 from helpers.display_names import get_display_name
+from helpers.permissions import is_bot_manager
+from helpers.substitutes import is_sub_target_channel, resolve_sub_grant
 
 class DraftCommands(commands.Cog):
     def __init__(self, bot):
@@ -174,6 +176,85 @@ class DraftCommands(commands.Cog):
                 "Failed to update your DM notification preference. Please try again later.",
                 ephemeral=True
             )
+
+    @discord.slash_command(
+        name='add_sub',
+        description="Grant a substitute access to this draft's chat and a team chat",
+        guild_ids=None
+    )
+    async def add_sub(
+        self,
+        ctx,
+        user: discord.Option(discord.Member, "The substitute to grant access"),
+        team: discord.Option(str, "Sub's team (only needed if you're not in this draft)",
+                             choices=["A", "B"], required=False, default=None),
+    ):
+        """Grant a substitute channel access without changing draft data."""
+        logger.info(f"Received add_sub from {ctx.author.id} for {user.id} "
+                    f"in channel {ctx.channel_id}")
+        await ctx.response.defer(ephemeral=True)
+        await self._do_add_sub(ctx, user, team)
+
+    async def _do_add_sub(self, ctx, user, team):
+        draft_session = await DraftSession.get_by_any_channel_id(ctx.channel_id)
+        if not draft_session:
+            await ctx.followup.send(
+                "This command can only be used in a draft's channels.",
+                ephemeral=True)
+            return
+        if not draft_session.channel_ids:
+            await ctx.followup.send(
+                "This draft's channels haven't been created yet — "
+                "add the sub once teams and channels exist.", ephemeral=True)
+            return
+
+        is_admin = await is_bot_manager(ctx)
+        decision, error = resolve_sub_grant(
+            draft_session, str(ctx.author.id), str(user.id), is_admin, team)
+        if error:
+            await ctx.followup.send(error, ephemeral=True)
+            return
+
+        granted, failed = [], []
+        for channel_id in draft_session.channel_ids:
+            channel = ctx.guild.get_channel(int(channel_id))
+            if not channel or not is_sub_target_channel(
+                    channel.name, draft_session.draft_id, decision.channel_prefix):
+                continue
+            try:
+                # Same overwrites teammates get at channel creation
+                await channel.set_permissions(
+                    user, read_messages=True, manage_messages=True)
+                granted.append(channel)
+            except discord.HTTPException:
+                logger.exception(f"add_sub: failed to set permissions on "
+                                 f"channel {channel.id}")
+                failed.append(channel)
+
+        if not granted and not failed:
+            await ctx.followup.send(
+                "Could not find this draft's channels — "
+                "they may have been deleted already.", ephemeral=True)
+            return
+
+        summary = (f"Granted {user.display_name} access to: "
+                   + ", ".join(c.mention for c in granted))
+        if failed:
+            summary += ("\n⚠️ Failed (Discord error): "
+                        + ", ".join(c.mention for c in failed))
+        await ctx.followup.send(summary, ephemeral=True)
+        logger.success(f"add_sub: granted {user.id} access to "
+                       f"{[c.id for c in granted]} in draft "
+                       f"{draft_session.session_id}")
+
+        draft_chat = next(
+            (c for c in granted
+             if str(c.id) == str(draft_session.draft_chat_channel)), None)
+        if draft_chat:
+            await draft_chat.send(
+                f"{user.mention} was added as a substitute for "
+                f"**{decision.team_display_name}** by "
+                f"{get_display_name(ctx.author, ctx.guild)}.")
 
 def setup(bot):
     bot.add_cog(DraftCommands(bot))

--- a/cogs/draft_commands.py
+++ b/cogs/draft_commands.py
@@ -215,6 +215,7 @@ class DraftCommands(commands.Cog):
             await ctx.followup.send(error, ephemeral=True)
             return
 
+        draft_chat_id = str(draft_session.draft_chat_channel)
         granted, failed = [], []
         for channel_id in draft_session.channel_ids:
             channel = ctx.guild.get_channel(int(channel_id))
@@ -245,8 +246,7 @@ class DraftCommands(commands.Cog):
         if failed:
             summary += ("\n⚠️ Failed (Discord error): "
                         + ", ".join(c.mention for c in failed))
-            if any(str(c.id) == str(draft_session.draft_chat_channel)
-                   for c in failed):
+            if any(str(c.id) == draft_chat_id for c in failed):
                 summary += ("\n⚠️ Skipped the public announcement because "
                             "the draft chat grant failed.")
         await ctx.followup.send(summary, ephemeral=True)
@@ -255,8 +255,7 @@ class DraftCommands(commands.Cog):
                        f"{draft_session.session_id}")
 
         draft_chat = next(
-            (c for c in granted
-             if str(c.id) == str(draft_session.draft_chat_channel)), None)
+            (c for c in granted if str(c.id) == draft_chat_id), None)
         if draft_chat:
             await draft_chat.send(
                 f"{user.mention} was added as a substitute for "

--- a/docs/superpowers/plans/2026-07-09-add-sub.md
+++ b/docs/superpowers/plans/2026-07-09-add-sub.md
@@ -1,0 +1,716 @@
+# `/add_sub` Substitute Channel Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `/add_sub user [team]` slash command that grants a substitute Discord permission overwrites on a draft's chat channel and one team's chat (and voice) channel, without touching draft data.
+
+**Architecture:** A pure decision helper in `helpers/substitutes.py` (authorization + team resolution + channel-name matching, fully unit-tested with no Discord objects), a fallback session lookup `DraftSession.get_by_any_channel_id()` so the command works from team chats, and a thin command in the `DraftCommands` cog that resolves Discord objects and applies `channel.set_permissions(...)`.
+
+**Tech Stack:** Python, py-cord (Discord), SQLAlchemy async + SQLite, pytest + pytest-asyncio, loguru.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-add-sub-design.md` (approved).
+
+## Global Constraints
+
+- Always run Python via pipenv: `pipenv run python -m pytest ...` (never bare `pytest` — imports break).
+- No database schema changes, no Alembic migration (stateless feature — spec non-goal).
+- The sub is never added to `sign_ups`, `team_a`, `team_b`, pairings, or results.
+- Permission overwrites granted to the sub must be exactly `read_messages=True, manage_messages=True` (identical to teammates, `views.py:1325`).
+- Team channel naming is hardcoded in `views.py:1464-1466` + `views.py:1299`: team_a → `Red-Team-Chat-{draft_id}`, team_b → `Blue-Team-Chat-{draft_id}`, voice (premade only) → `Red-Team-Voice-{draft_id}` / `Blue-Team-Voice-{draft_id}`, main chat → `Draft-Chat-{draft_id}`. Discord lowercases text channel names, so all name comparison must be case-insensitive.
+- `channel_ids` JSON stores channel IDs as **ints**; `draft_chat_channel` stores a **string**. Any comparison must normalize.
+- Follow existing cog conventions in `cogs/draft_commands.py`: loguru logging, `await ctx.response.defer(ephemeral=True)` then `ctx.followup.send(..., ephemeral=True)`.
+
+---
+
+### Task 1: Pure decision helpers (`helpers/substitutes.py`)
+
+**Files:**
+- Create: `helpers/substitutes.py`
+- Test: `tests/test_substitutes.py`
+
+**Interfaces:**
+- Consumes: a `DraftSession`-shaped object (only attributes `team_a`, `team_b`, `sign_ups`, `team_a_name`, `team_b_name` — a `SimpleNamespace` works in tests).
+- Produces (used by Tasks 2 and 3):
+  - `GrantDecision` dataclass: fields `team_key: str` ("A"/"B"), `channel_prefix: str` ("Red-Team"/"Blue-Team"), `team_display_name: str`.
+  - `resolve_sub_grant(session, invoker_id: str, target_id: str, is_admin: bool, team_choice: str | None = None) -> tuple[GrantDecision | None, str | None]` — exactly one element of the tuple is None; the second element is a user-facing error message.
+  - `is_sub_target_channel(channel_name: str, draft_id: str, channel_prefix: str) -> bool` — case-insensitive match against the three channel names the sub should get.
+  - `channel_ids_contains(channel_ids, channel_id) -> bool` — int/str-tolerant membership test.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_substitutes.py`:
+
+```python
+from types import SimpleNamespace
+
+from helpers.substitutes import (
+    GrantDecision,
+    channel_ids_contains,
+    is_sub_target_channel,
+    resolve_sub_grant,
+)
+
+
+def make_session(team_a=None, team_b=None, sign_ups=None,
+                 team_a_name=None, team_b_name=None):
+    return SimpleNamespace(
+        team_a=team_a or [],
+        team_b=team_b or [],
+        sign_ups=sign_ups or {},
+        team_a_name=team_a_name,
+        team_b_name=team_b_name,
+    )
+
+
+# ---- resolve_sub_grant ------------------------------------------------------
+
+def test_player_on_team_a_grants_red_team():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False)
+    assert error is None
+    assert decision.team_key == "A"
+    assert decision.channel_prefix == "Red-Team"
+    assert decision.team_display_name == "Red Team"  # fallback when name unset
+
+
+def test_player_on_team_b_grants_blue_team():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="2", target_id="9",
+                                        is_admin=False)
+    assert error is None
+    assert decision.team_key == "B"
+    assert decision.channel_prefix == "Blue-Team"
+
+
+def test_premade_team_name_used_for_display():
+    session = make_session(team_a=["1"], team_b=["2"],
+                           team_a_name="Goblin Gang", team_b_name="Merfolk Mob")
+    decision, _ = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                    is_admin=False)
+    assert decision.team_display_name == "Goblin Gang"
+
+
+def test_player_team_choice_is_ignored():
+    """A player always grants their own team, even if they pass team_choice."""
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False, team_choice="B")
+    assert error is None
+    assert decision.team_key == "A"
+
+
+def test_admin_not_in_draft_uses_team_choice():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True, team_choice="B")
+    assert error is None
+    assert decision.team_key == "B"
+    assert decision.channel_prefix == "Blue-Team"
+
+
+def test_admin_without_team_choice_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True)
+    assert decision is None
+    assert "team" in error.lower()
+
+
+def test_non_participant_non_admin_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=False)
+    assert decision is None
+    assert error is not None
+
+
+def test_target_already_on_a_team_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="2",
+                                        is_admin=False)
+    assert decision is None
+    assert "already" in error.lower()
+
+
+def test_target_in_sign_ups_is_error():
+    session = make_session(team_a=["1"], team_b=["2"], sign_ups={"9": "Niner"})
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False)
+    assert decision is None
+    assert "already" in error.lower()
+
+
+def test_none_team_fields_are_tolerated():
+    session = SimpleNamespace(team_a=None, team_b=None, sign_ups=None,
+                              team_a_name=None, team_b_name=None)
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True, team_choice="A")
+    assert error is None
+    assert decision.team_key == "A"
+
+
+# ---- is_sub_target_channel --------------------------------------------------
+
+def test_matches_lowercased_discord_text_channel_names():
+    # Discord lowercases text channel names on creation
+    assert is_sub_target_channel("draft-chat-AbC123".lower(), "AbC123", "Red-Team")
+    assert is_sub_target_channel("red-team-chat-abc123", "AbC123", "Red-Team")
+
+
+def test_matches_voice_channel_with_original_case():
+    assert is_sub_target_channel("Red-Team-Voice-AbC123", "AbC123", "Red-Team")
+
+
+def test_rejects_other_teams_channels():
+    assert not is_sub_target_channel("blue-team-chat-abc123", "AbC123", "Red-Team")
+    assert not is_sub_target_channel("Blue-Team-Voice-AbC123", "AbC123", "Red-Team")
+
+
+def test_rejects_channels_of_other_drafts():
+    assert not is_sub_target_channel("red-team-chat-zzz999", "AbC123", "Red-Team")
+
+
+# ---- channel_ids_contains ---------------------------------------------------
+
+def test_contains_handles_int_stored_ids_and_str_query():
+    assert channel_ids_contains([111, 222], "222")
+    assert channel_ids_contains([111, 222], 111)
+
+
+def test_contains_handles_str_stored_ids():
+    assert channel_ids_contains(["111", "222"], 222)
+
+
+def test_contains_handles_none_and_empty():
+    assert not channel_ids_contains(None, 111)
+    assert not channel_ids_contains([], 111)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pipenv run python -m pytest tests/test_substitutes.py -v`
+Expected: FAIL at collection with `ModuleNotFoundError: No module named 'helpers.substitutes'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `helpers/substitutes.py`:
+
+```python
+"""Pure decision logic for granting a substitute access to draft channels.
+
+No Discord objects in here — the DraftCommands cog resolves members/channels
+and applies the permission overwrites this module decides on.
+"""
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+# Team channels are created with these hardcoded prefixes (views.py):
+# team_a -> "Red-Team-Chat-{draft_id}", team_b -> "Blue-Team-Chat-{draft_id}".
+TEAM_A_CHANNEL_PREFIX = "Red-Team"
+TEAM_B_CHANNEL_PREFIX = "Blue-Team"
+
+
+@dataclass
+class GrantDecision:
+    team_key: str           # "A" or "B"
+    channel_prefix: str     # "Red-Team" or "Blue-Team"
+    team_display_name: str  # premade team name, or "Red Team"/"Blue Team"
+
+
+def resolve_sub_grant(
+    session,
+    invoker_id: str,
+    target_id: str,
+    is_admin: bool,
+    team_choice: Optional[str] = None,
+) -> Tuple[Optional[GrantDecision], Optional[str]]:
+    """Decide whether invoker may grant target sub access, and to which team.
+
+    Players on a team always grant their own team (team_choice is ignored);
+    admins outside the draft must pass team_choice "A" or "B".
+    Returns (decision, error) — exactly one is None.
+    """
+    team_a = session.team_a or []
+    team_b = session.team_b or []
+    sign_ups = session.sign_ups or {}
+
+    if target_id in team_a or target_id in team_b or target_id in sign_ups:
+        return None, "That user is already a participant in this draft."
+
+    if invoker_id in team_a:
+        team_key = "A"
+    elif invoker_id in team_b:
+        team_key = "B"
+    elif is_admin:
+        if team_choice not in ("A", "B"):
+            return None, ("You're not on a team in this draft — pass the "
+                          "`team` option (A or B) to choose the sub's team.")
+        team_key = team_choice
+    else:
+        return None, "Only players in this draft (or bot managers) can add a sub."
+
+    if team_key == "A":
+        display = session.team_a_name or "Red Team"
+        return GrantDecision("A", TEAM_A_CHANNEL_PREFIX, display), None
+    display = session.team_b_name or "Blue Team"
+    return GrantDecision("B", TEAM_B_CHANNEL_PREFIX, display), None
+
+
+def is_sub_target_channel(channel_name: str, draft_id: str, channel_prefix: str) -> bool:
+    """True if channel_name is one of the channels a sub should be granted.
+
+    Case-insensitive: Discord lowercases text channel names on creation,
+    while voice channels keep their original casing.
+    """
+    targets = {
+        f"draft-chat-{draft_id}".lower(),
+        f"{channel_prefix}-chat-{draft_id}".lower(),
+        f"{channel_prefix}-voice-{draft_id}".lower(),
+    }
+    return channel_name.lower() in targets
+
+
+def channel_ids_contains(channel_ids, channel_id) -> bool:
+    """Membership test tolerant of int-vs-str storage in the channel_ids JSON."""
+    if not channel_ids:
+        return False
+    wanted = str(channel_id)
+    return any(str(cid) == wanted for cid in channel_ids)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pipenv run python -m pytest tests/test_substitutes.py -v`
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add helpers/substitutes.py tests/test_substitutes.py
+git commit -m "feat: pure decision helpers for substitute channel access"
+```
+
+---
+
+### Task 2: Session lookup from any draft channel (`DraftSession.get_by_any_channel_id`)
+
+**Files:**
+- Modify: `models/draft_session.py` (add one classmethod after `get_by_channel_id`, which ends at line 86)
+- Test: `tests/test_substitutes.py` (append)
+
+**Interfaces:**
+- Consumes: `channel_ids_contains` from Task 1; existing `get_by_channel_id` (`models/draft_session.py:81`) which only matches `draft_chat_channel`.
+- Produces (used by Task 3): `DraftSession.get_by_any_channel_id(channel_id) -> DraftSession | None` classmethod — accepts int or str, matches `draft_chat_channel` first, then falls back to searching `channel_ids` JSON (so the command works from team chats), newest session first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_substitutes.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from models.draft_session import DraftSession
+
+
+def _mock_db_session(drafts):
+    """Async-context-manager mock for models.draft_session.db_session whose
+    execute() returns the given drafts via .scalars().all()."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = drafts
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    db = MagicMock(return_value=ctx)
+    return db
+
+
+# ---- DraftSession.get_by_any_channel_id --------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_prefers_draft_chat_match():
+    direct_hit = SimpleNamespace(session_id="s1")
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=direct_hit)) as direct:
+        found = await DraftSession.get_by_any_channel_id(555)
+    assert found is direct_hit
+    direct.assert_awaited_once_with("555")
+
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_falls_back_to_channel_ids():
+    other = SimpleNamespace(session_id="s0", channel_ids=[333])
+    match = SimpleNamespace(session_id="s1", channel_ids=[111, 222])  # ints, as stored
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=None)), \
+         patch("models.draft_session.db_session", _mock_db_session([other, match])):
+        found = await DraftSession.get_by_any_channel_id("222")
+    assert found is match
+
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_returns_none_when_no_match():
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=None)), \
+         patch("models.draft_session.db_session", _mock_db_session([])):
+        found = await DraftSession.get_by_any_channel_id(999)
+    assert found is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pipenv run python -m pytest tests/test_substitutes.py -v -k get_by_any`
+Expected: FAIL with `AttributeError: ... has no attribute 'get_by_any_channel_id'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `models/draft_session.py`, insert directly after the `get_by_channel_id` classmethod (after line 86, before `is_user_participating`):
+
+```python
+    @classmethod
+    async def get_by_any_channel_id(cls, channel_id):
+        """Get a draft session whose main chat OR any created channel matches.
+
+        Unlike get_by_channel_id (draft_chat_channel only), this also searches
+        the channel_ids JSON so lookups work from team chat channels too.
+        """
+        from helpers.substitutes import channel_ids_contains
+
+        channel_id = str(channel_id)
+        found = await cls.get_by_channel_id(channel_id)
+        if found:
+            return found
+        async with db_session() as session:
+            from sqlalchemy import desc
+            query = (select(cls)
+                     .where(cls.channel_ids.isnot(None))
+                     .order_by(desc(cls.draft_start_time)))
+            result = await session.execute(query)
+            for draft in result.scalars().all():
+                if channel_ids_contains(draft.channel_ids, channel_id):
+                    return draft
+        return None
+```
+
+Note: `channel_ids_contains` is imported inside the method to keep model import time free of helper dependencies (matches the local-import style used elsewhere in this codebase, e.g. `get_active_draft_for_user`).
+
+- [ ] **Step 4: Run the full test file to verify everything passes**
+
+Run: `pipenv run python -m pytest tests/test_substitutes.py -v`
+Expected: all tests PASS (Task 1 tests still green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add models/draft_session.py tests/test_substitutes.py
+git commit -m "feat: DraftSession.get_by_any_channel_id for team-chat lookups"
+```
+
+---
+
+### Task 3: `/add_sub` command in the DraftCommands cog
+
+**Files:**
+- Modify: `cogs/draft_commands.py` (imports at top; new command after `toggle_dm_notifications`, before the `setup()` function at line 178)
+- Test: `tests/test_add_sub_command.py`
+
+**Interfaces:**
+- Consumes: `resolve_sub_grant`, `is_sub_target_channel` (Task 1); `DraftSession.get_by_any_channel_id` (Task 2); existing `is_bot_manager(ctx)` (`helpers/permissions.py:34`); existing `get_display_name(member, guild)` (already imported in the cog).
+- Produces: `/add_sub` slash command. All logic lives in `DraftCommands._do_add_sub(self, ctx, user, team)` so tests can await it directly without py-cord command internals; the decorated `add_sub` is a thin wrapper that defers and delegates.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_add_sub_command.py`:
+
+```python
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.draft_commands import DraftCommands
+
+
+def make_channel(channel_id, name):
+    channel = MagicMock()
+    channel.id = channel_id
+    channel.name = name
+    channel.mention = f"#{name}"
+    channel.set_permissions = AsyncMock()
+    channel.send = AsyncMock()
+    return channel
+
+
+def make_ctx(invoker_id, channels):
+    ctx = MagicMock()
+    ctx.author.id = int(invoker_id)
+    ctx.author.display_name = f"user-{invoker_id}"
+    ctx.channel_id = 100
+    ctx.followup.send = AsyncMock()
+    ctx.guild.get_channel = lambda cid: channels.get(cid)
+    return ctx
+
+
+def make_sub(user_id=9):
+    sub = MagicMock()
+    sub.id = user_id
+    sub.display_name = "SubGuy"
+    sub.mention = f"<@{user_id}>"
+    return sub
+
+
+def make_draft(draft_id="abc123", channel_ids=None, draft_chat_channel="100",
+               team_a=("1",), team_b=("2",)):
+    return SimpleNamespace(
+        draft_id=draft_id,
+        channel_ids=channel_ids if channel_ids is not None else [100, 101, 102],
+        draft_chat_channel=draft_chat_channel,
+        team_a=list(team_a),
+        team_b=list(team_b),
+        sign_ups={"1": "One", "2": "Two"},
+        team_a_name=None,
+        team_b_name=None,
+    )
+
+
+@pytest.fixture
+def cog():
+    return DraftCommands(bot=MagicMock())
+
+
+# Channel names as Discord stores them: text channels lowercased
+def standard_channels(draft_id="abc123"):
+    return {
+        100: make_channel(100, f"draft-chat-{draft_id}"),
+        101: make_channel(101, f"red-team-chat-{draft_id}"),
+        102: make_channel(102, f"blue-team-chat-{draft_id}"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_player_grants_sub_draft_chat_and_own_team_chat(cog):
+    channels = standard_channels()
+    ctx = make_ctx("1", channels)  # invoker on team_a
+    sub = make_sub()
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, sub, None)
+
+    # Draft chat + red team chat get overwrites, blue team chat does not
+    channels[100].set_permissions.assert_awaited_once_with(
+        sub, read_messages=True, manage_messages=True)
+    channels[101].set_permissions.assert_awaited_once_with(
+        sub, read_messages=True, manage_messages=True)
+    channels[102].set_permissions.assert_not_awaited()
+
+    # Public announcement in draft chat, ephemeral confirmation to invoker
+    channels[100].send.assert_awaited_once()
+    assert sub.mention in channels[100].send.await_args.args[0]
+    ctx.followup.send.assert_awaited_once()
+    assert ctx.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_admin_outside_draft_grants_chosen_team(cog):
+    channels = standard_channels()
+    ctx = make_ctx("99", channels)  # not in draft
+    sub = make_sub()
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=True)):
+        await cog._do_add_sub(ctx, sub, "B")
+
+    channels[100].set_permissions.assert_awaited_once()
+    channels[102].set_permissions.assert_awaited_once()
+    channels[101].set_permissions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_not_a_draft_channel_is_ephemeral_error(cog):
+    ctx = make_ctx("1", {})
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=None)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+    assert ctx.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_non_participant_non_admin_gets_error_and_no_grants(cog):
+    channels = standard_channels()
+    ctx = make_ctx("99", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    for channel in channels.values():
+        channel.set_permissions.assert_not_awaited()
+    ctx.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deleted_channels_reported_as_error(cog):
+    # Session exists but none of its channels resolve in the guild anymore
+    ctx = make_ctx("1", {})
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+    assert "deleted" in ctx.followup.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_no_channel_ids_yet_is_error(cog):
+    ctx = make_ctx("1", {})
+    draft = make_draft(channel_ids=[])
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_discord_failure_is_reported(cog):
+    import discord
+    channels = standard_channels()
+    channels[101].set_permissions = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=500), "boom"))
+    ctx = make_ctx("1", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    message = ctx.followup.send.await_args.args[0]
+    assert "failed" in message.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pipenv run python -m pytest tests/test_add_sub_command.py -v`
+Expected: FAIL with `AttributeError: 'DraftCommands' object has no attribute '_do_add_sub'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `cogs/draft_commands.py`, add to the imports at the top (after line 10, `from helpers.display_names import get_display_name`):
+
+```python
+from helpers.permissions import is_bot_manager
+from helpers.substitutes import is_sub_target_channel, resolve_sub_grant
+```
+
+Then add the command methods inside the `DraftCommands` class, after `toggle_dm_notifications` and before the module-level `setup()` function:
+
+```python
+    @discord.slash_command(
+        name='add_sub',
+        description="Grant a substitute access to this draft's chat and a team chat",
+        guild_ids=None
+    )
+    async def add_sub(
+        self,
+        ctx,
+        user: discord.Option(discord.Member, "The substitute to grant access"),
+        team: discord.Option(str, "Sub's team (only needed if you're not in this draft)",
+                             choices=["A", "B"], required=False, default=None),
+    ):
+        """Grant a substitute channel access without changing draft data."""
+        logger.info(f"Received add_sub from {ctx.author.id} for {user.id} "
+                    f"in channel {ctx.channel_id}")
+        await ctx.response.defer(ephemeral=True)
+        await self._do_add_sub(ctx, user, team)
+
+    async def _do_add_sub(self, ctx, user, team):
+        draft_session = await DraftSession.get_by_any_channel_id(ctx.channel_id)
+        if not draft_session:
+            await ctx.followup.send(
+                "This command can only be used in a draft's channels.",
+                ephemeral=True)
+            return
+        if not draft_session.channel_ids:
+            await ctx.followup.send(
+                "This draft's channels haven't been created yet — "
+                "add the sub once teams and channels exist.", ephemeral=True)
+            return
+
+        is_admin = await is_bot_manager(ctx)
+        decision, error = resolve_sub_grant(
+            draft_session, str(ctx.author.id), str(user.id), is_admin, team)
+        if error:
+            await ctx.followup.send(error, ephemeral=True)
+            return
+
+        granted, failed = [], []
+        for channel_id in draft_session.channel_ids:
+            channel = ctx.guild.get_channel(int(channel_id))
+            if not channel or not is_sub_target_channel(
+                    channel.name, draft_session.draft_id, decision.channel_prefix):
+                continue
+            try:
+                # Same overwrites teammates get at channel creation
+                await channel.set_permissions(
+                    user, read_messages=True, manage_messages=True)
+                granted.append(channel)
+            except discord.HTTPException:
+                logger.exception(f"add_sub: failed to set permissions on "
+                                 f"channel {channel.id}")
+                failed.append(channel)
+
+        if not granted and not failed:
+            await ctx.followup.send(
+                "Could not find this draft's channels — "
+                "they may have been deleted already.", ephemeral=True)
+            return
+
+        summary = (f"Granted {user.display_name} access to: "
+                   + ", ".join(c.mention for c in granted))
+        if failed:
+            summary += ("\n⚠️ Failed (Discord error): "
+                        + ", ".join(c.mention for c in failed))
+        await ctx.followup.send(summary, ephemeral=True)
+        logger.success(f"add_sub: granted {user.id} access to "
+                       f"{[c.id for c in granted]} in draft "
+                       f"{draft_session.session_id}")
+
+        draft_chat = next(
+            (c for c in granted
+             if str(c.id) == str(draft_session.draft_chat_channel)), None)
+        if draft_chat:
+            await draft_chat.send(
+                f"{user.mention} was added as a substitute for "
+                f"**{decision.team_display_name}** by "
+                f"{get_display_name(ctx.author, ctx.guild)}.")
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `pipenv run python -m pytest tests/test_add_sub_command.py -v`
+Expected: all tests PASS
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+Run: `pipenv run python -m pytest`
+Expected: everything passes (no existing tests touch `/add_sub` paths, but the cog import change must not break `test_missing_imports.py` or the cog smoke tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cogs/draft_commands.py tests/test_add_sub_command.py
+git commit -m "feat: /add_sub command grants substitutes draft channel access"
+```
+
+---
+
+## Verification (after all tasks)
+
+- [ ] `pipenv run python -m pytest` — full suite green.
+- [ ] Manual smoke (optional, needs `TEST_MODE=true` locally, never in production): start the bot with `pipenv run python bot.py`, create a test draft, run `/add_sub` from a draft channel, and confirm the sub sees the draft chat and the correct team chat only.

--- a/docs/superpowers/specs/2026-07-09-add-sub-design.md
+++ b/docs/superpowers/specs/2026-07-09-add-sub-design.md
@@ -1,0 +1,99 @@
+# Design: `/add_sub` — Grant a Substitute Access to Draft Channels
+
+**Date:** 2026-07-09
+**Status:** Approved
+
+## Problem
+
+When a player needs a substitute mid-draft, there is no way to give that person
+access to the draft's private channels. Draft channels are created with
+per-member permission overwrites (`views.py`, `create_team_channel`), so anyone
+not signed up at channel-creation time cannot see the draft chat or team chat.
+
+## Goal
+
+A slash command that grants a substitute user access to the draft chat channel
+and one team's chat channel for an active draft. Channel access only — the
+sub is **not** added to sign-ups, teams, pairings, or results.
+
+## Non-Goals
+
+- Swapping the sub into the draft data (sign-ups, `team_a`/`team_b`, pairings).
+- Persisting/tracking subs in the database (no model change, no migration).
+- Removing a sub's access (admins can edit channel permissions manually; a
+  `/remove_sub` counterpart can be added later if needed).
+
+## Command
+
+`/add_sub user:<member> [team:<A|B>]`
+
+Defined in the `DraftCommands` cog (`cogs/draft_commands.py`), which already
+hosts run-in-draft-channel commands like `/report_match`.
+
+### Session resolution
+
+The command must be run in one of the draft's channels. Resolve the
+`DraftSession` via `DraftSession.get_by_channel_id()`; if that only matches the
+main draft chat, fall back to searching sessions whose `channel_ids` JSON
+contains the invoking channel's ID, so the command also works from team chats.
+If no session matches, reply ephemerally that the command must be used in an
+active draft channel.
+
+### Authorization and team resolution
+
+| Invoker | Allowed? | Team granted |
+|---|---|---|
+| Member of `team_a` or `team_b` | Yes | The invoker's own team (`team` param ignored) |
+| Not in draft, passes admin check | Yes | Must supply `team` param; error if omitted |
+| Anyone else | No — ephemeral error | — |
+
+The admin check reuses the existing logic in `helpers/permissions.py`
+(`is_bot_manager`: bot owner, configured manager role, or Manage Roles
+permission).
+
+### Channels granted
+
+For the resolved team, apply permission overwrites for the sub on:
+
+1. The draft chat channel (`draft_session.draft_chat_channel`).
+2. The team's text chat channel (identified among `channel_ids` using the same
+   naming scheme `create_team_channel` uses, e.g. `Red-Team-Chat-{draft_id}` /
+   `Blue-Team-Chat-{draft_id}`, keyed off `team_a_name`/`team_b_name`).
+3. The team's voice channel, if one exists (premade drafts).
+
+Overwrites match what teammates receive at channel creation
+(`read_messages=True, manage_messages=True`), so the sub's experience is
+identical to a team member's.
+
+### Feedback
+
+- **Success:** ephemeral confirmation to the invoker listing the channels
+  granted, plus a public message in the draft chat:
+  "@sub was added as a substitute for {team name} by @invoker".
+- **Errors (all ephemeral):**
+  - Not run in a draft channel.
+  - Draft completed/abandoned or channels already deleted.
+  - Target user is already a participant (`is_user_participating` or in
+    `sign_ups`) — friendly notice, no changes made.
+  - Target member cannot be resolved in the guild.
+  - Discord API failure while setting permissions (report which channels
+    succeeded/failed).
+
+## Architecture
+
+- **Pure helper** in `helpers/substitutes.py`:
+  `resolve_sub_grant(session, invoker_id, is_admin, team_choice) ->
+  GrantDecision | error` — decides authorization and which team applies, with
+  no Discord objects involved. This is the unit-tested core.
+- **Cog command** in `cogs/draft_commands.py`: resolves session + member,
+  calls the helper, applies `channel.set_permissions(...)` overwrites, sends
+  feedback. Uses loguru logging consistent with existing commands.
+
+## Testing
+
+- Unit tests in `tests/` (pytest, run via `pipenv run python -m pytest`) for
+  the pure helper: player-on-team-A, player-on-team-B, admin-with-team,
+  admin-without-team (error), non-participant non-admin (error), target
+  already in draft (error).
+- Discord interactions (permission overwrites, messages) covered with mocks
+  following existing test patterns in `tests/`.

--- a/docs/superpowers/specs/2026-07-09-add-sub-design.md
+++ b/docs/superpowers/specs/2026-07-09-add-sub-design.md
@@ -56,9 +56,11 @@ permission).
 For the resolved team, apply permission overwrites for the sub on:
 
 1. The draft chat channel (`draft_session.draft_chat_channel`).
-2. The team's text chat channel (identified among `channel_ids` using the same
+2. The team's text chat channel (identified among `channel_ids` using the
    naming scheme `create_team_channel` uses, e.g. `Red-Team-Chat-{draft_id}` /
-   `Blue-Team-Chat-{draft_id}`, keyed off `team_a_name`/`team_b_name`).
+   `Blue-Team-Chat-{draft_id}`; the prefixes `Red-Team` and `Blue-Team` are
+   hardcoded in `views.py`'s channel-creation code and do not vary with premade
+   team names — `team_a_name`/`team_b_name` are used for display purposes only).
 3. The team's voice channel, if one exists (premade drafts).
 
 Overwrites match what teammates receive at channel creation

--- a/helpers/substitutes.py
+++ b/helpers/substitutes.py
@@ -1,0 +1,80 @@
+"""Pure decision logic for granting a substitute access to draft channels.
+
+No Discord objects in here — the DraftCommands cog resolves members/channels
+and applies the permission overwrites this module decides on.
+"""
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+# Team channels are created with these hardcoded prefixes (views.py):
+# team_a -> "Red-Team-Chat-{draft_id}", team_b -> "Blue-Team-Chat-{draft_id}".
+TEAM_A_CHANNEL_PREFIX = "Red-Team"
+TEAM_B_CHANNEL_PREFIX = "Blue-Team"
+
+
+@dataclass
+class GrantDecision:
+    team_key: str           # "A" or "B"
+    channel_prefix: str     # "Red-Team" or "Blue-Team"
+    team_display_name: str  # premade team name, or "Red Team"/"Blue Team"
+
+
+def resolve_sub_grant(
+    session,
+    invoker_id: str,
+    target_id: str,
+    is_admin: bool,
+    team_choice: Optional[str] = None,
+) -> Tuple[Optional[GrantDecision], Optional[str]]:
+    """Decide whether invoker may grant target sub access, and to which team.
+
+    Players on a team always grant their own team (team_choice is ignored);
+    admins outside the draft must pass team_choice "A" or "B".
+    Returns (decision, error) — exactly one is None.
+    """
+    team_a = session.team_a or []
+    team_b = session.team_b or []
+    sign_ups = session.sign_ups or {}
+
+    if target_id in team_a or target_id in team_b or target_id in sign_ups:
+        return None, "That user is already a participant in this draft."
+
+    if invoker_id in team_a:
+        team_key = "A"
+    elif invoker_id in team_b:
+        team_key = "B"
+    elif is_admin:
+        if team_choice not in ("A", "B"):
+            return None, ("You're not on a team in this draft — pass the "
+                          "`team` option (A or B) to choose the sub's team.")
+        team_key = team_choice
+    else:
+        return None, "Only players in this draft (or bot managers) can add a sub."
+
+    if team_key == "A":
+        display = session.team_a_name or "Red Team"
+        return GrantDecision("A", TEAM_A_CHANNEL_PREFIX, display), None
+    display = session.team_b_name or "Blue Team"
+    return GrantDecision("B", TEAM_B_CHANNEL_PREFIX, display), None
+
+
+def is_sub_target_channel(channel_name: str, draft_id: str, channel_prefix: str) -> bool:
+    """True if channel_name is one of the channels a sub should be granted.
+
+    Case-insensitive: Discord lowercases text channel names on creation,
+    while voice channels keep their original casing.
+    """
+    targets = {
+        f"draft-chat-{draft_id}".lower(),
+        f"{channel_prefix}-chat-{draft_id}".lower(),
+        f"{channel_prefix}-voice-{draft_id}".lower(),
+    }
+    return channel_name.lower() in targets
+
+
+def channel_ids_contains(channel_ids, channel_id) -> bool:
+    """Membership test tolerant of int-vs-str storage in the channel_ids JSON."""
+    if not channel_ids:
+        return False
+    wanted = str(channel_id)
+    return any(str(cid) == wanted for cid in channel_ids)

--- a/helpers/substitutes.py
+++ b/helpers/substitutes.py
@@ -14,9 +14,9 @@ TEAM_B_CHANNEL_PREFIX = "Blue-Team"
 
 @dataclass
 class GrantDecision:
-    team_key: str           # "A" or "B"
-    channel_prefix: str     # "Red-Team" or "Blue-Team"
-    team_display_name: str  # premade team name, or "Red Team"/"Blue Team"
+    team_key: Optional[str]            # "A"/"B", or None for a team-less draft
+    channel_prefix: Optional[str]      # "Red-Team"/"Blue-Team", or None (draft chat only)
+    team_display_name: str             # premade team name, "Red Team"/"Blue Team", or "this draft"
 
 
 def resolve_sub_grant(
@@ -39,6 +39,12 @@ def resolve_sub_grant(
     if target_id in team_a or target_id in team_b or target_id in sign_ups:
         return None, "That user is already a participant in this draft."
 
+    if not team_a and not team_b:
+        # Team-less draft (e.g. swiss): only the shared draft chat exists.
+        if invoker_id in sign_ups or is_admin:
+            return GrantDecision(None, None, "this draft"), None
+        return None, "Only players in this draft (or bot managers) can add a sub."
+
     if invoker_id in team_a:
         team_key = "A"
     elif invoker_id in team_b:
@@ -58,17 +64,19 @@ def resolve_sub_grant(
     return GrantDecision("B", TEAM_B_CHANNEL_PREFIX, display), None
 
 
-def is_sub_target_channel(channel_name: str, draft_id: str, channel_prefix: str) -> bool:
+def is_sub_target_channel(channel_name: str, draft_id: str, channel_prefix: Optional[str]) -> bool:
     """True if channel_name is one of the channels a sub should be granted.
 
     Case-insensitive: Discord lowercases text channel names on creation,
     while voice channels keep their original casing.
+
+    channel_prefix is None for team-less drafts, where only the shared
+    draft chat exists.
     """
-    targets = {
-        f"draft-chat-{draft_id}".lower(),
-        f"{channel_prefix}-chat-{draft_id}".lower(),
-        f"{channel_prefix}-voice-{draft_id}".lower(),
-    }
+    targets = {f"draft-chat-{draft_id}".lower()}
+    if channel_prefix:
+        targets.add(f"{channel_prefix}-chat-{draft_id}".lower())
+        targets.add(f"{channel_prefix}-voice-{draft_id}".lower())
     return channel_name.lower() in targets
 
 

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -86,11 +86,16 @@ class DraftSession(Base):
             return result.scalar_one_or_none()
 
     @classmethod
-    async def get_by_any_channel_id(cls, channel_id):
+    async def get_by_any_channel_id(cls, channel_id: int | str):
         """Get a draft session whose main chat OR any created channel matches.
 
         Unlike get_by_channel_id (draft_chat_channel only), this also searches
         the channel_ids JSON so lookups work from team chat channels too.
+
+        The SQL LIKE prefilter narrows candidates to sessions whose channel_ids
+        JSON contains the channel ID as a substring; the Python
+        channel_ids_contains check then confirms exact membership to avoid
+        false positives (e.g. channel 123 matching stored ID 51234).
         """
         from helpers.substitutes import channel_ids_contains
 
@@ -102,6 +107,7 @@ class DraftSession(Base):
             from sqlalchemy import desc
             query = (select(cls)
                      .where(cls.channel_ids.isnot(None))
+                     .where(cls.channel_ids.cast(String).like(f'%{channel_id}%'))
                      .order_by(desc(cls.draft_start_time)))
             result = await session.execute(query)
             for draft in result.scalars().all():

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -84,7 +84,31 @@ class DraftSession(Base):
             query = select(cls).filter_by(draft_chat_channel=channel_id)
             result = await session.execute(query)
             return result.scalar_one_or_none()
-    
+
+    @classmethod
+    async def get_by_any_channel_id(cls, channel_id):
+        """Get a draft session whose main chat OR any created channel matches.
+
+        Unlike get_by_channel_id (draft_chat_channel only), this also searches
+        the channel_ids JSON so lookups work from team chat channels too.
+        """
+        from helpers.substitutes import channel_ids_contains
+
+        channel_id = str(channel_id)
+        found = await cls.get_by_channel_id(channel_id)
+        if found:
+            return found
+        async with db_session() as session:
+            from sqlalchemy import desc
+            query = (select(cls)
+                     .where(cls.channel_ids.isnot(None))
+                     .order_by(desc(cls.draft_start_time)))
+            result = await session.execute(query)
+            for draft in result.scalars().all():
+                if channel_ids_contains(draft.channel_ids, channel_id):
+                    return draft
+        return None
+
     def is_user_participating(self, user_id: str) -> bool:
         """Check if a user is participating in this draft session"""
         return user_id in self.team_a or user_id in self.team_b

--- a/models/draft_session.py
+++ b/models/draft_session.py
@@ -1,6 +1,6 @@
 from sqlalchemy import Column, Integer, String, DateTime, JSON, Boolean, text
 from sqlalchemy.orm import relationship
-from sqlalchemy import select
+from sqlalchemy import select, desc
 from datetime import datetime
 from urllib.parse import quote
 from database.models_base import Base
@@ -104,7 +104,6 @@ class DraftSession(Base):
         if found:
             return found
         async with db_session() as session:
-            from sqlalchemy import desc
             query = (select(cls)
                      .where(cls.channel_ids.isnot(None))
                      .where(cls.channel_ids.cast(String).like(f'%{channel_id}%'))

--- a/tests/test_add_sub_command.py
+++ b/tests/test_add_sub_command.py
@@ -106,6 +106,26 @@ async def test_admin_outside_draft_grants_chosen_team(cog):
 
 
 @pytest.mark.asyncio
+async def test_teamless_draft_grants_draft_chat_only(cog):
+    # Swiss/team-less draft: only the shared draft chat channel exists.
+    channels = {100: make_channel(100, "draft-chat-abc123")}
+    ctx = make_ctx("1", channels)  # invoker is a sign-up, not on a team
+    sub = make_sub()
+    draft = make_draft(channel_ids=[100], team_a=[], team_b=[])
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, sub, None)
+
+    channels[100].set_permissions.assert_awaited_once_with(
+        sub, read_messages=True, manage_messages=True)
+    channels[100].send.assert_awaited_once()
+    assert "this draft" in channels[100].send.await_args.args[0]
+    ctx.followup.send.assert_awaited_once()
+    assert ctx.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
 async def test_not_a_draft_channel_is_ephemeral_error(cog):
     ctx = make_ctx("1", {})
     with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",

--- a/tests/test_add_sub_command.py
+++ b/tests/test_add_sub_command.py
@@ -197,4 +197,4 @@ async def test_all_grants_failing_reports_could_not_grant(cog):
         await cog._do_add_sub(ctx, make_sub(), None)
     message = ctx.followup.send.await_args.args[0]
     assert "could not grant" in message.lower()
-    assert "granted" not in message.lower().split("\n")[0][:7]
+    assert not message.lower().startswith("granted")

--- a/tests/test_add_sub_command.py
+++ b/tests/test_add_sub_command.py
@@ -165,3 +165,19 @@ async def test_partial_discord_failure_is_reported(cog):
         await cog._do_add_sub(ctx, make_sub(), None)
     message = ctx.followup.send.await_args.args[0]
     assert "failed" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_draft_chat_failure_skips_announcement_and_notes_it(cog):
+    channels = standard_channels()
+    channels[100].set_permissions = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=500), "boom"))
+    ctx = make_ctx("1", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    channels[100].send.assert_not_awaited()
+    message = ctx.followup.send.await_args.args[0]
+    assert "announcement" in message.lower()

--- a/tests/test_add_sub_command.py
+++ b/tests/test_add_sub_command.py
@@ -181,3 +181,20 @@ async def test_draft_chat_failure_skips_announcement_and_notes_it(cog):
     channels[100].send.assert_not_awaited()
     message = ctx.followup.send.await_args.args[0]
     assert "announcement" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_all_grants_failing_reports_could_not_grant(cog):
+    channels = standard_channels()
+    for channel in channels.values():
+        channel.set_permissions = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(status=500), "boom"))
+    ctx = make_ctx("1", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    message = ctx.followup.send.await_args.args[0]
+    assert "could not grant" in message.lower()
+    assert "granted" not in message.lower().split("\n")[0][:7]

--- a/tests/test_add_sub_command.py
+++ b/tests/test_add_sub_command.py
@@ -1,0 +1,167 @@
+import discord
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.draft_commands import DraftCommands
+
+
+def make_channel(channel_id, name):
+    channel = MagicMock()
+    channel.id = channel_id
+    channel.name = name
+    channel.mention = f"#{name}"
+    channel.set_permissions = AsyncMock()
+    channel.send = AsyncMock()
+    return channel
+
+
+def make_ctx(invoker_id, channels):
+    ctx = MagicMock()
+    ctx.author.id = int(invoker_id)
+    ctx.author.display_name = f"user-{invoker_id}"
+    ctx.channel_id = 100
+    ctx.followup.send = AsyncMock()
+    ctx.guild.get_channel = lambda cid: channels.get(cid)
+    return ctx
+
+
+def make_sub(user_id=9):
+    sub = MagicMock()
+    sub.id = user_id
+    sub.display_name = "SubGuy"
+    sub.mention = f"<@{user_id}>"
+    return sub
+
+
+def make_draft(draft_id="abc123", channel_ids=None, draft_chat_channel="100",
+               team_a=("1",), team_b=("2",)):
+    return SimpleNamespace(
+        draft_id=draft_id,
+        session_id="sess_123",
+        channel_ids=channel_ids if channel_ids is not None else [100, 101, 102],
+        draft_chat_channel=draft_chat_channel,
+        team_a=list(team_a),
+        team_b=list(team_b),
+        sign_ups={"1": "One", "2": "Two"},
+        team_a_name=None,
+        team_b_name=None,
+    )
+
+
+@pytest.fixture
+def cog():
+    return DraftCommands(bot=MagicMock())
+
+
+# Channel names as Discord stores them: text channels lowercased
+def standard_channels(draft_id="abc123"):
+    return {
+        100: make_channel(100, f"draft-chat-{draft_id}"),
+        101: make_channel(101, f"red-team-chat-{draft_id}"),
+        102: make_channel(102, f"blue-team-chat-{draft_id}"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_player_grants_sub_draft_chat_and_own_team_chat(cog):
+    channels = standard_channels()
+    ctx = make_ctx("1", channels)  # invoker on team_a
+    sub = make_sub()
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, sub, None)
+
+    # Draft chat + red team chat get overwrites, blue team chat does not
+    channels[100].set_permissions.assert_awaited_once_with(
+        sub, read_messages=True, manage_messages=True)
+    channels[101].set_permissions.assert_awaited_once_with(
+        sub, read_messages=True, manage_messages=True)
+    channels[102].set_permissions.assert_not_awaited()
+
+    # Public announcement in draft chat, ephemeral confirmation to invoker
+    channels[100].send.assert_awaited_once()
+    assert sub.mention in channels[100].send.await_args.args[0]
+    ctx.followup.send.assert_awaited_once()
+    assert ctx.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_admin_outside_draft_grants_chosen_team(cog):
+    channels = standard_channels()
+    ctx = make_ctx("99", channels)  # not in draft
+    sub = make_sub()
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=True)):
+        await cog._do_add_sub(ctx, sub, "B")
+
+    channels[100].set_permissions.assert_awaited_once()
+    channels[102].set_permissions.assert_awaited_once()
+    channels[101].set_permissions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_not_a_draft_channel_is_ephemeral_error(cog):
+    ctx = make_ctx("1", {})
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=None)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+    assert ctx.followup.send.await_args.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_non_participant_non_admin_gets_error_and_no_grants(cog):
+    channels = standard_channels()
+    ctx = make_ctx("99", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    for channel in channels.values():
+        channel.set_permissions.assert_not_awaited()
+    ctx.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deleted_channels_reported_as_error(cog):
+    # Session exists but none of its channels resolve in the guild anymore
+    ctx = make_ctx("1", {})
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+    assert "deleted" in ctx.followup.send.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_no_channel_ids_yet_is_error(cog):
+    ctx = make_ctx("1", {})
+    draft = make_draft(channel_ids=[])
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    ctx.followup.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_discord_failure_is_reported(cog):
+    channels = standard_channels()
+    channels[101].set_permissions = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=500), "boom"))
+    ctx = make_ctx("1", channels)
+    draft = make_draft()
+    with patch("cogs.draft_commands.DraftSession.get_by_any_channel_id",
+               AsyncMock(return_value=draft)), \
+         patch("cogs.draft_commands.is_bot_manager", AsyncMock(return_value=False)):
+        await cog._do_add_sub(ctx, make_sub(), None)
+    message = ctx.followup.send.await_args.args[0]
+    assert "failed" in message.lower()

--- a/tests/test_substitutes.py
+++ b/tests/test_substitutes.py
@@ -1,4 +1,7 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from helpers.substitutes import (
     GrantDecision,
@@ -6,6 +9,7 @@ from helpers.substitutes import (
     is_sub_target_channel,
     resolve_sub_grant,
 )
+from models.draft_session import DraftSession
 
 
 def make_session(team_a=None, team_b=None, sign_ups=None,
@@ -145,12 +149,6 @@ def test_contains_handles_none_and_empty():
 
 
 # ---- DraftSession.get_by_any_channel_id --------------------------------------
-
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-
-from models.draft_session import DraftSession
-
 
 def _mock_db_session(drafts):
     """Async-context-manager mock for models.draft_session.db_session whose

--- a/tests/test_substitutes.py
+++ b/tests/test_substitutes.py
@@ -142,3 +142,55 @@ def test_contains_handles_str_stored_ids():
 def test_contains_handles_none_and_empty():
     assert not channel_ids_contains(None, 111)
     assert not channel_ids_contains([], 111)
+
+
+# ---- DraftSession.get_by_any_channel_id --------------------------------------
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from models.draft_session import DraftSession
+
+
+def _mock_db_session(drafts):
+    """Async-context-manager mock for models.draft_session.db_session whose
+    execute() returns the given drafts via .scalars().all()."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = drafts
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    db = MagicMock(return_value=ctx)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_prefers_draft_chat_match():
+    direct_hit = SimpleNamespace(session_id="s1")
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=direct_hit)) as direct:
+        found = await DraftSession.get_by_any_channel_id(555)
+    assert found is direct_hit
+    direct.assert_awaited_once_with("555")
+
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_falls_back_to_channel_ids():
+    other = SimpleNamespace(session_id="s0", channel_ids=[333])
+    match = SimpleNamespace(session_id="s1", channel_ids=[111, 222])  # ints, as stored
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=None)), \
+         patch("models.draft_session.db_session", _mock_db_session([other, match])):
+        found = await DraftSession.get_by_any_channel_id("222")
+    assert found is match
+
+
+@pytest.mark.asyncio
+async def test_get_by_any_channel_id_returns_none_when_no_match():
+    with patch.object(DraftSession, "get_by_channel_id",
+                      AsyncMock(return_value=None)), \
+         patch("models.draft_session.db_session", _mock_db_session([])):
+        found = await DraftSession.get_by_any_channel_id(999)
+    assert found is None

--- a/tests/test_substitutes.py
+++ b/tests/test_substitutes.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+from helpers.substitutes import (
+    GrantDecision,
+    channel_ids_contains,
+    is_sub_target_channel,
+    resolve_sub_grant,
+)
+
+
+def make_session(team_a=None, team_b=None, sign_ups=None,
+                 team_a_name=None, team_b_name=None):
+    return SimpleNamespace(
+        team_a=team_a or [],
+        team_b=team_b or [],
+        sign_ups=sign_ups or {},
+        team_a_name=team_a_name,
+        team_b_name=team_b_name,
+    )
+
+
+# ---- resolve_sub_grant ------------------------------------------------------
+
+def test_player_on_team_a_grants_red_team():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False)
+    assert error is None
+    assert decision.team_key == "A"
+    assert decision.channel_prefix == "Red-Team"
+    assert decision.team_display_name == "Red Team"  # fallback when name unset
+
+
+def test_player_on_team_b_grants_blue_team():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="2", target_id="9",
+                                        is_admin=False)
+    assert error is None
+    assert decision.team_key == "B"
+    assert decision.channel_prefix == "Blue-Team"
+
+
+def test_premade_team_name_used_for_display():
+    session = make_session(team_a=["1"], team_b=["2"],
+                           team_a_name="Goblin Gang", team_b_name="Merfolk Mob")
+    decision, _ = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                    is_admin=False)
+    assert decision.team_display_name == "Goblin Gang"
+
+
+def test_player_team_choice_is_ignored():
+    """A player always grants their own team, even if they pass team_choice."""
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False, team_choice="B")
+    assert error is None
+    assert decision.team_key == "A"
+
+
+def test_admin_not_in_draft_uses_team_choice():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True, team_choice="B")
+    assert error is None
+    assert decision.team_key == "B"
+    assert decision.channel_prefix == "Blue-Team"
+
+
+def test_admin_without_team_choice_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True)
+    assert decision is None
+    assert "team" in error.lower()
+
+
+def test_non_participant_non_admin_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=False)
+    assert decision is None
+    assert error is not None
+
+
+def test_target_already_on_a_team_is_error():
+    session = make_session(team_a=["1"], team_b=["2"])
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="2",
+                                        is_admin=False)
+    assert decision is None
+    assert "already" in error.lower()
+
+
+def test_target_in_sign_ups_is_error():
+    session = make_session(team_a=["1"], team_b=["2"], sign_ups={"9": "Niner"})
+    decision, error = resolve_sub_grant(session, invoker_id="1", target_id="9",
+                                        is_admin=False)
+    assert decision is None
+    assert "already" in error.lower()
+
+
+def test_none_team_fields_are_tolerated():
+    session = SimpleNamespace(team_a=None, team_b=None, sign_ups=None,
+                              team_a_name=None, team_b_name=None)
+    decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
+                                        is_admin=True, team_choice="A")
+    assert error is None
+    assert decision.team_key == "A"
+
+
+# ---- is_sub_target_channel --------------------------------------------------
+
+def test_matches_lowercased_discord_text_channel_names():
+    # Discord lowercases text channel names on creation
+    assert is_sub_target_channel("draft-chat-AbC123".lower(), "AbC123", "Red-Team")
+    assert is_sub_target_channel("red-team-chat-abc123", "AbC123", "Red-Team")
+
+
+def test_matches_voice_channel_with_original_case():
+    assert is_sub_target_channel("Red-Team-Voice-AbC123", "AbC123", "Red-Team")
+
+
+def test_rejects_other_teams_channels():
+    assert not is_sub_target_channel("blue-team-chat-abc123", "AbC123", "Red-Team")
+    assert not is_sub_target_channel("Blue-Team-Voice-AbC123", "AbC123", "Red-Team")
+
+
+def test_rejects_channels_of_other_drafts():
+    assert not is_sub_target_channel("red-team-chat-zzz999", "AbC123", "Red-Team")
+
+
+# ---- channel_ids_contains ---------------------------------------------------
+
+def test_contains_handles_int_stored_ids_and_str_query():
+    assert channel_ids_contains([111, 222], "222")
+    assert channel_ids_contains([111, 222], 111)
+
+
+def test_contains_handles_str_stored_ids():
+    assert channel_ids_contains(["111", "222"], 222)
+
+
+def test_contains_handles_none_and_empty():
+    assert not channel_ids_contains(None, 111)
+    assert not channel_ids_contains([], 111)

--- a/tests/test_substitutes.py
+++ b/tests/test_substitutes.py
@@ -103,12 +103,48 @@ def test_target_in_sign_ups_is_error():
 
 
 def test_none_team_fields_are_tolerated():
+    """None team_a/team_b/sign_ups is a team-less draft — no crash, draft chat only."""
     session = SimpleNamespace(team_a=None, team_b=None, sign_ups=None,
                               team_a_name=None, team_b_name=None)
     decision, error = resolve_sub_grant(session, invoker_id="99", target_id="9",
                                         is_admin=True, team_choice="A")
     assert error is None
-    assert decision.team_key == "A"
+    assert decision.team_key is None
+    assert decision.channel_prefix is None
+
+
+# ---- team-less drafts (e.g. swiss) ------------------------------------------
+
+def test_teamless_draft_participant_gets_draft_chat_only():
+    session = make_session(team_a=[], team_b=[], sign_ups={"p1": "P1"})
+    decision, error = resolve_sub_grant(session, invoker_id="p1", target_id="sub",
+                                        is_admin=False)
+    assert error is None
+    assert decision.channel_prefix is None
+    assert decision.team_key is None
+    assert decision.team_display_name == "this draft"
+
+
+def test_teamless_draft_admin_gets_draft_chat_only():
+    session = make_session(team_a=[], team_b=[], sign_ups={"p1": "P1"})
+    decision, error = resolve_sub_grant(session, invoker_id="admin", target_id="sub",
+                                        is_admin=True)
+    assert error is None
+    assert decision.channel_prefix is None
+    assert decision.team_key is None
+
+
+def test_teamless_draft_non_participant_non_admin_rejected():
+    session = make_session(team_a=[], team_b=[], sign_ups={"p1": "P1"})
+    decision, error = resolve_sub_grant(session, invoker_id="stranger", target_id="sub",
+                                        is_admin=False)
+    assert decision is None
+    assert error is not None
+
+
+def test_teamless_target_channel_matches_draft_chat_only():
+    assert is_sub_target_channel("draft-chat-ABC", "ABC", None) is True
+    assert is_sub_target_channel("red-team-chat-ABC", "ABC", None) is False
 
 
 # ---- is_sub_target_channel --------------------------------------------------


### PR DESCRIPTION
Adds `/add_sub`, which grants a substitute player read/manage access to a running draft's team and draft-chat channels.

- `DraftSession.get_by_any_channel_id` for team-chat lookups (bounded scan).
- Pure decision helpers for who gets access, with tests.
- Surfaces a clear message when a draft-chat grant is skipped/fails.

Includes design spec, implementation plan, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)