### PR TITLE
fix(draftmancer): store raw nickname for premade sign-ups (emoji codes in usernames)

### DIFF
--- a/tests/test_premade_draftmancer_names.py
+++ b/tests/test_premade_draftmancer_names.py
@@ -1,0 +1,62 @@
+"""Regression test: premade team-join must store the RAW nickname in sign_ups.
+
+sign_ups values are used verbatim as Draftmancer usernames (get_draft_link_for_user)
+and for seating matches. get_display_name() prepends custom-emoji icons like
+"<:coveted_jewel:1460802711694999613>", which render as that literal code in
+Draftmancer. Every other sign-up path stores interaction.user.display_name (raw);
+the premade path must too.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from views import PersistentView
+
+
+def _async_session_local_mock():
+    """Mock for `async with AsyncSessionLocal() as db: async with db.begin(): ...`."""
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+    begin = MagicMock()
+    begin.__aenter__ = AsyncMock(return_value=None)
+    begin.__aexit__ = AsyncMock(return_value=False)
+    db.begin = MagicMock(return_value=begin)
+    outer = MagicMock()
+    outer.__aenter__ = AsyncMock(return_value=db)
+    outer.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=outer)
+
+
+@pytest.mark.asyncio
+async def test_premade_join_stores_plain_name_not_emoji_decorated():
+    # Non-empty sign_ups mirrors reality (others have already joined) and avoids
+    # the `session.sign_ups or {}` empty-dict shortcut making a fresh dict.
+    session = SimpleNamespace(
+        session_id="s1", sign_ups={"99": "Bob"},
+        team_a=[], team_b=[], team_a_name="Team A", team_b_name="Team B",
+    )
+    view = PersistentView(
+        bot=MagicMock(), draft_session_id="s1", session_type="premade",
+        team_a_name="Team A", team_b_name="Team B",
+    )
+    view.update_team_view = AsyncMock()
+
+    interaction = MagicMock()
+    interaction.user.id = 1
+    interaction.user.display_name = "Alice"
+    interaction.guild = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    button = MagicMock()
+    button.custom_id = "Team_A_s1"
+
+    # If the code used get_display_name, this decorated value would leak into
+    # sign_ups (and thus the Draftmancer link). It must not.
+    decorated = "<:coveted_jewel:1460802711694999613> Alice"
+    with patch("views.get_draft_session", AsyncMock(return_value=session)), \
+         patch("views.AsyncSessionLocal", _async_session_local_mock()), \
+         patch("views.get_display_name", lambda member, guild=None: decorated):
+        await view.team_assignment_callback(interaction, button)
+
+    assert session.sign_ups["1"] == "Alice"

--- a/views.py
+++ b/views.py
@@ -1075,7 +1075,11 @@ class PersistentView(discord.ui.View):
 
         user_id = str(interaction.user.id)
         custom_id = button.custom_id
-        user_name = get_display_name(interaction.user, interaction.guild)
+        # Store the RAW nickname (like every other sign-up path) — sign_ups values
+        # are used verbatim as Draftmancer usernames and for seating matches.
+        # get_display_name() prepends custom-emoji icons (e.g. ring bearer/crown)
+        # that render as literal "<:name:id>" codes outside Discord.
+        user_name = interaction.user.display_name
 
         primary_team = secondary_team = primary_key = secondary_key = None
 


### PR DESCRIPTION
## Bug

On premade drafts, players' **Draftmancer** usernames showed as literal codes like `<:coveted_jewel:1460802711694999613>` instead of their name, and seating-name matching could fail.

## Root cause

The icons `get_display_name()` prepends are **custom Discord emojis** (ring bearer `<:coveted_jewel:…>`, double/triple crown), which render as the emoji inside Discord but as the literal `<:name:1234567890>` string anywhere else.

`sign_ups` is the single source for every Draftmancer username — `get_draft_link_for_user()` appends `&userName=<encoded>`, and the seating/presence logic matches `sign_ups.values()` against Draftmancer's raw usernames. Its de-facto contract, held by 4 of the 5 sign-up paths, is "store the raw nickname" (`interaction.user.display_name`). The **premade** team-join handler (`views.py:1078`) diverged and stored `get_display_name(...)` (icons + markdown escaping), so premade players got Draftmancer links pre-filled with the emoji code and their seating name didn't match.

## Fix

Store `interaction.user.display_name` on the premade path, exactly like every other sign-up path. This fixes all three Draftmancer consumers at once (personalized links, seating order, presence status), since they all read `sign_ups`.

Discord-side displays are unaffected — the premade team/queue embeds re-derive names via live member lookup (`get_display_name_by_id`), so ring bearer / crown icons still show in Discord; only the stored value (used for Draftmancer) becomes the plain nickname.

## Testing

- New regression test `tests/test_premade_draftmancer_names.py` drives the premade team-join callback and asserts `sign_ups` stores the raw `"Alice"`, not the emoji-decorated value. Fails before the fix (captures the `<:coveted_jewel:…> Alice` leak), passes after.
- Full suite: **611 passed, 9 skipped, 0 failed.**

## Note

Premade drafts already in progress have decorated names stored from before this change; those self-correct when an affected user re-joins a team or on the next draft — no migration needed for such transient data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
