### PR TITLE
feat(stats): re-anchor skill rating display to the familiar 1500 Elo scale

### DIFF
--- a/helpers/skill.py
+++ b/helpers/skill.py
@@ -45,9 +45,33 @@ def rating_counts_for(session_type):
     return session_type in RATING_SESSION_TYPES
 
 
-def skill_rating(mu, sigma):
-    """Scaled, Elo-like conservative rating for display: round((mu - 3*sigma) * 40)."""
-    return round((mu - 3 * sigma) * 40)
+# Display anchoring: a new player shows exactly RATING_ANCHOR; each TrueSkill
+# mu point moves the display by up to RATING_POINTS_PER_MU, discounted by a
+# games-based shrink factor g/(g + RATING_SHRINK_GAMES). The shrink keeps
+# short hot streaks from spiking past long proven records (a 16-6 newcomer
+# earns less than half of their mu edge until ~30 games), while the anchor
+# still holds exactly at zero games. 95/mu is wider than the
+# win-probability-faithful Elo conversion (~45/mu) on purpose — it puts the
+# server's top proven players around ~1850, matching the familiar MTG Elo
+# Project scale, at the cost of overstating win odds implied by point gaps.
+RATING_ANCHOR = 1500
+RATING_POINTS_PER_MU = 95
+RATING_SHRINK_GAMES = 30
+
+
+def skill_rating(mu, sigma, games):
+    """Elo-anchored display rating with small-sample shrinkage.
+
+    round(1500 + (mu - 25) * g/(g+30) * 95): a new player shows exactly 1500,
+    the strongest proven players reach ~1850, and a hot short record is pulled
+    toward the anchor until it is earned over more games. Uses mu alone (not
+    the mu - 3*sigma conservative floor) so the anchor holds for new players
+    too; the "(provisional)" label under ESTABLISHED_GAMES flags the remaining
+    uncertainty.
+    """
+    del sigma  # kept in the signature for call-site stability
+    weight = games / (games + RATING_SHRINK_GAMES)
+    return round(RATING_ANCHOR + (mu - PRIOR_MU) * weight * RATING_POINTS_PER_MU)
 
 
 def is_established(games):

--- a/player_stats.py
+++ b/player_stats.py
@@ -610,6 +610,7 @@ async def create_stats_embed(user, stats_weekly, stats_monthly, stats_lifetime):
     skill = stats_lifetime.get('skill_rating')
     if skill is not None:
         value = f"{skill} (provisional)" if stats_lifetime.get('skill_provisional') else str(skill)
+        value += "\n*New players start at 1500 · a 100-point gap ≈ 60% match favorite*"
         embed.add_field(name="🎯 Skill Rating", value=value, inline=False)
 
     # Add cube-specific stats if any are available

--- a/stats_display.py
+++ b/stats_display.py
@@ -34,7 +34,7 @@ async def _player_skill_rating(player_id, guild_id):
         return None, None
     mu, sigma, games_won, games_lost = row
     games = (games_won or 0) + (games_lost or 0)
-    return skill_rating(mu, sigma), not is_established(games)
+    return skill_rating(mu, sigma, games), not is_established(games)
 
 
 async def get_stats_embed_for_player(

--- a/tests/test_create_stats_embed_skill.py
+++ b/tests/test_create_stats_embed_skill.py
@@ -26,18 +26,21 @@ def _field(embed, name):
     return next((f for f in embed.fields if f.name == name), None)
 
 
+SCALE_NOTE = "\n*New players start at 1500 · a 100-point gap ≈ 60% match favorite*"
+
+
 @pytest.mark.asyncio
 async def test_established_rating_shown_plain():
-    lifetime = _stats(skill_rating=1030, skill_provisional=False)
+    lifetime = _stats(skill_rating=1620, skill_provisional=False)
     embed = await create_stats_embed(_User(), _stats(), _stats(), lifetime)
-    assert _field(embed, "🎯 Skill Rating").value == "1030"
+    assert _field(embed, "🎯 Skill Rating").value == "1620" + SCALE_NOTE
 
 
 @pytest.mark.asyncio
 async def test_provisional_rating_labelled():
-    lifetime = _stats(skill_rating=412, skill_provisional=True)
+    lifetime = _stats(skill_rating=1552, skill_provisional=True)
     embed = await create_stats_embed(_User(), _stats(), _stats(), lifetime)
-    assert _field(embed, "🎯 Skill Rating").value == "412 (provisional)"
+    assert _field(embed, "🎯 Skill Rating").value == "1552 (provisional)" + SCALE_NOTE
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -28,11 +28,27 @@ def test_rating_counts_for_included_and_excluded_types():
     assert rating_counts_for(None) is False
 
 
-def test_skill_rating_scales_conservative_estimate():
-    # (25 - 3*8.333) * 40 = (25 - 24.999) * 40 ≈ 0.04 -> rounds to 0
-    assert skill_rating(25.0, 25.0 / 3) == 0
-    # A converged strong player: (30 - 3*1) * 40 = 1080
-    assert skill_rating(30.0, 1.0) == 1080
+def test_skill_rating_is_elo_anchored():
+    # A brand-new player sits exactly on the 1500 anchor regardless of sigma
+    assert skill_rating(25.0, 25.0 / 3, 0) == 1500
+    # A proven strong player: 1500 + (29 - 25) * (270/300) * 95 = 1842
+    assert skill_rating(29.0, 1.0, 270) == 1842
+    # Sigma does not move the displayed number
+    assert skill_rating(29.0, 8.0, 270) == 1842
+    # Below-average play reads below the anchor, shrunk the same way
+    assert skill_rating(21.0, 1.0, 270) == 1158
+
+
+def test_skill_rating_shrinks_small_samples():
+    # A hot 20-game record cannot spike past a proven strong player: the
+    # games-based shrink discounts a higher mu earned over a short sample.
+    hot_newcomer = skill_rating(30.5, 1.8, 22)
+    proven_strong = skill_rating(29.0, 0.8, 270)
+    assert hot_newcomer < proven_strong
+    # More games at the same mu always earn more distance from the anchor
+    assert skill_rating(29.0, 1.0, 30) < skill_rating(29.0, 1.0, 300)
+    # An average record stays at the anchor no matter the sample size
+    assert skill_rating(25.0, 1.0, 500) == 1500
 
 
 def test_is_established_threshold():

--- a/tests/test_stats_display.py
+++ b/tests/test_stats_display.py
@@ -205,7 +205,7 @@ class TestGetStatsEmbedForPlayer:
                 games_won=15, games_lost=10))          # 25 >= 20 -> established
             await session.commit()
         rating, provisional = await _player_skill_rating("555", "g")
-        assert rating == 1080
+        assert rating == 1716    # 1500 + (30-25) * (25/55) * 95
         assert provisional is False
 
     @pytest.mark.asyncio
@@ -218,7 +218,7 @@ class TestGetStatsEmbedForPlayer:
                 games_won=3, games_lost=2))            # 5 < 20 -> provisional
             await session.commit()
         rating, provisional = await _player_skill_rating("556", "g")
-        assert rating == 1080
+        assert rating == 1568    # 1500 + (30-25) * (5/35) * 95
         assert provisional is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

Re-anchors the displayed 🎯 Skill Rating to the familiar 1500-based Elo scale and adds a one-line scale reference to the stats embed. **Display-only** — stored TrueSkill μ/σ, the match-update path, team balancing, and the backfill are untouched; no migration.

## Why

The old display was the TrueSkill conservative floor, `round((μ − 3σ) × 40)`: new players showed **0**, the server median sat near 890, and ratings climbed hundreds of points during a player's first games purely from shrinking uncertainty. The group found the numbers impossible to anchor against any familiar rating scale.

## New formula

```
rating = 1500 + (μ − 25) × games/(games + 30) × 95
```

| Property | Behavior |
|---|---|
| New player | Exactly **1500**, moves both directions from there |
| Top proven players | ~1800–1860 (quinniac 1857, LSV 1819 on the main server) |
| Hot short records | Shrunk toward 1500 until earned (a 16–6 start shows ~1722, not #1) |
| 100-point gap | ≈ 58% game / **60% Bo3 match** favorite between proven players |
| Established median | ~1580 |

The games-based shrink (`g/(g+30)`) replaces the σ floor as the small-sample guard: rank order among established players is essentially unchanged, but a 20-game sample only earns ~40% of its μ edge. The existing "(provisional)" label (<20 rated games) is unchanged.

The stats embed now shows the scale reference under the rating:
> *New players start at 1500 · a 100-point gap ≈ 60% match favorite*

Constants (`RATING_ANCHOR`, `RATING_POINTS_PER_MU`, `RATING_SHRINK_GAMES`) are named in `helpers/skill.py` for future feel-tuning.

## Testing

- Full suite: **588 passed, 9 skipped**
- `test_skill_helpers.py`: anchor, shrinkage, and sigma-independence properties
- `test_stats_display.py` / `test_create_stats_embed_skill.py`: embed values incl. the new scale note
- Validated the scale against the prod DB copy (2026-07-13): distribution, familiar players, and implied win % per gap reviewed with the group's intuition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xit2mp6FR3bz2PtkqQ24vB
