### PR TITLE
Fix quiz starvation: persist spaces_object_key + paginate Spaces listing

### DIFF
--- a/helpers/digital_ocean_helper.py
+++ b/helpers/digital_ocean_helper.py
@@ -214,16 +214,20 @@ class DigitalOceanHelper:
 
             async with client as s3:
                 self.logger.debug(f"Listing objects with bucket={self.bucket}, prefix={prefix}")
-                response = await s3.list_objects_v2(
-                    Bucket=self.bucket,
-                    Prefix=prefix
-                )
-
-                if 'Contents' not in response:
-                    self.logger.debug(f"No contents found for prefix {prefix}")
-                    return []
-
-                keys = [obj['Key'] for obj in response['Contents']]
+                keys = []
+                continuation_token = None
+                while True:
+                    kwargs = {"Bucket": self.bucket, "Prefix": prefix}
+                    if continuation_token:
+                        kwargs["ContinuationToken"] = continuation_token
+                    response = await s3.list_objects_v2(**kwargs)
+                    keys.extend(obj["Key"] for obj in response.get("Contents", []))
+                    continuation_token = response.get("NextContinuationToken")
+                    if not (response.get("IsTruncated") and continuation_token):
+                        # Stop when the API says we're done, or defensively if it
+                        # claims truncation but omits the token (avoids re-fetching
+                        # the first page forever).
+                        break
                 self.logger.debug(f"Found {len(keys)} keys for prefix {prefix}")
                 return keys
 

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -762,7 +762,7 @@ class DraftSetupManager:
                     return True
 
             # Upload raw JSON + per-player MPT files to Spaces.
-            upload_successful = await self.save_to_digitalocean_spaces(draft_data)
+            object_key = await self.save_to_digitalocean_spaces(draft_data)
 
             async with db_session() as session:
                 draft_session = (await session.execute(
@@ -770,7 +770,7 @@ class DraftSetupManager:
                 )).scalar_one_or_none()
                 if not draft_session:
                     # Spaces upload may already have happened; only the DB write failed.
-                    self.logger.warning(f"No draft session for {self.session_id} (spaces_upload={upload_successful})")
+                    self.logger.warning(f"No draft session for {self.session_id} (spaces_key={object_key})")
                     return False
 
                 # Always persist the raw log so the data is never lost.
@@ -778,7 +778,7 @@ class DraftSetupManager:
 
                 # Only mark fully captured when Spaces succeeded, so a failed
                 # upload stays retryable (logs_captured_at stays NULL).
-                if upload_successful:
+                if object_key:
                     discord_user_pack_picks = {}
                     if draft_session.sign_ups:
                         discord_ids = list(draft_session.sign_ups.keys())
@@ -791,11 +791,12 @@ class DraftSetupManager:
                                 discord_user_pack_picks[discord_ids[idx]] = self.get_pack_first_picks(draft_data, draft_user_id)
                     draft_session.pack_first_picks = discord_user_pack_picks
                     draft_session.logs_captured_at = datetime.now()
+                    draft_session.spaces_object_key = object_key
 
                 await session.commit()
 
-            self.logger.info(f"Captured draft log for {self.session_id} (spaces_upload={upload_successful})")
-            return upload_successful
+            self.logger.info(f"Captured draft log for {self.session_id} (spaces_key={object_key})")
+            return bool(object_key)
         except Exception as e:
             self.logger.exception(f"Error capturing draft log: {e}")
             return False
@@ -868,7 +869,8 @@ class DraftSetupManager:
             self.logger.exception(f"Error in scheduled publish for {self.session_id}: {e}")
 
     async def save_to_digitalocean_spaces(self, draft_data):
-        """Upload draft log data to DigitalOcean Spaces"""
+        """Upload draft log data to DigitalOcean Spaces. Returns the object key
+        (e.g. 'team/cube-ts-id.json') on success, or None on failure."""
         start_time = draft_data.get("time")
         draft_id = draft_data.get("sessionID")
         
@@ -888,15 +890,15 @@ class DraftSetupManager:
                 
                 # If upload successful, also generate and upload MagicProTools format logs
                 await self.process_draft_logs_for_magicprotools(draft_data, do_helper)
-                
-                return True
+
+                return result.object_path
             else:
                 self.logger.warning("Failed to upload draft log data to DigitalOcean Spaces")
-                return False
-                
+                return None
+
         except Exception as e:
             self.logger.error(f"Error uploading to DigitalOcean Space: {e}")
-            return False
+            return None
 
     async def process_draft_logs_for_magicprotools(self, draft_data, do_helper):
         """Process the draft log and generate formatted logs for each player."""

--- a/tests/test_do_helper_pagination.py
+++ b/tests/test_do_helper_pagination.py
@@ -1,0 +1,38 @@
+"""list_objects must follow ContinuationToken to return >1000 keys."""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from helpers.digital_ocean_helper import DigitalOceanHelper
+
+
+@pytest.mark.asyncio
+async def test_list_objects_paginates():
+    pages = [
+        {"Contents": [{"Key": "b/team/a.json"}, {"Key": "b/team/b.json"}],
+         "IsTruncated": True, "NextContinuationToken": "tok2"},
+        {"Contents": [{"Key": "b/team/c.json"}], "IsTruncated": False},
+    ]
+    calls = []
+    fake_s3 = MagicMock()
+    async def _list(**kwargs):
+        calls.append(kwargs)
+        return pages[len(calls) - 1]
+    fake_s3.list_objects_v2 = _list
+
+    @asynccontextmanager
+    async def _client_ctx():
+        yield fake_s3
+
+    helper = DigitalOceanHelper.__new__(DigitalOceanHelper)
+    helper.config_valid = True
+    helper.bucket = "b"
+    helper.logger = MagicMock()
+    helper.create_raw_client = AsyncMock(return_value=_client_ctx())
+
+    keys = await helper.list_objects("b/team/")
+
+    assert keys == ["b/team/a.json", "b/team/b.json", "b/team/c.json"]
+    assert len(calls) == 2
+    assert calls[1].get("ContinuationToken") == "tok2"   # second page requested with token

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -54,7 +54,7 @@ async def test_capture_stores_data_and_stamps_without_publishing():
                          data_received=False)
     db_factory, session = _mock_db_session(ds)
     with patch("services.draft_setup_manager.db_session", db_factory), \
-         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=True)) as spaces, \
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value="team/x.json")) as spaces, \
          patch.object(DraftSetupManager, "get_pack_first_picks", MagicMock(return_value={})), \
          patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
         ok = await m.capture_draft_log(_draft_data())
@@ -65,6 +65,7 @@ async def test_capture_stores_data_and_stamps_without_publishing():
     assert ds.data_received is False
     assert ds.draft_data is not None
     assert ds.logs_captured_at is not None
+    assert ds.spaces_object_key == "team/x.json"
     session.commit.assert_awaited()
 
 
@@ -76,7 +77,7 @@ async def test_capture_is_idempotent():
                          data_received=False)
     db_factory, _ = _mock_db_session(ds)
     with patch("services.draft_setup_manager.db_session", db_factory), \
-         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=True)) as spaces:
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value="team/x.json")) as spaces:
         ok = await m.capture_draft_log(_draft_data())
 
     assert ok is True
@@ -99,10 +100,10 @@ async def test_capture_spaces_failure_keeps_db_copy_without_stamp():
     m = _manager()
     ds = SimpleNamespace(session_id="sid", sign_ups={"d1": "Alice", "d2": "Bob"},
                          draft_data=None, pack_first_picks=None, logs_captured_at=None,
-                         data_received=False)
+                         data_received=False, spaces_object_key=None)
     db_factory, session = _mock_db_session(ds)
     with patch("services.draft_setup_manager.db_session", db_factory), \
-         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=False)) as spaces, \
+         patch.object(DraftSetupManager, "save_to_digitalocean_spaces", AsyncMock(return_value=None)) as spaces, \
          patch.object(DraftSetupManager, "get_pack_first_picks", MagicMock(return_value={})), \
          patch.object(DraftSetupManager, "send_magicprotools_embed", AsyncMock()) as embed:
         ok = await m.capture_draft_log(_draft_data())
@@ -112,6 +113,7 @@ async def test_capture_spaces_failure_keeps_db_copy_without_stamp():
     embed.assert_not_called()
     assert ds.draft_data is not None        # raw log still saved (data safety)
     assert ds.logs_captured_at is None      # NOT stamped -> retryable
+    assert ds.spaces_object_key is None     # upload failed -> no key, stays retryable
 
 
 @pytest.mark.asyncio
@@ -267,3 +269,16 @@ async def test_manually_unlock_delegates_to_publish_with_release():
         result = await m.manually_unlock_draft_logs()
     assert result is True
     pub.assert_awaited_once_with(release=True)
+
+
+@pytest.mark.asyncio
+async def test_save_to_spaces_returns_object_key():
+    m = DraftSetupManager.__new__(DraftSetupManager)   # bypass __init__
+    m.session_type = "team"; m.cube_id = "TestCube"
+    m.logger = MagicMock()
+    m.process_draft_logs_for_magicprotools = AsyncMock(return_value=True)
+    fake_result = MagicMock(success=True, object_path="team/TestCube-123-DBABC.json")
+    fake_helper = MagicMock(); fake_helper.upload_json = AsyncMock(return_value=fake_result)
+    with patch("services.draft_setup_manager.DigitalOceanHelper", return_value=fake_helper):
+        key = await m.save_to_digitalocean_spaces({"time": 123, "sessionID": "DBABC"})
+    assert key == "team/TestCube-123-DBABC.json"


### PR DESCRIPTION
## Problem
Guild 1399789864961970337's quiz cycled a single draft and then failed every day at 17:00 with `No unused draft+seat combinations found (checked 1 drafts, 6 combinations already used)`. The quiz only draws drafts where `spaces_object_key IS NOT NULL`, and two bugs left almost no drafts eligible (repo-wide, only ~5% had a key).

## Root causes & fixes
1. **Key never recorded on capture.** `draft_setup_manager.save_to_digitalocean_spaces` uploaded the draft JSON to Spaces but returned only a bool, so `capture_draft_log` never stored the object key. It now returns `result.object_path` (the `team/…json` form `load_from_spaces` expects) and `capture_draft_log` persists `draft_session.spaces_object_key` in its success gate. Stops the bleeding for new drafts.
2. **Backfill listing capped at 1000.** `DigitalOceanHelper.list_objects` made a single `list_objects_v2` call (S3 caps at 1000 keys), so the recovery script `backfill_spaces_keys.py` missed most files. It now paginates via `ContinuationToken` (with a defensive break if the API claims truncation without a token).

## Verified against a prod DB copy
- Before: guild 1399 had **1** eligible draft.
- Paginated listing now sees all **2217** objects (was 1000); running `backfill_spaces_keys.py --execute` recovers guild 1399 to **242 eligible drafts (241 unused)** — the quiz no longer starves.

## Recovery step (ops, after merge/deploy)
Run `pipenv run python backfill_spaces_keys.py --execute` once to populate historical keys (now that listing paginates). No schema/migration change.

## Tests
New/updated: `tests/test_log_capture.py` (asserts key is persisted on success, stays None on upload failure), `tests/test_do_helper_pagination.py` (asserts ContinuationToken is followed across pages). Full suite: 534 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)