### PR TITLE
feat(debt): Most Outstanding — top-3 net-creditor leaderboard on staked servers

### DIFF
--- a/cogs/debt_commands.py
+++ b/cogs/debt_commands.py
@@ -351,7 +351,10 @@ class DebtCommands(commands.Cog):
             await ctx.followup.send("No outstanding debts in this guild.")
             return
 
-        pages = build_guild_debt_embed_pages(ctx.guild, rows, include_description=False)
+        from services.debt_service import get_most_outstanding_creditors
+        top_creditors = await get_most_outstanding_creditors(str(ctx.guild.id))
+        pages = build_guild_debt_embed_pages(
+            ctx.guild, rows, include_description=False, top_creditors=top_creditors)
         await ctx.followup.send(embed=pages[0])
 
     @discord.slash_command(name="debts-post", description="[Admin] Post public debt summary with settle button")

--- a/cogs/debt_commands.py
+++ b/cogs/debt_commands.py
@@ -390,7 +390,9 @@ class DebtCommands(commands.Cog):
                     logger.warning(f"Could not delete old debt summary message: {e}")
 
             # Build and post the public message
-            pages = build_guild_debt_embed_pages(ctx.guild, rows)
+            from services.debt_service import get_most_outstanding_creditors
+            top_creditors = await get_most_outstanding_creditors(guild_id)
+            pages = build_guild_debt_embed_pages(ctx.guild, rows, top_creditors=top_creditors)
             view = PublicSettleDebtsView(pages=pages)
             public_message = await ctx.channel.send(embed=pages[0], view=view)
 

--- a/database/message_management.py
+++ b/database/message_management.py
@@ -270,7 +270,7 @@ class DebtSummaryStickyStrategy(StickyStrategy):
         self, sticky_message: Message, bot: discord.Client, session: AsyncSession
     ) -> Tuple[str, Optional[discord.Embed], Optional[discord.ui.View], Dict[str, Any]]:
         # Function-local imports to avoid circular dependencies
-        from services.debt_service import get_guild_debt_rows
+        from services.debt_service import get_guild_debt_rows, get_most_outstanding_creditors
         from debt_views.helpers import build_guild_debt_embed_pages
         from debt_views.settle_views import PublicSettleDebtsView
 
@@ -279,7 +279,8 @@ class DebtSummaryStickyStrategy(StickyStrategy):
 
         # Re-fetch debt data to allow the sticky update to refresh content
         rows = await get_guild_debt_rows(guild_id)
-        pages = build_guild_debt_embed_pages(guild, rows)
+        top_creditors = await get_most_outstanding_creditors(guild_id)
+        pages = build_guild_debt_embed_pages(guild, rows, top_creditors=top_creditors)
 
         view = PublicSettleDebtsView(pages=pages)
 

--- a/debt_views/helpers.py
+++ b/debt_views/helpers.py
@@ -84,7 +84,23 @@ def build_guild_debt_embed(guild: discord.Guild, rows: list, include_description
     return embed
 
 
-def build_guild_debt_embed_pages(guild: discord.Guild, rows: list, per_page: int = 10, include_description: bool = True) -> list:
+_MEDALS = ("🥇", "🥈", "🥉")
+
+
+def _build_most_outstanding_field(guild, top_creditors):
+    """Return (name, value) for the 🏆 Most Outstanding leaderboard field, or
+    None when there are no net creditors."""
+    if not top_creditors:
+        return None
+    lines = []
+    for rank, (player_id, net) in enumerate(top_creditors):
+        medal = _MEDALS[rank] if rank < len(_MEDALS) else f"{rank + 1}."
+        name = get_member_name(guild, player_id)
+        lines.append(f"{medal} {name} — {net} tix")
+    return "🏆 Most Outstanding", "\n".join(lines)
+
+
+def build_guild_debt_embed_pages(guild: discord.Guild, rows: list, per_page: int = 10, include_description: bool = True, top_creditors: list = None) -> list:
     """
     Build a list of paginated guild debt summary embeds.
 
@@ -126,6 +142,11 @@ def build_guild_debt_embed_pages(guild: discord.Guild, rows: list, per_page: int
             description=description,
             color=discord.Color.orange()
         )
+
+        if page_num == 0:
+            leaderboard = _build_most_outstanding_field(guild, top_creditors)
+            if leaderboard:
+                embed.add_field(name=leaderboard[0], value=leaderboard[1], inline=False)
 
         debt_lines = []
         for row in page_rows:

--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -1150,11 +1150,12 @@ class PublicSettleDebtsView(View):
             await interaction.response.defer()
             return
 
-        from services.debt_service import get_guild_debt_rows
+        from services.debt_service import get_guild_debt_rows, get_most_outstanding_creditors
         from debt_views.helpers import build_guild_debt_embed_pages
 
         rows = await get_guild_debt_rows(str(guild.id))
-        pages = build_guild_debt_embed_pages(guild, rows)
+        top_creditors = await get_most_outstanding_creditors(str(guild.id))
+        pages = build_guild_debt_embed_pages(guild, rows, top_creditors=top_creditors)
 
         current_page = self._get_current_page_from_embed(interaction)
         new_page = current_page + direction

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -1022,3 +1022,39 @@ async def get_guild_debt_rows(guild_id: str) -> list:
         )
         result = await session.execute(query)
         return result.all()
+
+
+async def get_top_net_creditors(guild_id: str, limit: int = 3) -> list:
+    """Top net creditors in a guild: players whose summed ledger balance is
+    positive (owed more than they owe), highest first.
+
+    Returns a list of (player_id, net) tuples, length 0..limit. The sum is the
+    live/outstanding net — settlements post offsetting entries, so a settled
+    creditor nets to zero and drops off.
+    """
+    async with db_session() as session:
+        query = (
+            select(
+                DebtLedger.player_id,
+                func.sum(DebtLedger.amount).label('net')
+            )
+            .where(DebtLedger.guild_id == guild_id)
+            .group_by(DebtLedger.player_id)
+            .having(func.sum(DebtLedger.amount) > 0)
+            .order_by(func.sum(DebtLedger.amount).desc())
+            .limit(limit)
+        )
+        result = await session.execute(query)
+        return [(row.player_id, row.net) for row in result.all()]
+
+
+async def get_most_outstanding_creditors(guild_id: str, limit: int = 3) -> list:
+    """Top creditors for the debt-summary leaderboard, gated to staked servers.
+
+    Returns [] on non-money servers so the section never renders there and no
+    query runs. On money servers, delegates to get_top_net_creditors.
+    """
+    from config import is_money_server
+    if not is_money_server(guild_id):
+        return []
+    return await get_top_net_creditors(guild_id, limit)

--- a/tests/test_debt_leaderboard.py
+++ b/tests/test_debt_leaderboard.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from debt_views.helpers import build_guild_debt_embed_pages
+
+
+def _row(player_id, counterparty_id, balance):
+    return SimpleNamespace(player_id=player_id, counterparty_id=counterparty_id, balance=balance)
+
+
+def _guild():
+    return MagicMock()
+
+
+# get_member_name(guild, id) -> display name; patch it to a predictable name.
+def _patch_names():
+    return patch("debt_views.helpers.get_member_name", lambda guild, uid: f"User-{uid}")
+
+
+def test_top_creditors_field_is_prepended_on_first_page():
+    rows = [_row("bob", "alice", -120)]
+    with _patch_names():
+        pages = build_guild_debt_embed_pages(
+            _guild(), rows, top_creditors=[("alice", 150), ("bob", 80)])
+    first = pages[0].fields[0]
+    assert first.name == "🏆 Most Outstanding"
+    assert "🥇 User-alice — 150 tix" in first.value
+    assert "🥈 User-bob — 80 tix" in first.value
+    # It comes before the outstanding-debts field.
+    assert pages[0].fields[1].name.startswith("Outstanding Debts")
+
+
+def test_no_field_when_top_creditors_none():
+    rows = [_row("bob", "alice", -120)]
+    with _patch_names():
+        pages = build_guild_debt_embed_pages(_guild(), rows)  # default None
+    assert all(f.name != "🏆 Most Outstanding" for f in pages[0].fields)
+
+
+def test_no_field_when_top_creditors_empty():
+    rows = [_row("bob", "alice", -120)]
+    with _patch_names():
+        pages = build_guild_debt_embed_pages(_guild(), rows, top_creditors=[])
+    assert all(f.name != "🏆 Most Outstanding" for f in pages[0].fields)
+
+
+def test_field_only_on_first_page():
+    # 12 rows, per_page=10 -> 2 pages; leaderboard only on page 0.
+    rows = [_row(f"d{i}", f"c{i}", -(i + 1)) for i in range(12)]
+    with _patch_names():
+        pages = build_guild_debt_embed_pages(
+            _guild(), rows, per_page=10, top_creditors=[("alice", 150)])
+    assert pages[0].fields[0].name == "🏆 Most Outstanding"
+    assert all(f.name != "🏆 Most Outstanding" for f in pages[1].fields)

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -1588,3 +1588,75 @@ class TestGetDebtHistory:
         # Verify they're in descending order by creation time
         for i in range(len(entries) - 1):
             assert entries[i].created_at >= entries[i + 1].created_at
+
+
+from unittest.mock import patch
+from services.debt_service import get_top_net_creditors, get_most_outstanding_creditors
+
+
+class TestTopNetCreditors:
+    """Tests for the Most Outstanding leaderboard query."""
+
+    async def _owe(self, guild, debtor, creditor, amount):
+        await create_ledger_entries(
+            guild_id=guild, debtor_id=debtor, creditor_id=creditor,
+            amount=amount, source_type="draft", source_id=f"s-{debtor}-{creditor}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_ranks_net_creditors_desc_and_excludes_non_creditors(self, test_db):
+        g = "g1"
+        # bob owes alice 120; carol owes alice 30  -> alice net +150
+        await self._owe(g, "bob", "alice", 120)
+        await self._owe(g, "carol", "alice", 30)
+        # dave owes bob 200 -> bob net (-120 + 200) = +80
+        await self._owe(g, "dave", "bob", 200)
+        # carol net -30 (excluded), dave net -200 (excluded)
+
+        result = await get_top_net_creditors(g, limit=3)
+
+        assert result == [("alice", 150), ("bob", 80)]
+
+    @pytest.mark.asyncio
+    async def test_excludes_net_zero_players(self, test_db):
+        g = "g2"
+        # alice and bob owe each other equally -> both net 0
+        await self._owe(g, "bob", "alice", 50)
+        await self._owe(g, "alice", "bob", 50)
+
+        result = await get_top_net_creditors(g, limit=3)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self, test_db):
+        g = "g3"
+        for i, amt in enumerate([10, 40, 30, 20]):
+            await self._owe(g, f"debtor{i}", f"cred{i}", amt)
+        # nets: cred1=40, cred2=30, cred3=20, cred0=10 -> top 2 = cred1, cred2
+        result = await get_top_net_creditors(g, limit=2)
+
+        assert result == [("cred1", 40), ("cred2", 30)]
+
+    @pytest.mark.asyncio
+    async def test_scoped_to_guild(self, test_db):
+        await self._owe("gA", "bob", "alice", 99)
+        await self._owe("gB", "dan", "carol", 5)
+
+        result = await get_top_net_creditors("gA", limit=3)
+
+        assert result == [("alice", 99)]
+
+    @pytest.mark.asyncio
+    async def test_gate_returns_empty_on_non_money_server(self, test_db):
+        await self._owe("gX", "bob", "alice", 99)
+        with patch("config.is_money_server", return_value=False):
+            result = await get_most_outstanding_creditors("gX", limit=3)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_gate_delegates_on_money_server(self, test_db):
+        await self._owe("gY", "bob", "alice", 99)
+        with patch("config.is_money_server", return_value=True):
+            result = await get_most_outstanding_creditors("gY", limit=3)
+        assert result == [("alice", 99)]

--- a/utils.py
+++ b/utils.py
@@ -1209,8 +1209,10 @@ async def update_debt_summary_for_guild(bot, guild_id: str):
                         logger.warning(f"Failed to delete legacy debt summary message: {e}")
 
                 # Get all debts and build embed pages
+                from services.debt_service import get_most_outstanding_creditors
                 rows = await get_guild_debt_rows(guild_id)
-                pages = build_guild_debt_embed_pages(guild, rows)
+                top_creditors = await get_most_outstanding_creditors(guild_id)
+                pages = build_guild_debt_embed_pages(guild, rows, top_creditors=top_creditors)
                 view = PublicSettleDebtsView(pages=pages)
 
                 new_message = await channel.send(embed=pages[0], view=view)


### PR DESCRIPTION
## What

Adds a **🏆 Most Outstanding** leaderboard to the guild debt summary on **staked (money) servers**: the top 3 users who are net creditors (owed more than they owe), ranked by their live net amount owed to them.

It renders as a leading field on the debt-summary embed:

```
🏆 Most Outstanding
🥇 Alice — 150 tix
🥈 Bob — 80 tix
🥉 Carol — 45 tix
```

## How it works

- **Net creditor** = a player whose `SUM(debt_ledger.amount) > 0` within the guild. The ledger stores mirrored entries per debt and settlements post offsetting entries, so this sum *is* the live/outstanding net — no separate "active debt" tracking needed.
- **`get_top_net_creditors(guild_id, limit=3)`** (`services/debt_service.py`) — `GROUP BY player_id HAVING SUM(amount) > 0 ORDER BY net DESC LIMIT 3`. Pure read, **no migration**.
- **`get_most_outstanding_creditors(...)`** wraps it with the money-server gate: returns `[]` without querying on non-money servers (`is_money_server`), so free servers do zero extra work and show nothing.
- **`build_guild_debt_embed_pages(..., top_creditors=None)`** gains an optional param that prepends the field to page 0 only. Default `None` keeps every existing caller byte-for-byte unchanged.
- Wired into **all five** debt-summary render paths so the leaderboard is consistent however the message is produced or re-rendered: sticky refresh, initial sticky create, `/debts-admin`, `/debts-post`, and settle-view pagination.

## Edge cases

Fewer than 3 creditors → show fewer; zero net creditors → section omitted; departed members → existing name fallback; ties at rank 3 → SQL ordering. No new update triggers — it refreshes on the existing debt-change events.

## Testing

- `get_top_net_creditors` / gate: 6 tests (net calc across mixed debtor/creditor entries, `>0` filter, net-zero exclusion, ordering, limit, guild scoping, both gate branches).
- Embed field: 4 tests (prepend on page 0, medals/format, `None`/empty → omitted, page-0-only).
- Full suite: **620 passed, 9 skipped, 0 failed.**

Built test-first via subagent-driven development, with per-task reviews and a final adversarial whole-branch review (verified all 5 render paths are wired, the gate is query-free on free servers, and the empty-rows early-return can never hide a real leaderboard). A handful of cosmetic minors (docstring, return-type hints, test import placement) were triaged as non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
