### PR TITLE
Trophy Quiz (1/3): shared card-image fetch + all-or-nothing compositors + MPT deck-view helper

### DIFF
--- a/cogs/quiz_commands.py
+++ b/cogs/quiz_commands.py
@@ -24,6 +24,40 @@ QUIZ_NUM_PICKS = 4  # Number of picks to quiz on
 ELIGIBLE_DRAFT_DAYS = 365  # Look back 1 year for eligible drafts
 
 
+async def build_pack_image_or_abort(
+    *,
+    enabled: bool,
+    draft_data: Optional[dict],
+    booster_ids: List[str],
+    quiz_id: str,
+    images_config: dict,
+) -> Tuple[Optional[discord.File], bool]:
+    """Return (discord.File|None, abort: bool).
+
+    - flag off  -> (None, False): caller posts with no image.
+    - flag on, composite ok -> (File, False).
+    - flag on, composite None/raises -> (None, True): caller must NOT post."""
+    if not (enabled and draft_data):
+        return None, False
+    try:
+        compositor = PackCompositor(
+            card_width=images_config.get("card_width", 244),
+            card_height=images_config.get("card_height", 340),
+            border_pixels=images_config.get("border_pixels", 5),
+        )
+        image_bytes = await compositor.create_pack_composite(
+            booster_ids, draft_data.get("carddata", {})
+        )
+    except Exception as e:
+        logger.error(f"[QUIZ_IMAGE] Pack composite raised for quiz {quiz_id}: {e}", exc_info=True)
+        return None, True
+    if not image_bytes:
+        logger.error(f"[QUIZ_IMAGE] Pack composite None for quiz {quiz_id}; aborting post")
+        return None, True
+    fresh = BytesIO(image_bytes.getvalue())
+    return discord.File(fp=fresh, filename=f"quiz_pack_{quiz_id}.jpg"), False
+
+
 async def _generate_next_display_id(guild_id: str) -> int:
     """
     Generate the next sequential display ID for a guild.
@@ -217,6 +251,31 @@ class QuizCommands(commands.Cog):
         }
         correct_answers = [pick.picked_id for pick in pack_trace.picks]
 
+        # Generate pack composite image if enabled and draft data available.
+        # This must happen BEFORE the QuizSession is persisted: an
+        # enabled-but-unbuildable image aborts the whole quiz, and
+        # _select_random_draft_and_seat treats ANY row for a
+        # (draft_session_id, starting_seat) as "used" (no message_id
+        # filter) - persisting first would orphan a row and permanently
+        # burn that draft+seat combo.
+        config = get_config(guild_id)
+        quiz_images_config = config.get("features", {}).get("quiz_pack_images", {})
+        images_enabled = quiz_images_config.get("enabled", False)
+
+        logger.info(f"[QUIZ_IMAGE] Feature enabled: {images_enabled}, draft_data available: {draft_data is not None}")
+
+        pack_image_file, abort = await build_pack_image_or_abort(
+            enabled=images_enabled,
+            draft_data=draft_data,
+            booster_ids=pack_trace.picks[0].booster_ids,
+            quiz_id=quiz_id,
+            images_config=quiz_images_config,
+        )
+        if abort:
+            # Image was expected (feature enabled) but could not be built - do not post
+            logger.error(f"[QUIZ_IMAGE] Aborting quiz post for {quiz_id}: pack image required but unavailable")
+            return None
+
         async with db_session() as session:
             quiz_session = QuizSession(
                 quiz_id=quiz_id,
@@ -238,76 +297,14 @@ class QuizCommands(commands.Cog):
         embed = self.create_quiz_embed(draft_session, pack_trace, analysis, mpt_url, display_id)
         view = QuizPublicView(quiz_id, analysis, pack_trace)
 
-        # Generate pack composite image if enabled and draft data available
-        pack_image_file = None
-        config = get_config(guild_id)
-        quiz_images_config = config.get("features", {}).get("quiz_pack_images", {})
-
-        logger.info(f"[QUIZ_IMAGE] Feature enabled: {quiz_images_config.get('enabled', False)}, draft_data available: {draft_data is not None}")
-
-        if quiz_images_config.get("enabled", False) and draft_data:
-            try:
-                logger.info(f"[QUIZ_IMAGE] Starting pack composite generation for quiz {quiz_id}")
-                compositor = PackCompositor(
-                    card_width=quiz_images_config.get("card_width", 244),
-                    card_height=quiz_images_config.get("card_height", 340),
-                    border_pixels=quiz_images_config.get("border_pixels", 5)
-                )
-                first_pick = pack_trace.picks[0]
-                carddata = draft_data.get("carddata", {})
-                logger.info(f"[QUIZ_IMAGE] Carddata has {len(carddata)} cards, pack has {len(first_pick.booster_ids)} cards")
-
-                image_bytes = await compositor.create_pack_composite(
-                    first_pick.booster_ids,
-                    carddata
-                )
-
-                if image_bytes:
-                    # Get the image data and create a fresh BytesIO
-                    # This ensures Discord can read it without any pointer issues
-                    image_data = image_bytes.getvalue()
-                    logger.info(f"[QUIZ_IMAGE] Composite created successfully, size: {len(image_data)} bytes")
-
-                    # Create a fresh BytesIO from the data for Discord
-                    fresh_bytes = BytesIO(image_data)
-
-                    pack_image_file = discord.File(
-                        fp=fresh_bytes,
-                        filename=f"quiz_pack_{quiz_id}.jpg"
-                    )
-                    # Update embed to reference the attachment
-                    embed.set_image(url=f"attachment://quiz_pack_{quiz_id}.jpg")
-                    logger.info(f"[QUIZ_IMAGE] Discord.File created and embed.set_image() called for quiz {quiz_id}")
-                else:
-                    logger.warning(f"[QUIZ_IMAGE] Composite generation returned None")
-            except Exception as e:
-                logger.error(f"[QUIZ_IMAGE] Pack composite generation failed: {e}", exc_info=True)
-        else:
-            logger.info(f"[QUIZ_IMAGE] Skipping pack image generation")
-
         # Post message with embed and optional pack image
         if pack_image_file:
+            embed.set_image(url=f"attachment://quiz_pack_{quiz_id}.jpg")
             logger.info(f"[QUIZ_IMAGE] Posting quiz with pack image attachment")
-            logger.info(f"[QUIZ_IMAGE] About to call channel.send() - embed={type(embed).__name__}, file={type(pack_image_file).__name__}, view={type(view).__name__}")
-
-            # Try posting with image
-            try:
-                logger.info(f"[QUIZ_IMAGE] Attempting to post with image...")
-                message = await channel.send(embed=embed, file=pack_image_file, view=view)
-                logger.info(f"[QUIZ_IMAGE] Successfully posted with image! message_id={message.id}")
-            except discord.Forbidden as e:
-                logger.error(f"[QUIZ_IMAGE] Permission denied (403) posting with image: {e}. Falling back to no image.")
-                logger.warning(f"[QUIZ_IMAGE] Bot needs 'Attach Files' permission in channel {channel_id}")
-                # Fall back to posting without image
-                message = await channel.send(embed=embed, view=view)
-                logger.info(f"[QUIZ_IMAGE] Posted without image due to permissions. message_id={message.id}")
-            except Exception as e:
-                logger.error(f"[QUIZ_IMAGE] Unexpected error posting with image: {e}", exc_info=True)
-                # Fall back to posting without image
-                message = await channel.send(embed=embed, view=view)
-                logger.info(f"[QUIZ_IMAGE] Posted without image due to error. message_id={message.id}")
-
-            logger.info(f"[QUIZ_IMAGE] channel.send() completed, message_id={message.id}")
+            message = await channel.send(embed=embed, file=pack_image_file, view=view)
+            logger.info(f"[QUIZ_IMAGE] Successfully posted with image! message_id={message.id}")
+        else:
+            message = await channel.send(embed=embed, view=view)
 
         # Update QuizSession with message_id
         async with db_session() as session:

--- a/helpers/card_image_fetcher.py
+++ b/helpers/card_image_fetcher.py
@@ -1,0 +1,98 @@
+"""Shared, retry-aware card-image fetch for quiz composites.
+
+Walks a URL ladder (captured printing -> DFC face -> Scryfall by-UUID ->
+Scryfall by-name = a different printing) and retries transient failures with
+exponential backoff, honouring an optional wall-clock deadline. Returns a PIL
+image, or None only after the whole ladder is exhausted (or the deadline
+passes)."""
+
+import asyncio
+import time
+from io import BytesIO
+from typing import List, Optional
+from urllib.parse import quote
+
+import aiohttp
+from loguru import logger
+from PIL import Image
+
+SCRYFALL_HEADERS = {
+    "User-Agent": "DraftBot/1.0 (quiz card images)",
+    "Accept": "image/*",
+}
+_TRANSIENT_STATUSES = {429, 500, 502, 503, 504}
+
+
+def build_image_url_ladder(card_id: str, carddata: dict) -> List[str]:
+    """Ordered, de-duplicated candidate image URLs for one card."""
+    urls: List[str] = []
+    info = carddata.get(card_id) or {}
+
+    image_uris = info.get("image_uris") or {}
+    if image_uris.get("normal"):
+        urls.append(image_uris["normal"])
+
+    faces = info.get("card_faces") or []
+    if faces:
+        face_uris = (faces[0] or {}).get("image_uris") or {}
+        if face_uris.get("normal"):
+            urls.append(face_uris["normal"])
+
+    urls.append(f"https://api.scryfall.com/cards/{card_id}?format=image&version=normal")
+
+    name = info.get("name")
+    if name:
+        urls.append(
+            f"https://api.scryfall.com/cards/named?exact={quote(name)}"
+            "&format=image&version=normal"
+        )
+
+    return list(dict.fromkeys(urls))
+
+
+async def fetch_card_image(
+    session: aiohttp.ClientSession,
+    card_id: str,
+    carddata: dict,
+    *,
+    max_retries: int = 3,
+    base_delay: float = 0.5,
+    timeout: int = 10,
+    deadline: Optional[float] = None,
+) -> Optional[Image.Image]:
+    """Fetch one card image, retrying transient failures with exponential
+    backoff and falling through the URL ladder. `deadline` is an absolute
+    time.monotonic() timestamp; once passed the fetch gives up immediately."""
+    for url in build_image_url_ladder(card_id, carddata):
+        headers = SCRYFALL_HEADERS if "api.scryfall.com" in url else None
+        for attempt in range(max_retries):
+            if deadline is not None and time.monotonic() >= deadline:
+                logger.warning(f"[card-image] deadline exceeded fetching {card_id}")
+                return None
+            try:
+                async with session.get(
+                    url,
+                    timeout=aiohttp.ClientTimeout(total=timeout),
+                    headers=headers,
+                ) as resp:
+                    if resp.status == 200:
+                        body = await resp.read()
+                        try:
+                            return Image.open(BytesIO(body))
+                        except Exception as e:
+                            logger.warning(
+                                f"[card-image] undecodable image body for {card_id} "
+                                f"at {url}: {e}"
+                            )
+                            break  # treat as a failed rung -> next rung
+                    if resp.status in _TRANSIENT_STATUSES:
+                        if attempt < max_retries - 1:
+                            await asyncio.sleep(base_delay * (2 ** attempt))
+                        continue
+                    break  # definitive failure for this rung -> next rung
+            except (asyncio.TimeoutError, aiohttp.ClientError):
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(base_delay * (2 ** attempt))
+                continue
+    logger.warning(f"[card-image] all rungs exhausted for {card_id}")
+    return None

--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -16,21 +16,33 @@ class MagicProtoolsHelper:
         self.do_helper = DigitalOceanHelper()
         self.api_key = os.getenv("MPT_API_KEY")
         
-    def convert_to_magicprotools_format(self, draft_log: Dict[str, Any], user_id: str) -> str:
+    def extract_deck_token(self, url: Optional[str]) -> Optional[str]:
+        """Return the `deck` query-param token from an /api/draft/add result URL, or None."""
+        if not url:
+            return None
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        tokens = params.get("deck")
+        return tokens[0] if tokens else None
+
+    def convert_to_magicprotools_format(self, draft_log: Dict[str, Any], user_id: str, anonymize: bool = False) -> str:
         """Convert a draft log JSON to MagicProTools format for a specific user."""
         output = []
-        
+
         # Basic draft info
         output.append(f"Event #: {draft_log['sessionID']}_{draft_log['time']}")
         output.append(f"Time: {datetime.fromtimestamp(draft_log['time']/1000).strftime('%a, %d %b %Y %H:%M:%S GMT')}")
         output.append(f"Players:")
-        
+
         # Add player names
+        opponent = 0
         for player_id, user_data in draft_log['users'].items():
             if player_id == user_id:
-                output.append(f"--> {user_data['userName']}")
+                name = "Drafter" if anonymize else user_data['userName']
+                output.append(f"--> {name}")
             else:
-                output.append(f"    {user_data['userName']}")
+                opponent += 1
+                name = f"Player {opponent}" if anonymize else user_data['userName']
+                output.append(f"    {name}")
         
         output.append("")
         
@@ -237,6 +249,41 @@ class MagicProtoolsHelper:
             self.logger.error(f"Error generating and uploading MagicProTools format logs: {e}")
             return result
     
+    async def submit_deck_view(self, user_id: str, draft_data: Dict[str, Any], deck_text: str) -> Optional[str]:
+        """Upload the anonymized draft + deck to MPT; return the /deck/show URL or None."""
+        if not self.api_key:
+            self.logger.warning(f"[MPT] No API key; cannot build deck view (user_id: {user_id})")
+            return None
+        try:
+            draft = self.convert_to_magicprotools_format(draft_data, user_id, anonymize=True)
+            data = {"draft": draft, "deck": deck_text, "apiKey": self.api_key, "platform": "mtgadraft"}
+            headers = {
+                "Accept": "application/json, text/plain, */*",
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": "https://draftmancer.com",
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post("https://magicprotools.com/api/draft/add",
+                                        headers=headers, data=data) as resp:
+                    if resp.status != 200:
+                        self.logger.warning(f"[MPT] deck view non-200: {resp.status} (user_id: {user_id})")
+                        return None
+                    body = await resp.json()
+            if body.get("error") or "url" not in body:
+                self.logger.warning(
+                    f"[MPT] deck view bad body: error={body.get('error')!r} url_present={'url' in body} "
+                    f"(user_id: {user_id})"
+                )
+                return None
+            token = self.extract_deck_token(body["url"])
+            if not token:
+                self.logger.warning(f"[MPT] deck view: no deck token in returned url (user_id: {user_id})")
+                return None
+            return f"https://magicprotools.com/deck/show?id={token}"
+        except Exception as e:
+            self.logger.error(f"[MPT] deck view submit failed: {e} (user_id: {user_id})")
+            return None
+
     def get_pack_first_picks(self, draft_data: Dict[str, Any], user_id: str) -> Dict[str, str]:
         """
         Extract the first pick card name for each pack for a specific user

--- a/helpers/pack_compositor.py
+++ b/helpers/pack_compositor.py
@@ -5,11 +5,16 @@ This module downloads Scryfall card images and composites them into a grid layou
 """
 
 import asyncio
+import time
 import aiohttp
 from io import BytesIO
 from PIL import Image
 from typing import Optional, List
 from loguru import logger
+
+from helpers.card_image_fetcher import fetch_card_image
+
+PACK_COMPOSITE_DEADLINE_SECONDS = 45
 
 
 class PackCompositor:
@@ -28,87 +33,18 @@ class PackCompositor:
         self.card_height = card_height
         self.border = border_pixels
 
-    def get_scryfall_image_url(self, card_id: str, carddata: dict) -> Optional[str]:
-        """
-        Get Scryfall image URL for a card.
-
-        First tries to extract from carddata if available, otherwise constructs
-        the URL directly from the Scryfall card ID using Scryfall's API.
-
-        Args:
-            card_id: The Scryfall card UUID
-            carddata: The draft's carddata dictionary
-
-        Returns:
-            Image URL string or None if not found
-        """
-        try:
-            # First, try to get from carddata if it exists
-            card_info = carddata.get(card_id)
-            if card_info:
-                # Try to get normal image URL
-                image_uris = card_info.get("image_uris", {})
-                if "normal" in image_uris:
-                    return image_uris["normal"]
-
-                # For double-faced cards, try card_faces
-                card_faces = card_info.get("card_faces", [])
-                if card_faces and len(card_faces) > 0:
-                    face_image_uris = card_faces[0].get("image_uris", {})
-                    if "normal" in face_image_uris:
-                        return face_image_uris["normal"]
-
-            # Fallback: Construct Scryfall API URL directly from card ID
-            # This works because the card_id IS the Scryfall UUID
-            # The API will redirect to the actual image
-            scryfall_url = f"https://api.scryfall.com/cards/{card_id}?format=image&version=normal"
-            logger.debug(f"Using Scryfall API URL for card {card_id}")
-            return scryfall_url
-
-        except Exception as e:
-            logger.error(f"Error getting image URL for card {card_id}: {e}")
-            return None
-
     async def download_card_image(
         self,
         session: aiohttp.ClientSession,
         card_id: str,
         carddata: dict,
-        timeout: int = 10
+        timeout: int = 10,
+        deadline: Optional[float] = None,
     ) -> Optional[Image.Image]:
-        """
-        Download a single card image from Scryfall.
-
-        Args:
-            session: aiohttp session for making requests
-            card_id: The card UUID
-            carddata: The draft's carddata dictionary
-            timeout: Request timeout in seconds
-
-        Returns:
-            PIL Image object or None on failure
-        """
-        try:
-            # Get image URL
-            image_url = self.get_scryfall_image_url(card_id, carddata)
-            if not image_url:
-                return None
-
-            # Download image
-            async with session.get(image_url, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
-                if response.status != 200:
-                    logger.warning(f"Failed to download image for {card_id}: HTTP {response.status}")
-                    return None
-
-                image_bytes = await response.read()
-                return Image.open(BytesIO(image_bytes))
-
-        except asyncio.TimeoutError:
-            logger.warning(f"Timeout downloading image for card {card_id}")
-            return None
-        except Exception as e:
-            logger.error(f"Error downloading image for card {card_id}: {e}")
-            return None
+        """Download one card image via the shared retry-aware fetcher."""
+        return await fetch_card_image(
+            session, card_id, carddata, timeout=timeout, deadline=deadline
+        )
 
     async def create_pack_composite(
         self,
@@ -132,77 +68,90 @@ class PackCompositor:
                 logger.warning(f"Expected 15 cards in pack, got {len(pack_card_ids)}")
                 # Continue anyway, will handle missing cards
 
-            # Download all card images in parallel
+            # Download all card images in parallel, all-or-nothing under a deadline
+            deadline = time.monotonic() + PACK_COMPOSITE_DEADLINE_SECONDS
+            semaphore = asyncio.Semaphore(10)
+
+            async def _one(session, card_id):
+                async with semaphore:
+                    return await self.download_card_image(
+                        session, card_id, carddata, timeout, deadline
+                    )
+
             async with aiohttp.ClientSession() as session:
-                download_tasks = [
-                    self.download_card_image(session, card_id, carddata, timeout)
-                    for card_id in pack_card_ids
-                ]
-                card_images = await asyncio.gather(*download_tasks, return_exceptions=True)
+                results = await asyncio.gather(
+                    *(_one(session, cid) for cid in pack_card_ids),
+                    return_exceptions=True,
+                )
 
-            # Filter out failed downloads and exceptions
             valid_images = []
-            for i, img in enumerate(card_images):
-                if isinstance(img, Exception):
-                    logger.warning(f"Exception downloading card {i}: {img}")
-                elif img is not None:
-                    valid_images.append((i, img))
-                else:
-                    logger.warning(f"Failed to download card at index {i}")
-
-            if not valid_images:
-                logger.error("Failed to download any card images")
-                return None
+            for i, img in enumerate(results):
+                if isinstance(img, Exception) or img is None:
+                    logger.error(
+                        f"[pack-composite] card {pack_card_ids[i]} (index {i}) unfetchable "
+                        f"({'exception' if isinstance(img, Exception) else 'none'}); "
+                        f"aborting composite (all-or-nothing)"
+                    )
+                    return None
+                valid_images.append((i, img))
 
             logger.info(f"Successfully downloaded {len(valid_images)}/15 card images")
 
-            # Create composite image
-            # Layout: 5 cards wide × 3 cards tall
-            cols = 5
-            rows = 3
-
-            # Calculate canvas size
-            canvas_width = (cols * self.card_width) + ((cols + 1) * self.border)
-            canvas_height = (rows * self.card_height) + ((rows + 1) * self.border)
-
-            # Create blank canvas with black background
-            canvas = Image.new('RGB', (canvas_width, canvas_height), color=(0, 0, 0))
-
-            # Paste each card image onto canvas
-            for index, img in valid_images:
-                # Calculate grid position (0-indexed)
-                row = index // cols
-                col = index % cols
-
-                # Calculate pixel position
-                x = self.border + (col * (self.card_width + self.border))
-                y = self.border + (row * (self.card_height + self.border))
-
-                # Resize image if needed
-                if img.size != (self.card_width, self.card_height):
-                    img = img.resize((self.card_width, self.card_height), Image.Resampling.LANCZOS)
-
-                # Paste onto canvas
-                canvas.paste(img, (x, y))
-
-            # Save to BytesIO
-            # Use JPEG with quality=85 to reduce file size significantly
-            # PNG was too large (2.4MB) and caused Discord upload timeouts
-            output = BytesIO()
-
-            # Convert RGBA to RGB for JPEG (JPEG doesn't support transparency)
-            if canvas.mode == 'RGBA':
-                # Create white background
-                rgb_canvas = Image.new('RGB', canvas.size, (255, 255, 255))
-                rgb_canvas.paste(canvas, mask=canvas.split()[3] if len(canvas.split()) == 4 else None)
-                canvas = rgb_canvas
-
-            canvas.save(output, format='JPEG', quality=85, optimize=True)
-            output.seek(0)
-
-            logger.info(f"Successfully created pack composite: {canvas_width}x{canvas_height}px, size: {len(output.getvalue())} bytes")
-            return output
+            return await asyncio.to_thread(self._render_grid, valid_images)
 
         except Exception as e:
             logger.error(f"Error creating pack composite: {e}", exc_info=True)
             return None
+
+    def _render_grid(self, valid_images: List[tuple]) -> BytesIO:
+        """Synchronous compositing + JPEG encoding (offloaded via asyncio.to_thread
+        so the PIL canvas build and .save() don't block the event loop).
+
+        valid_images: [(index, PIL.Image), ...] positioned into a 5x3 grid.
+        """
+        # Create composite image
+        # Layout: 5 cards wide × 3 cards tall
+        cols = 5
+        rows = 3
+
+        # Calculate canvas size
+        canvas_width = (cols * self.card_width) + ((cols + 1) * self.border)
+        canvas_height = (rows * self.card_height) + ((rows + 1) * self.border)
+
+        # Create blank canvas with black background
+        canvas = Image.new('RGB', (canvas_width, canvas_height), color=(0, 0, 0))
+
+        # Paste each card image onto canvas
+        for index, img in valid_images:
+            # Calculate grid position (0-indexed)
+            row = index // cols
+            col = index % cols
+
+            # Calculate pixel position
+            x = self.border + (col * (self.card_width + self.border))
+            y = self.border + (row * (self.card_height + self.border))
+
+            # Resize image if needed
+            if img.size != (self.card_width, self.card_height):
+                img = img.resize((self.card_width, self.card_height), Image.Resampling.LANCZOS)
+
+            # Paste onto canvas
+            canvas.paste(img, (x, y))
+
+        # Save to BytesIO
+        # Use JPEG with quality=85 to reduce file size significantly
+        # PNG was too large (2.4MB) and caused Discord upload timeouts
+        output = BytesIO()
+
+        # Convert RGBA to RGB for JPEG (JPEG doesn't support transparency)
+        if canvas.mode == 'RGBA':
+            # Create white background
+            rgb_canvas = Image.new('RGB', canvas.size, (255, 255, 255))
+            rgb_canvas.paste(canvas, mask=canvas.split()[3] if len(canvas.split()) == 4 else None)
+            canvas = rgb_canvas
+
+        canvas.save(output, format='JPEG', quality=85, optimize=True)
+        output.seek(0)
+
+        logger.info(f"Successfully created pack composite: {canvas_width}x{canvas_height}px, size: {len(output.getvalue())} bytes")
+        return output

--- a/helpers/pile_compositor.py
+++ b/helpers/pile_compositor.py
@@ -1,0 +1,161 @@
+"""Mana-value pile-view composite for a drafted pool.
+
+Buckets a pool by mana value (with a dedicated Lands column) and renders each
+bucket as an overlapping vertical stack: every card but the bottom one is
+offset down by a name-bar height so its name/mana cost shows, and the bottom
+card shows full art. The composed image stacks the main deck block, a
+labeled SIDEBOARD divider, and the sideboard block vertically. Fetches art
+via the shared retry-aware fetcher and is all-or-nothing (any unfetchable
+card -> None)."""
+
+import asyncio
+import time
+from io import BytesIO
+from typing import List, Optional, Tuple
+
+import aiohttp
+from loguru import logger
+from PIL import Image, ImageDraw, ImageFont
+
+from helpers.card_image_fetcher import fetch_card_image
+
+PILE_COMPOSITE_DEADLINE_SECONDS = 45
+_MV_COLUMNS = ["0", "1", "2", "3", "4", "5", "6", "7+"]
+
+
+def _is_land(info: dict) -> bool:
+    return info.get("mana_cost", "") == "" and (info.get("cmc") or 0) == 0
+
+
+def _mv_label(info: dict) -> str:
+    cmc = int(info.get("cmc") or 0)
+    return "7+" if cmc >= 7 else str(cmc)
+
+
+def bucket_cards(card_ids: List[str], carddata: dict) -> List[Tuple[str, List[str]]]:
+    """Ordered (column_label, [card_id,...]) for non-empty columns only.
+    Column order: Lands, 0..6, 7+. Cards within a column are sorted by name."""
+    column_order = ["Lands", *_MV_COLUMNS]
+    buckets = {label: [] for label in column_order}
+    for cid in card_ids:
+        info = carddata.get(cid)
+        # A card absent from carddata entirely defaults to MV0, not Lands —
+        # an empty info dict would otherwise trivially satisfy the land rule.
+        label = "Lands" if info is not None and _is_land(info) else _mv_label(info or {})
+        buckets[label].append(cid)
+
+    def _name(cid):
+        return ((carddata.get(cid) or {}).get("name") or "").lower()
+
+    ordered = []
+    for label in column_order:
+        cids = buckets[label]
+        if cids:
+            ordered.append((label, sorted(cids, key=_name)))
+    return ordered
+
+
+class PileImageBuilder:
+    """Renders one deck's pool as an MV-bucketed overlapping pile image."""
+
+    def __init__(self, card_width: int = 160, card_height: int = 223,
+                 name_bar_ratio: float = 0.18, border: int = 8):
+        self.card_width = card_width
+        self.card_height = card_height
+        self.name_bar = max(1, int(card_height * name_bar_ratio))
+        self.border = border
+
+    async def build(self, main_ids: List[str], side_ids: List[str], carddata: dict) -> Optional[BytesIO]:
+        main_cols = bucket_cards(main_ids, carddata)
+        side_cols = bucket_cards(side_ids, carddata)
+        if not main_cols and not side_cols:
+            logger.error("[pile] no cards to render")
+            return None
+
+        deadline = time.monotonic() + PILE_COMPOSITE_DEADLINE_SECONDS
+        semaphore = asyncio.Semaphore(10)
+
+        async def _one(session, cid):
+            async with semaphore:
+                return await fetch_card_image(
+                    session, cid, carddata, deadline=deadline
+                )
+
+        # Fetch every unique card once (a pool can repeat a card_id).
+        unique_ids = list({cid for cols in (main_cols, side_cols) for _, cids in cols for cid in cids})
+        async with aiohttp.ClientSession() as session:
+            results = await asyncio.gather(
+                *(_one(session, cid) for cid in unique_ids),
+                return_exceptions=True,
+            )
+
+        images = {}
+        for cid, img in zip(unique_ids, results):
+            if isinstance(img, Exception) or img is None:
+                logger.error(f"[pile] card {cid} unfetchable; aborting (all-or-nothing)")
+                return None
+            images[cid] = img
+
+        try:
+            return await asyncio.to_thread(self._render_deck, main_cols, side_cols, images)
+        except Exception as e:
+            logger.error(f"[pile] render failed: {e}", exc_info=True)
+            return None
+
+    def _render_columns(self, columns, images) -> Image.Image:
+        """One block of MV pile columns -> a PIL canvas (was the body of _render)."""
+        cw, ch, nb, b = self.card_width, self.card_height, self.name_bar, self.border
+
+        def col_height(cids):
+            return ch + nb * (len(cids) - 1)
+
+        canvas_w = b + len(columns) * (cw + b)
+        canvas_h = b + max(col_height(cids) for _, cids in columns) + b
+        canvas = Image.new("RGB", (canvas_w, canvas_h), (0, 0, 0))
+
+        for col_idx, (_label, cids) in enumerate(columns):
+            x = b + col_idx * (cw + b)
+            for row_idx, cid in enumerate(cids):
+                img = images[cid]
+                if img.size != (cw, ch):
+                    img = img.resize((cw, ch), Image.Resampling.LANCZOS)
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                y = b + row_idx * nb
+                canvas.paste(img, (x, y))
+
+        return canvas
+
+    def _divider(self, width: int, text: str) -> Image.Image:
+        """A labeled divider strip separating the main deck from the sideboard."""
+        h = 28
+        strip = Image.new("RGB", (width, h), (40, 40, 40))
+        draw = ImageDraw.Draw(strip)
+        draw.text((self.border, 7), text, fill=(230, 230, 230), font=ImageFont.load_default())
+        return strip
+
+    def _render_deck(self, main_cols, side_cols, images) -> BytesIO:
+        main_block = self._render_columns(main_cols, images) if main_cols else None
+        side_block = self._render_columns(side_cols, images) if side_cols else None
+
+        present = [bl for bl in (main_block, side_block) if bl is not None]
+        total_w = max(max(bl.width for bl in present), self.border * 2)
+
+        blocks = []
+        if main_block is not None:
+            blocks.append(main_block)
+        if side_block is not None:
+            blocks.append(self._divider(total_w, "SIDEBOARD"))
+            blocks.append(side_block)
+
+        total_h = sum(bl.height for bl in blocks)
+        canvas = Image.new("RGB", (total_w, total_h), (0, 0, 0))
+        y = 0
+        for bl in blocks:
+            canvas.paste(bl, (0, y))
+            y += bl.height
+
+        out = BytesIO()
+        canvas.save(out, format="JPEG", quality=85, optimize=True)
+        out.seek(0)
+        return out

--- a/tests/test_card_image_fetcher.py
+++ b/tests/test_card_image_fetcher.py
@@ -1,0 +1,163 @@
+import time
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+from PIL import Image
+
+from helpers.card_image_fetcher import build_image_url_ladder, fetch_card_image
+
+
+def _png_bytes():
+    buf = BytesIO()
+    Image.new("RGB", (4, 4), (10, 20, 30)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _FakeResp:
+    def __init__(self, status, body=b""):
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def read(self):
+        return self._body
+
+
+class _FakeSession:
+    """Maps each URL to a queue of _FakeResp; pops per call so a URL can fail
+    then succeed. Records the URLs requested in order."""
+
+    def __init__(self, responses: dict):
+        self._responses = {u: list(q) for u, q in responses.items()}
+        self.requested = []
+
+    def get(self, url, **kwargs):
+        self.requested.append(url)
+        queue = self._responses.get(url)
+        if not queue:
+            return _FakeResp(404)
+        return queue.pop(0)
+
+
+CARDDATA = {
+    "cid1": {"name": "Lightning Bolt", "image_uris": {"normal": "http://cdn/bolt.jpg"}},
+}
+CAPTURED = "http://cdn/bolt.jpg"
+BY_NAME = "https://api.scryfall.com/cards/named?exact=Lightning%20Bolt&format=image&version=normal"
+BY_ID = "https://api.scryfall.com/cards/cid1?format=image&version=normal"
+
+DFC_CARDDATA = {
+    "cid2": {
+        "name": "Some DFC",
+        "card_faces": [
+            {"image_uris": {"normal": "http://cdn/face.jpg"}},
+            {"image_uris": {"normal": "http://cdn/back.jpg"}},
+        ],
+    },
+}
+FACE_URL = "http://cdn/face.jpg"
+
+
+def test_ladder_order_and_dedup():
+    ladder = build_image_url_ladder("cid1", CARDDATA)
+    assert ladder[0] == CAPTURED
+    assert ladder[-1] == BY_NAME
+    assert "cards/cid1?format=image" in ladder[1]
+    assert len(ladder) == len(set(ladder))
+
+
+@pytest.mark.asyncio
+async def test_success_on_captured_url_first_try():
+    session = _FakeSession({CAPTURED: [_FakeResp(200, _png_bytes())]})
+    img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is not None
+    assert session.requested == [CAPTURED]
+
+
+@pytest.mark.asyncio
+async def test_transient_then_success_retries_with_backoff():
+    session = _FakeSession({CAPTURED: [_FakeResp(503), _FakeResp(200, _png_bytes())]})
+    with patch("helpers.card_image_fetcher.asyncio.sleep", new=AsyncMock()) as slept:
+        img = await fetch_card_image(session, "cid1", CARDDATA, base_delay=0.5)
+    assert img is not None
+    slept.assert_awaited_once_with(0.5)          # one backoff before the retry
+    assert session.requested == [CAPTURED, CAPTURED]
+
+
+@pytest.mark.asyncio
+async def test_404_advances_to_name_rung():
+    session = _FakeSession({
+        CAPTURED: [_FakeResp(404)],
+        BY_NAME: [_FakeResp(200, _png_bytes())],
+    })
+    img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is not None
+    assert session.requested[0] == CAPTURED
+    assert session.requested[-1] == BY_NAME       # reached the different-version rung
+
+
+@pytest.mark.asyncio
+async def test_all_rungs_fail_returns_none():
+    session = _FakeSession({})                    # every URL -> 404
+    with patch("helpers.card_image_fetcher.asyncio.sleep", new=AsyncMock()):
+        img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is None
+
+
+@pytest.mark.asyncio
+async def test_deadline_already_passed_fails_fast():
+    session = _FakeSession({CAPTURED: [_FakeResp(200, _png_bytes())]})
+    past = time.monotonic() - 1.0
+    img = await fetch_card_image(session, "cid1", CARDDATA, deadline=past)
+    assert img is None
+    assert session.requested == []                # never even attempted
+
+
+@pytest.mark.asyncio
+async def test_dfc_face_rung_used_when_no_top_level_image():
+    ladder = build_image_url_ladder("cid2", DFC_CARDDATA)
+    assert ladder[0] == FACE_URL                   # no top-level image_uris -> face rung is first
+
+    session = _FakeSession({FACE_URL: [_FakeResp(200, _png_bytes())]})
+    img = await fetch_card_image(session, "cid2", DFC_CARDDATA)
+    assert img is not None
+    assert session.requested == [FACE_URL]
+
+
+@pytest.mark.asyncio
+async def test_retries_exhaust_then_advances_to_next_rung():
+    max_retries = 3
+    session = _FakeSession({
+        CAPTURED: [_FakeResp(503), _FakeResp(503), _FakeResp(503)],
+        BY_ID: [_FakeResp(200, _png_bytes())],
+    })
+    with patch("helpers.card_image_fetcher.asyncio.sleep", new=AsyncMock()) as slept:
+        img = await fetch_card_image(
+            session, "cid1", CARDDATA, max_retries=max_retries, base_delay=0.5
+        )
+    assert img is not None
+    assert session.requested.count(CAPTURED) == max_retries   # all attempts on first rung used
+    assert session.requested[-1] == BY_ID                      # then advanced to next rung
+    assert slept.await_count == max_retries - 1                # no wasted sleep on last attempt
+
+
+@pytest.mark.asyncio
+async def test_200_with_non_image_body_advances_to_next_rung():
+    # A 200 whose body isn't a decodable image (corrupt/HTML) must not crash
+    # with PIL.UnidentifiedImageError - it should be treated as a failed
+    # rung and fall through to the next one, without retrying this rung.
+    session = _FakeSession({
+        CAPTURED: [_FakeResp(200, b"<html>nope")],
+        BY_ID: [_FakeResp(200, _png_bytes())],
+    })
+    img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is not None
+    assert session.requested.count(CAPTURED) == 1               # no retry on same rung
+    assert session.requested[-1] == BY_ID                       # advanced to next rung

--- a/tests/test_mpt_deck_view.py
+++ b/tests/test_mpt_deck_view.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from helpers.magicprotools_helper import MagicProtoolsHelper
+
+
+def _helper():
+    return MagicProtoolsHelper()
+
+
+def test_extract_deck_token():
+    h = _helper()
+    url = "https://magicprotools.com/draft/show?id=ABC&deck=TOKEN-123_xy"
+    assert h.extract_deck_token(url) == "TOKEN-123_xy"
+    assert h.extract_deck_token("https://magicprotools.com/draft/show?id=ABC") is None
+    assert h.extract_deck_token("") is None
+    assert h.extract_deck_token(None) is None
+
+
+def _draft_log():
+    return {
+        "sessionID": "s1", "time": 1000,
+        "setRestriction": [],
+        "users": {
+            "dmA": {"userName": "RealAlice", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c0", "c1"], "pick": [0]}]},
+            "dmB": {"userName": "RealBob", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c0", "c1"], "pick": [1]}]},
+        },
+        "carddata": {"c0": {"name": "Lightning Bolt", "set": "lea"},
+                     "c1": {"name": "Llanowar Elves", "set": "lea"}},
+    }
+
+
+def test_anonymize_hides_all_usernames_marks_target():
+    h = _helper()
+    out = h.convert_to_magicprotools_format(_draft_log(), "dmA", anonymize=True)
+    assert "RealAlice" not in out and "RealBob" not in out   # no real names
+    assert "--> Drafter" in out                               # target marked + labeled
+    assert "Player 1" in out                                  # other player relabeled
+    assert "Lightning Bolt" in out                            # real cards kept
+
+
+def test_non_anonymized_output_unchanged():
+    h = _helper()
+    out = h.convert_to_magicprotools_format(_draft_log(), "dmA")   # default False
+    assert "--> RealAlice" in out and "    RealBob" in out
+
+
+def _ok_session(json_body):
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(return_value=json_body)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    sess = MagicMock()
+    sess.post = MagicMock(return_value=cm)
+    outer = MagicMock()
+    outer.__aenter__ = AsyncMock(return_value=sess)
+    outer.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=outer)
+
+
+@pytest.mark.asyncio
+async def test_submit_deck_view_returns_deck_show_url():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    body = {"url": "https://magicprotools.com/draft/show?id=D&deck=TOK99"}
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", _ok_session(body)):
+        url = await h.submit_deck_view("dmA", _draft_log(), "4 Lightning Bolt\n")
+    assert url == "https://magicprotools.com/deck/show?id=TOK99"
+
+
+@pytest.mark.asyncio
+async def test_submit_deck_view_none_on_error_body():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession",
+               _ok_session({"error": "bad"})):
+        assert await h.submit_deck_view("dmA", _draft_log(), "x") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_deck_view_none_without_key():
+    h = MagicProtoolsHelper()
+    h.api_key = None
+    assert await h.submit_deck_view("dmA", _draft_log(), "x") is None

--- a/tests/test_pack_compositor.py
+++ b/tests/test_pack_compositor.py
@@ -1,0 +1,48 @@
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+
+from helpers.pack_compositor import PackCompositor
+
+
+def _img():
+    return Image.new("RGB", (244, 340), (0, 0, 0))
+
+
+def _carddata(n):
+    return {f"c{i}": {"name": f"Card {i}", "image_uris": {"normal": f"http://x/{i}.jpg"}} for i in range(n)}
+
+
+@pytest.mark.asyncio
+async def test_composite_none_when_any_card_unfetchable():
+    ids = [f"c{i}" for i in range(15)]
+    cd = _carddata(15)
+
+    async def fetch(session, card_id, carddata, **kw):
+        return None if card_id == "c7" else _img()
+
+    with patch("helpers.pack_compositor.fetch_card_image", new=AsyncMock(side_effect=fetch)):
+        out = await PackCompositor().create_pack_composite(ids, cd)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_composite_none_when_fetch_raises():
+    ids = [f"c{i}" for i in range(15)]
+    cd = _carddata(15)
+    with patch("helpers.pack_compositor.fetch_card_image",
+               new=AsyncMock(side_effect=RuntimeError("boom"))):
+        out = await PackCompositor().create_pack_composite(ids, cd)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_composite_ok_when_all_fetched():
+    ids = [f"c{i}" for i in range(15)]
+    cd = _carddata(15)
+    with patch("helpers.pack_compositor.fetch_card_image", new=AsyncMock(return_value=_img())):
+        out = await PackCompositor().create_pack_composite(ids, cd)
+    assert isinstance(out, BytesIO)
+    assert len(out.getvalue()) > 0

--- a/tests/test_pile_compositor.py
+++ b/tests/test_pile_compositor.py
@@ -1,0 +1,174 @@
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+
+from helpers.pile_compositor import bucket_cards, PileImageBuilder
+
+
+def _cd():
+    return {
+        "land":  {"name": "Wastes",         "cmc": 0, "mana_cost": "",       "image_uris": {"normal": "u"}},
+        "zero":  {"name": "Ornithopter",    "cmc": 0, "mana_cost": "{0}",    "image_uris": {"normal": "u"}},
+        "ballista": {"name": "Walking Ballista", "cmc": 0, "mana_cost": "{X}{X}", "image_uris": {"normal": "u"}},
+        "one":   {"name": "Bolt",           "cmc": 1, "mana_cost": "{R}",    "image_uris": {"normal": "u"}},
+        "seven": {"name": "Titan",          "cmc": 7, "mana_cost": "{5}{G}{G}", "image_uris": {"normal": "u"}},
+        "nine":  {"name": "Emrakul",        "cmc": 9, "mana_cost": "{9}",    "image_uris": {"normal": "u"}},
+        "amv1":  {"name": "Aardvark",       "cmc": 1, "mana_cost": "{W}",    "image_uris": {"normal": "u"}},
+    }
+
+
+def test_bucketing_lands_mv_and_seven_plus():
+    cols = dict(bucket_cards(["land", "zero", "ballista", "one", "amv1", "seven", "nine"], _cd()))
+    assert cols["Lands"] == ["land"]                 # empty mana_cost + cmc 0
+    assert set(cols["0"]) == {"zero", "ballista"}    # {0} artifact and X-spell stay in MV0
+    assert cols["1"] == ["amv1", "one"]              # name-sorted: Aardvark before Bolt
+    assert set(cols["7+"]) == {"seven", "nine"}      # cmc>=7 collapse
+
+
+def test_bucketing_sorts_within_column_by_name():
+    cols = dict(bucket_cards(["one", "amv1"], _cd()))
+    assert cols["1"] == ["amv1", "one"]              # Aardvark before Bolt
+
+
+def test_bucketing_absent_card_defaults_to_mv0_not_lands():
+    # A card_id with no entry in carddata must not be misclassified as a Land
+    # (an empty info dict trivially satisfies the land rule).
+    cols = dict(bucket_cards(["ghost"], {}))
+    assert cols["0"] == ["ghost"]
+    assert "Lands" not in cols
+
+
+def test_bucketing_duplicate_card_ids_not_collapsed():
+    cols = dict(bucket_cards(["one", "one", "one"], _cd()))
+    assert cols["1"] == ["one", "one", "one"]
+
+
+@pytest.mark.asyncio
+async def test_build_none_when_any_card_unfetchable():
+    cd = _cd()
+    async def fetch(session, card_id, carddata, **kw):
+        return None if card_id == "one" else Image.new("RGB", (244, 340), (1, 2, 3))
+    with patch("helpers.pile_compositor.fetch_card_image", new=AsyncMock(side_effect=fetch)):
+        out = await PileImageBuilder().build(["land", "one"], [], cd)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_build_none_when_fetch_raises():
+    cd = _cd()
+    with patch("helpers.pile_compositor.fetch_card_image",
+               new=AsyncMock(side_effect=RuntimeError("boom"))):
+        out = await PileImageBuilder().build(["land", "one"], [], cd)
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_build_returns_jpeg_bytes_on_success():
+    cd = _cd()
+    with patch("helpers.pile_compositor.fetch_card_image",
+               new=AsyncMock(return_value=Image.new("RGB", (244, 340), (1, 2, 3)))):
+        out = await PileImageBuilder().build(["land", "one", "seven"], [], cd)
+    assert isinstance(out, BytesIO)
+    data = out.getvalue()
+    assert data[:2] == b"\xff\xd8"                   # JPEG SOI marker
+
+
+@pytest.mark.asyncio
+async def test_build_returns_jpeg_bytes_for_duplicate_card_ids():
+    cd = _cd()
+    with patch("helpers.pile_compositor.fetch_card_image",
+               new=AsyncMock(return_value=Image.new("RGB", (244, 340), (1, 2, 3)))):
+        out = await PileImageBuilder().build(["one", "one", "one"], [], cd)
+    assert isinstance(out, BytesIO)
+    data = out.getvalue()
+    assert data[:2] == b"\xff\xd8"                   # JPEG SOI marker
+
+
+@pytest.mark.asyncio
+async def test_build_canvas_dimensions_match_geometry_formula():
+    # 1 land + 3 cards at cmc 1 -> two columns: "Lands" (1 card) and "1"
+    # (3 cards, the tallest column).
+    cd = _cd()
+    cd["a"] = {"name": "Aardvark", "cmc": 1, "mana_cost": "{W}", "image_uris": {"normal": "u"}}
+    cd["b"] = {"name": "Bolt", "cmc": 1, "mana_cost": "{R}", "image_uris": {"normal": "u"}}
+    cd["c"] = {"name": "Charm", "cmc": 1, "mana_cost": "{U}", "image_uris": {"normal": "u"}}
+    card_ids = ["land", "a", "b", "c"]
+
+    builder = PileImageBuilder()
+    cols = dict(bucket_cards(card_ids, cd))
+    assert cols["Lands"] == ["land"]
+    assert cols["1"] == ["a", "b", "c"]
+    num_cols = 2
+    max_cards_in_col = 3
+
+    cw, ch, nb, b = builder.card_width, builder.card_height, builder.name_bar, builder.border
+    expected_w = b + num_cols * (cw + b)
+    expected_h = b + (ch + nb * (max_cards_in_col - 1)) + b
+
+    with patch("helpers.pile_compositor.fetch_card_image",
+               new=AsyncMock(return_value=Image.new("RGB", (cw, ch)))):
+        out = await builder.build(card_ids, [], cd)
+
+    assert isinstance(out, BytesIO)
+    img = Image.open(out)
+    assert img.size == (expected_w, expected_h)
+
+
+@pytest.mark.asyncio
+async def test_build_renders_sideboard_taller_than_main_only():
+    cd = _cd()
+    solid = Image.new("RGB", (244, 340), (1, 2, 3))
+    with patch("helpers.pile_compositor.fetch_card_image", new=AsyncMock(return_value=solid)):
+        main_only = await PileImageBuilder().build(["one", "seven"], [], cd)
+        with_side = await PileImageBuilder().build(["one", "seven"], ["land", "amv1"], cd)
+    h_main = Image.open(BytesIO(main_only.getvalue())).size[1]
+    h_side = Image.open(BytesIO(with_side.getvalue())).size[1]
+    assert h_side > h_main            # sideboard section adds height
+
+
+@pytest.mark.asyncio
+async def test_build_none_when_a_sideboard_card_unfetchable():
+    cd = _cd()
+    async def fetch(session, card_id, carddata, **kw):
+        return None if card_id == "amv1" else Image.new("RGB", (244, 340), (1, 2, 3))
+    with patch("helpers.pile_compositor.fetch_card_image", new=AsyncMock(side_effect=fetch)):
+        out = await PileImageBuilder().build(["one"], ["amv1"], cd)
+    assert out is None                # all-or-nothing across main ∪ side
+
+
+@pytest.mark.asyncio
+async def test_sideboard_divider_spans_full_width_when_sideboard_wider():
+    # Main deck is narrow (1 MV column); sideboard is wider (3 MV columns:
+    # Lands, "1", "7+"). The composed canvas width must follow the wider
+    # sideboard block, and the SIDEBOARD divider strip must span that full
+    # width -- not just the narrower main block's width.
+    cd = _cd()
+    solid = Image.new("RGB", (244, 340), (1, 2, 3))
+    builder = PileImageBuilder()
+    cw, ch, nb, b = builder.card_width, builder.card_height, builder.name_bar, builder.border
+
+    main_ids = ["one"]                    # 1 column ("1"), 1 card tall
+    side_ids = ["land", "one", "seven"]   # 3 columns: Lands, "1", "7+" -- each 1 card tall
+
+    main_cols = dict(bucket_cards(main_ids, cd))
+    side_cols = dict(bucket_cards(side_ids, cd))
+    assert len(main_cols) == 1
+    assert len(side_cols) == 3
+
+    main_block_h = b + (ch + nb * (1 - 1)) + b   # tallest main column has 1 card
+
+    with patch("helpers.pile_compositor.fetch_card_image", new=AsyncMock(return_value=solid)):
+        out = await builder.build(main_ids, side_ids, cd)
+
+    assert isinstance(out, BytesIO)
+    img = Image.open(BytesIO(out.getvalue())).convert("RGB")
+    canvas_w, _canvas_h = img.size
+
+    divider_y = main_block_h + 14   # middle of the 28px divider strip
+    sample_x = canvas_w - 5         # near the right edge of the canvas
+    r, g, bch = img.getpixel((sample_x, divider_y))
+
+    for channel in (r, g, bch):
+        assert abs(channel - 40) <= 25, (r, g, bch)

--- a/tests/test_quiz_pack_image.py
+++ b/tests/test_quiz_pack_image.py
@@ -1,0 +1,149 @@
+import os
+import tempfile
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import cogs.quiz_commands as quiz_commands
+from cogs.quiz_commands import build_pack_image_or_abort
+from database.db_session import AsyncSessionLocal
+from database.models_base import Base
+from models import DraftSession, QuizSession
+from services.draft_analysis import DraftAnalysis
+
+
+@pytest.mark.asyncio
+async def test_returns_none_flag_off_no_image_expected():
+    # flag off -> (file=None, abort=False): post normally, no image
+    file, abort = await build_pack_image_or_abort(
+        enabled=False, draft_data={"carddata": {}}, booster_ids=[], quiz_id="q", images_config={}
+    )
+    assert file is None and abort is False
+
+
+@pytest.mark.asyncio
+async def test_aborts_when_enabled_and_composite_none():
+    with patch("cogs.quiz_commands.PackCompositor.create_pack_composite",
+               new=AsyncMock(return_value=None)):
+        file, abort = await build_pack_image_or_abort(
+            enabled=True, draft_data={"carddata": {"c": {}}}, booster_ids=["c"],
+            quiz_id="q", images_config={},
+        )
+    assert file is None and abort is True            # do not post
+
+
+@pytest.mark.asyncio
+async def test_returns_file_when_enabled_and_composite_ok():
+    from io import BytesIO
+    with patch("cogs.quiz_commands.PackCompositor.create_pack_composite",
+               new=AsyncMock(return_value=BytesIO(b"\xff\xd8jpg"))):
+        file, abort = await build_pack_image_or_abort(
+            enabled=True, draft_data={"carddata": {"c": {}}}, booster_ids=["c"],
+            quiz_id="q", images_config={},
+        )
+    assert file is not None and abort is False
+
+
+@pytest.mark.asyncio
+async def test_aborts_when_enabled_and_composite_raises():
+    # A raised exception during compositing must also hard-fail (abort=True),
+    # not degrade to posting text-only.
+    with patch("cogs.quiz_commands.PackCompositor.create_pack_composite",
+               new=AsyncMock(side_effect=RuntimeError("boom"))):
+        file, abort = await build_pack_image_or_abort(
+            enabled=True, draft_data={"carddata": {"c": {}}}, booster_ids=["c"],
+            quiz_id="q", images_config={},
+        )
+    assert file is None and abort is True
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db'); tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose(); os.unlink(tmp.name)
+
+
+class _FakeChannel:
+    """Minimal stand-in for a discord.TextChannel: records sent payloads."""
+
+    def __init__(self, channel_id=999):
+        self.id = channel_id
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        message = AsyncMock()
+        message.id = 555
+        message.pin = AsyncMock()
+        return message
+
+
+def _six_player_draft_data():
+    """6-player draft, pack 0 passes left; enough picks for a 4-pick trace
+    starting at seat 0."""
+    users = {}
+    for i in range(6):
+        booster = [f"c{j}" for j in range(i, 6)]
+        users[f"user{i}"] = {
+            "userName": f"Player{i}",
+            "seatNum": i,
+            "picks": [
+                {"packNum": 0, "pickNum": i, "pick": [0], "booster": booster},
+            ],
+        }
+    carddata = {f"c{i}": {"name": f"Card{i}"} for i in range(6)}
+    return {"sessionID": "TEST_SESSION", "users": users, "carddata": carddata}
+
+
+@pytest.mark.asyncio
+async def test_create_and_post_quiz_aborts_without_orphaning_session(test_db):
+    """An enabled-but-unbuildable pack image must abort with no QuizSession
+    row persisted at all (a message_id-less orphan would permanently burn
+    the draft+seat combo via _select_random_draft_and_seat)."""
+    draft_data = _six_player_draft_data()
+    analysis = DraftAnalysis(draft_data)
+    pack_trace = analysis.trace_pack(pack_num=0, length=4, starting_seat=0)
+    assert pack_trace is not None and len(pack_trace.picks) == 4  # sanity
+
+    draft_session = DraftSession(
+        session_id="test_session",
+        guild_id="g1",
+        cube="TestCube",
+        draft_start_time=datetime.now(),
+        spaces_object_key="key",
+    )
+
+    cog = quiz_commands.QuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    fake_config = {"features": {"quiz_pack_images": {"enabled": True}}}
+    with patch("cogs.quiz_commands.get_config", return_value=fake_config), \
+         patch("cogs.quiz_commands.PackCompositor.create_pack_composite",
+               AsyncMock(return_value=None)):
+        message = await cog._create_and_post_quiz(
+            guild_id="g1",
+            channel_id="c1",
+            channel=channel,
+            draft_session=draft_session,
+            analysis=analysis,
+            pack_trace=pack_trace,
+            mpt_url=None,
+            draft_data=draft_data,
+            posted_by="mod",
+            starting_seat=0,
+        )
+
+    assert message is None
+    assert channel.sent == []  # never posted
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(select(QuizSession))
+        assert result.scalars().all() == []  # never persisted


### PR DESCRIPTION
**Stacked PR 1 of 3** — bottom of the Trophy Quiz stack. Review this first.

This layer holds the shared image/MPT helpers, and it is the layer that **touches existing behaviour** (the pick/pack quiz already use `PackCompositor` and the MPT helper), so it's isolated for careful review.

### What's here
- **`helpers/card_image_fetcher.py`** (new) — shared, retry-aware fetch: a URL ladder (captured printing → DFC face → Scryfall by-UUID → Scryfall by-name), exponential backoff on *transient* failures only (429/5xx/timeout), immediate fall-through on definitive ones (404), and a wall-clock `deadline` for fail-fast/bounded work.
- **`helpers/pack_compositor.py`** — now delegates downloads to the shared fetcher and is **all-or-nothing** (any unfetchable card → `None`, no partial composite). PIL compositing offloaded via `asyncio.to_thread` so it never blocks the event loop.
- **`helpers/pile_compositor.py`** (new) — mana-value overlapping pile view (main deck + labeled SIDEBOARD section), same all-or-nothing + deadline semantics.
- **`helpers/magicprotools_helper.py`** — opt-in `anonymize` (existing callers unchanged, byte-for-byte) + `submit_deck_view` + `extract_deck_token`.
- **`cogs/quiz_commands.py`** — pack quiz **hard-fails** (does not post) when images are enabled but the composite can't be built; unchanged when the feature flag is off.

### Behaviour changes to existing features
- Pack composite went from "drop failures, composite survivors" → **all-or-nothing**.
- Pack quiz now aborts the post (instead of degrading to no-image) when its image flag is on and the composite fails.

Pure/unit-tested: `tests/test_card_image_fetcher.py`, `test_pack_compositor.py`, `test_pile_compositor.py`, `test_mpt_deck_view.py`, `test_quiz_pack_image.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ