### PR TITLE
Trophy Quiz (2/3): data + scoring foundation (models, migrations, scoring, selection, split, leaderboard)

### DIFF
--- a/alembic/versions/troph1quiz00_add_trophy_quiz.py
+++ b/alembic/versions/troph1quiz00_add_trophy_quiz.py
@@ -1,0 +1,50 @@
+"""add trophy quiz tables and leaderboard columns"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'troph1quiz00'
+down_revision: Union[str, Sequence[str], None] = 'logcapr0recon'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'trophy_quiz_sessions',
+        sa.Column('quiz_id', sa.String(length=64), primary_key=True),
+        sa.Column('display_id', sa.Integer(), nullable=False),
+        sa.Column('guild_id', sa.String(length=64), nullable=False),
+        sa.Column('channel_id', sa.String(length=64), nullable=False),
+        sa.Column('message_id', sa.String(length=64), nullable=True),
+        sa.Column('draft_session_id', sa.String(length=128), nullable=False),
+        sa.Column('decks', sa.JSON(), nullable=False),
+        sa.Column('posted_by', sa.String(length=64), nullable=False),
+        sa.Column('posted_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('total_participants', sa.Integer(), server_default=sa.text('0')),
+    )
+    op.create_index('ix_trophy_quiz_sessions_guild_display_id', 'trophy_quiz_sessions',
+                    ['guild_id', 'display_id'], unique=True)
+    op.create_table(
+        'trophy_quiz_submissions',
+        sa.Column('quiz_id', sa.String(length=64), sa.ForeignKey('trophy_quiz_sessions.quiz_id'), primary_key=True),
+        sa.Column('player_id', sa.String(length=64), primary_key=True),
+        sa.Column('display_name', sa.String(length=128)),
+        sa.Column('guesses', sa.JSON(), nullable=False),
+        sa.Column('direction_correct', sa.Boolean(), nullable=False, server_default=sa.text('0')),
+        sa.Column('exact_points', sa.JSON(), nullable=False),
+        sa.Column('points_earned', sa.Integer(), nullable=False),
+        sa.Column('submitted_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+    with op.batch_alter_table('leaderboard_messages', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('trophy_quiz_points_view_message_id', sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column('trophy_quiz_points_timeframe', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('leaderboard_messages', schema=None) as batch_op:
+        batch_op.drop_column('trophy_quiz_points_timeframe')
+        batch_op.drop_column('trophy_quiz_points_view_message_id')
+    op.drop_index('ix_trophy_quiz_sessions_guild_display_id', table_name='trophy_quiz_sessions')
+    op.drop_table('trophy_quiz_submissions')
+    op.drop_table('trophy_quiz_sessions')

--- a/alembic/versions/trophreveal01_add_trophy_quiz_reveals.py
+++ b/alembic/versions/trophreveal01_add_trophy_quiz_reveals.py
@@ -1,0 +1,27 @@
+"""add trophy_quiz_reveals table
+
+Revision ID: trophreveal01
+Revises: troph1quiz00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "trophreveal01"
+down_revision = "troph1quiz00"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "trophy_quiz_reveals",
+        sa.Column("quiz_id", sa.String(length=64), nullable=False),
+        sa.Column("player_id", sa.String(length=64), nullable=False),
+        sa.Column("revealed_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.ForeignKeyConstraint(["quiz_id"], ["trophy_quiz_sessions.quiz_id"]),
+        sa.PrimaryKeyConstraint("quiz_id", "player_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("trophy_quiz_reveals")

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -568,6 +568,8 @@ class AdminCommands(commands.Cog):
                     leaderboard_record.perfect_streak_view_message_id = None
                     leaderboard_record.quiz_points_view_message_id = None
                     leaderboard_record.draft_win_streak_view_message_id = None
+                    leaderboard_record.trophy_quiz_points_view_message_id = None
+                    leaderboard_record.trophy_quiz_points_timeframe = None
 
                     await session.commit()
                     logger.info(f"Leaderboard channel changed to {channel.name} for guild {ctx.guild.name} by {ctx.author.name}")

--- a/leaderboard_config.py
+++ b/leaderboard_config.py
@@ -98,6 +98,12 @@ CATEGORY_CONFIGS = {
         "color": discord.Color.from_rgb(138, 43, 226),  # Blue-violet
         "formatter": lambda p, rank: f"{get_medal(rank)}{p['display_name']}: {p['total_points']} points ({p['total_quizzes']} quizzes, {p['accuracy_percentage']:.1f}% accuracy)"
     },
+    "trophy_quiz_points": {
+        "title": "Trophy Quiz Leaderboard",
+        "description_template": "Players with the most trophy-quiz points",
+        "color": discord.Color.from_rgb(212, 175, 55),  # Trophy gold
+        "formatter": lambda p, rank: f"{get_medal(rank)}{p['display_name']}: {p['total_points']} points ({p['total_quizzes']} quizzes)"
+    },
     "draft_win_streak": {
         "title": "Order of the White Lotus",
         "description_template": "Longest consecutive draft win streaks (min {streak_min} draft wins)",

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -20,6 +20,9 @@ from .quiz_scheduling import QuizChannel, QuizSchedule
 from .debt_ledger import DebtLedger
 from .debt_summary_message import DebtSummaryMessage
 from .tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
+from .trophy_quiz_session import TrophyQuizSession
+from .trophy_quiz_submission import TrophyQuizSubmission
+from .trophy_quiz_reveal import TrophyQuizReveal
 
 # Export all models
 __all__ = [
@@ -56,5 +59,8 @@ __all__ = [
     'Tournament',
     'TournamentParticipant',
     'TournamentRound',
-    'TournamentMatch'
+    'TournamentMatch',
+    'TrophyQuizSession',
+    'TrophyQuizSubmission',
+    'TrophyQuizReveal',
 ]

--- a/models/leaderboard_message.py
+++ b/models/leaderboard_message.py
@@ -26,6 +26,8 @@ class LeaderboardMessage(Base):
     quiz_points_timeframe = Column(String(20), default='lifetime')
     draft_win_streak_view_message_id = Column(String(64))
     draft_win_streak_timeframe = Column(String(20), default='lifetime')
+    trophy_quiz_points_view_message_id = Column(String(64))
+    trophy_quiz_points_timeframe = Column(String(20), default='lifetime')
 
     def __repr__(self):
         return f"<LeaderboardMessage(guild_id={self.guild_id}, message_id={self.message_id})>"

--- a/models/trophy_quiz_reveal.py
+++ b/models/trophy_quiz_reveal.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, DateTime, ForeignKey, text
+from database.models_base import Base
+
+
+class TrophyQuizReveal(Base):
+    """One row = a player paid to reveal the pilots on a trophy quiz. Persisted at
+    click time so re-opening the quiz remembers it (the -2 penalty can't be dodged)."""
+    __tablename__ = 'trophy_quiz_reveals'
+
+    quiz_id = Column(String(64), ForeignKey('trophy_quiz_sessions.quiz_id'), primary_key=True)
+    player_id = Column(String(64), primary_key=True)
+    revealed_at = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'))

--- a/models/trophy_quiz_session.py
+++ b/models/trophy_quiz_session.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, DateTime, text, JSON, Index
+from database.models_base import Base
+
+
+class TrophyQuizSession(Base):
+    __tablename__ = 'trophy_quiz_sessions'
+
+    quiz_id = Column(String(64), primary_key=True)   # guild_id-timestamp
+    display_id = Column(Integer, nullable=False)
+    guild_id = Column(String(64), nullable=False)
+    channel_id = Column(String(64), nullable=False)
+    message_id = Column(String(64), nullable=True)
+    draft_session_id = Column(String(128), nullable=False)
+    decks = Column(JSON, nullable=False)             # [{slot, drafter_id, wins, pool}] x2
+    posted_by = Column(String(64), nullable=False)
+    posted_at = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'))
+    total_participants = Column(Integer, default=0, server_default=text('0'))
+
+    __table_args__ = (
+        Index('ix_trophy_quiz_sessions_guild_display_id', 'guild_id', 'display_id', unique=True),
+    )

--- a/models/trophy_quiz_submission.py
+++ b/models/trophy_quiz_submission.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, text, JSON
+from database.models_base import Base
+
+
+class TrophyQuizSubmission(Base):
+    __tablename__ = 'trophy_quiz_submissions'
+
+    quiz_id = Column(String(64), ForeignKey('trophy_quiz_sessions.quiz_id'), primary_key=True)
+    player_id = Column(String(64), primary_key=True)
+    display_name = Column(String(128))
+    guesses = Column(JSON, nullable=False)            # [winsA, winsB]
+    direction_correct = Column(Boolean, nullable=False, default=False)
+    exact_points = Column(JSON, nullable=False)       # [ptsA, ptsB]
+    points_earned = Column(Integer, nullable=False)
+    submitted_at = Column(DateTime, server_default=text('CURRENT_TIMESTAMP'))

--- a/services/draft_log_store.py
+++ b/services/draft_log_store.py
@@ -17,15 +17,9 @@ from helpers.substitutes import TEAM_A_CHANNEL_PREFIX, TEAM_B_CHANNEL_PREFIX
 from models.draft_session import DraftSession
 
 
-def render_pool(draft_data: dict, user_id: str) -> str:
-    """Importable decklist for one drafter's full pool: `"<count> <CardName>"`
-    lines from `users[user_id].cards`, using the front-face card name. Returns
-    "" if the user or their cards are missing."""
-    users = draft_data.get("users") or {}
-    user = users.get(user_id) or {}
-    carddata = draft_data.get("carddata") or {}
-    card_ids = user.get("cards") or []
-
+def _grouped_lines(card_ids: list, carddata: dict) -> list:
+    """`"<count> <CardName>"` lines for `card_ids`, grouped by name (using the
+    front-face card name) and ordered by first appearance."""
     counts: dict[str, int] = {}
     order: list[str] = []
     for cid in card_ids:
@@ -35,7 +29,18 @@ def render_pool(draft_data: dict, user_id: str) -> str:
         if name not in counts:
             order.append(name)
         counts[name] = counts.get(name, 0) + 1
-    return "\n".join(f"{counts[name]} {name}" for name in order)
+    return [f"{counts[name]} {name}" for name in order]
+
+
+def render_pool(draft_data: dict, user_id: str) -> str:
+    """Importable decklist for one drafter's full pool: `"<count> <CardName>"`
+    lines from `users[user_id].cards`, using the front-face card name. Returns
+    "" if the user or their cards are missing."""
+    users = draft_data.get("users") or {}
+    user = users.get(user_id) or {}
+    carddata = draft_data.get("carddata") or {}
+    card_ids = user.get("cards") or []
+    return "\n".join(_grouped_lines(card_ids, carddata))
 
 
 def map_discord_to_draftmancer(draft_data: dict, sign_ups: dict) -> dict[str, str]:
@@ -174,3 +179,40 @@ async def post_team_logs(session_id: str, bot) -> bool:
             ds.team_logs_posted_at = datetime.now()
             await session.commit()
     return True
+
+
+_BASIC_LAND_NAMES = {"W": "Plains", "U": "Island", "B": "Swamp", "R": "Mountain", "G": "Forest", "C": "Wastes"}
+
+
+def split_decklist(draft_data: dict, user_id: str) -> dict:
+    """Split a drafter's pool into built main deck, basic-land counts, and sideboard.
+
+    Uses users[user_id].decklist when the player built a deck (non-empty main);
+    otherwise falls back to the full pool as main with no basics/sideboard.
+    """
+    user = (draft_data.get("users") or {}).get(user_id) or {}
+    decklist = user.get("decklist") or {}
+    main = decklist.get("main") or []
+    if main:
+        return {
+            "main": list(main),
+            "basics": dict(decklist.get("lands") or {}),
+            "side": list(decklist.get("side") or []),
+        }
+    return {"main": list(user.get("cards") or []), "basics": {}, "side": []}
+
+
+def build_mtgo_deck_text(split: dict, carddata: dict) -> str:
+    """MTGO-format deck text: main + basics, then a blank line and the sideboard
+    (sideboard block omitted when empty)."""
+    main_lines = _grouped_lines(split.get("main") or [], carddata)
+    basics = split.get("basics") or {}
+    # Emit basics in a stable WUBRGC order (not the source-map order).
+    for color, name in _BASIC_LAND_NAMES.items():
+        count = basics.get(color, 0)
+        if count:
+            main_lines.append(f"{count} {name}")
+    side_lines = _grouped_lines(split.get("side") or [], carddata)
+    if side_lines:
+        return "\n".join(main_lines) + "\n\n" + "\n".join(side_lines)
+    return "\n".join(main_lines)

--- a/services/leaderboard_service.py
+++ b/services/leaderboard_service.py
@@ -8,6 +8,8 @@ from models.perfect_streak_history import PerfectStreakHistory
 from models.draft_streak_history import DraftStreakHistory
 from models.player import PlayerStats
 from models import QuizStats, QuizSubmission, QuizSession
+from models.trophy_quiz_submission import TrophyQuizSubmission
+from models.trophy_quiz_session import TrophyQuizSession
 
 # Win Streak minimum requirements by timeframe
 STREAK_MINIMUMS = {
@@ -387,6 +389,9 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
         elif category == "quiz_points":
             # Use dedicated function for quiz stats (doesn't need draft aggregation)
             sorted_players = await get_quiz_points_leaderboard_data(guild_id, timeframe, limit, session)
+
+        elif category == "trophy_quiz_points":
+            sorted_players = await get_trophy_quiz_points_leaderboard_data(guild_id, timeframe, limit, session)
 
         elif category == "draft_win_streak":
             # Use dedicated function for draft win streak (Order of the White Lotus)
@@ -892,6 +897,44 @@ async def get_quiz_points_leaderboard_data(guild_id, timeframe, limit, session):
             })
 
     # Apply limit
+    return leaderboard_data[:limit]
+
+
+async def get_trophy_quiz_points_leaderboard_data(guild_id, timeframe, limit, session):
+    """Rank players by summed TrophyQuizSubmission.points_earned in the guild.
+    Aggregates submissions directly for all timeframes; separate from the pick
+    quiz's quiz_points leaderboard."""
+    # Calculate date cutoff for timeframe
+    if timeframe == "90d":
+        cutoff_date = datetime.now() - timedelta(days=90)
+    elif timeframe == "30d":
+        cutoff_date = datetime.now() - timedelta(days=30)
+    elif timeframe == "14d":
+        cutoff_date = datetime.now() - timedelta(days=14)
+    else:
+        cutoff_date = None
+
+    stmt = select(TrophyQuizSubmission).join(
+        TrophyQuizSession,
+        TrophyQuizSubmission.quiz_id == TrophyQuizSession.quiz_id
+    ).where(TrophyQuizSession.guild_id == str(guild_id))
+    if cutoff_date is not None:
+        stmt = stmt.where(TrophyQuizSubmission.submitted_at >= cutoff_date)
+
+    submissions = (await session.execute(stmt)).scalars().all()
+
+    player_aggregates = {}
+    for sub in submissions:
+        agg = player_aggregates.setdefault(sub.player_id, {
+            "player_id": sub.player_id,
+            "display_name": sub.display_name,
+            "total_points": 0,
+            "total_quizzes": 0
+        })
+        agg["total_points"] += sub.points_earned
+        agg["total_quizzes"] += 1
+
+    leaderboard_data = sorted(player_aggregates.values(), key=lambda p: p["total_points"], reverse=True)
     return leaderboard_data[:limit]
 
 

--- a/services/trophy_quiz_reveal_store.py
+++ b/services/trophy_quiz_reveal_store.py
@@ -1,0 +1,27 @@
+from sqlalchemy.exc import IntegrityError
+from database.db_session import db_session
+from models import TrophyQuizReveal
+
+
+async def has_revealed(quiz_id: str, player_id: str) -> bool:
+    """True if this player has paid to reveal the pilots on this quiz."""
+    async with db_session() as session:
+        row = await session.get(TrophyQuizReveal, (quiz_id, player_id))
+    return row is not None
+
+
+async def record_reveal(quiz_id: str, player_id: str) -> None:
+    """Idempotently mark that this player revealed the pilots on this quiz.
+
+    Tolerates a concurrent duplicate (rapid double-click): the check-then-insert
+    can race two interactions past the existence check, and the losing commit hits
+    the composite PK. Swallow that — the row exists either way, so it's a no-op.
+    """
+    async with db_session() as session:
+        existing = await session.get(TrophyQuizReveal, (quiz_id, player_id))
+        if existing is None:
+            session.add(TrophyQuizReveal(quiz_id=quiz_id, player_id=player_id))
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()  # a concurrent click already recorded it

--- a/services/trophy_quiz_service.py
+++ b/services/trophy_quiz_service.py
@@ -1,0 +1,121 @@
+"""Pure logic for the Trophy Quiz: record labels, scoring, and (Task 2/3) record
+computation + deck selection. No Discord objects here."""
+
+from services.draft_log_store import render_pool, map_discord_to_draftmancer
+
+DIRECTION_POINTS = 4
+EXACT_POINTS = 3     # flat: same for any exactly-correct record (keeps max constant)
+EXTREME_TARGET_RATE = 1 / 2   # extreme and middle equally likely (no-hedge point under flat scoring)
+REVEAL_COST = 2  # points deducted (floored at 0) when a player pays to reveal names
+
+
+def apply_reveal_cost(base_total: int, revealed: bool) -> int:
+    """Final quiz score after an optional pay-to-reveal-names penalty, floored at 0."""
+    return max(0, base_total - REVEAL_COST) if revealed else base_total
+
+
+def record_label(wins: int) -> str:
+    """'3-0', '2-1', '1-2', '0-3' for a 3-round record."""
+    return f"{wins}-{3 - wins}"
+
+
+def is_extreme(wins: int) -> bool:
+    """True for a 3-0 or 0-3 — used by selection biasing, not scoring."""
+    return wins in (0, 3)
+
+
+def score_submission(guessed_wins: list, actual_wins: list) -> dict:
+    """Score a 2-deck submission. guessed/actual are [winsA, winsB].
+
+    +DIRECTION_POINTS if the guessed better deck (more guessed wins) matches the
+    actual better deck; a tie guess scores 0 for direction. Each exactly-correct
+    record adds a flat +EXACT_POINTS, so the max is constant regardless of the
+    records (a shared total can't reveal whether the quiz held a trophy).
+    """
+    if guessed_wins[0] == guessed_wins[1]:
+        guessed_better = None
+    else:
+        guessed_better = 0 if guessed_wins[0] > guessed_wins[1] else 1
+    actual_better = 0 if actual_wins[0] > actual_wins[1] else 1
+
+    direction_correct = guessed_better == actual_better
+    direction_points = DIRECTION_POINTS if direction_correct else 0
+    exact_points = [
+        EXACT_POINTS if g == a else 0
+        for g, a in zip(guessed_wins, actual_wins)
+    ]
+    return {
+        "direction_correct": direction_correct,
+        "direction_points": direction_points,
+        "exact_points": exact_points,
+        "total": direction_points + sum(exact_points),
+    }
+
+
+def compute_records(match_results) -> dict:
+    """Per-player {wins, matches, reported} from a draft's match results. matches
+    counts appearances; wins counts winner_id; reported counts the player's
+    matches that are decided (non-null winner_id)."""
+    recs: dict = {}
+
+    def _entry(pid):
+        return recs.setdefault(pid, {"wins": 0, "matches": 0, "reported": 0})
+
+    for m in match_results:
+        decided = m.winner_id is not None
+        for pid in (m.player1_id, m.player2_id):
+            if pid is None:
+                continue
+            entry = _entry(pid)
+            entry["matches"] += 1
+            if decided:
+                entry["reported"] += 1
+        if decided:
+            _entry(m.winner_id)["wins"] += 1
+    return recs
+
+
+def _pick_from_bucket(bucket, rng):
+    """Pick one drafter from a bucket, choosing an extreme with probability
+    EXTREME_TARGET_RATE when the bucket offers both an extreme and a middle."""
+    extremes = [d for d in bucket if is_extreme(d["wins"])]
+    middles = [d for d in bucket if not is_extreme(d["wins"])]
+    if extremes and middles:
+        group = extremes if rng.random() < EXTREME_TARGET_RATE else middles
+    else:
+        group = extremes or middles
+    return rng.choice(group)
+
+
+def select_two_decks(draft_data, sign_ups, match_results, rng):
+    """Pick one better-bucket (wins>=2) and one worse-bucket (wins<=1) deck from
+    a pod that has >=1 extreme (3-0/0-3), or None if ineligible.
+
+    A qualifying drafter has a clean mapping, exactly 3 FULLY-REPORTED matches, and
+    a non-empty pool. Selection is biased toward extremes (EXTREME_TARGET_RATE),
+    not forced. The stored deck keeps its rendered `pool` text.
+    """
+    mapping = map_discord_to_draftmancer(draft_data, sign_ups)
+    if not mapping:
+        return None
+    records = compute_records(match_results)
+
+    qualifying = []
+    for discord_id, dm_id in mapping.items():
+        rec = records.get(discord_id)
+        if not rec or rec["matches"] != 3 or rec["reported"] != 3:
+            continue
+        pool = render_pool(draft_data, dm_id)
+        if not pool:
+            continue
+        qualifying.append({"drafter_id": discord_id, "wins": rec["wins"], "pool": pool})
+
+    better = [q for q in qualifying if q["wins"] >= 2]
+    worse = [q for q in qualifying if q["wins"] <= 1]
+    has_extreme = any(is_extreme(q["wins"]) for q in qualifying)
+    if not better or not worse or not has_extreme:
+        return None
+
+    pair = [_pick_from_bucket(better, rng), _pick_from_bucket(worse, rng)]
+    rng.shuffle(pair)
+    return pair

--- a/tests/test_decklist_split.py
+++ b/tests/test_decklist_split.py
@@ -1,0 +1,55 @@
+from services.draft_log_store import split_decklist, build_mtgo_deck_text
+
+CARDDATA = {
+    "m1": {"name": "Mana Drain"}, "m2": {"name": "Duress"}, "m3": {"name": "Duress"},
+    "s1": {"name": "Negate"}, "s2": {"name": "Brainstorm"},
+    "p1": {"name": "Ponder"},
+}
+
+
+def _dd(user):
+    return {"users": {"u": user}, "carddata": CARDDATA}
+
+
+def test_split_uses_decklist_when_built():
+    dd = _dd({
+        "cards": ["m1", "m2", "m3", "s1", "s2"],
+        "decklist": {"main": ["m1", "m2", "m3"], "side": ["s1", "s2"], "lands": {"U": 6, "B": 5, "W": 0}},
+    })
+    split = split_decklist(dd, "u")
+    assert split["main"] == ["m1", "m2", "m3"]
+    assert split["side"] == ["s1", "s2"]
+    assert split["basics"] == {"U": 6, "B": 5, "W": 0}
+
+
+def test_split_falls_back_to_full_pool_when_unbuilt():
+    dd = _dd({"cards": ["m1", "p1"]})  # no decklist
+    split = split_decklist(dd, "u")
+    assert split["main"] == ["m1", "p1"]
+    assert split["basics"] == {}
+    assert split["side"] == []
+
+
+def test_split_falls_back_when_main_empty():
+    dd = _dd({"cards": ["m1"], "decklist": {"main": [], "side": [], "lands": {}}})
+    assert split_decklist(dd, "u")["main"] == ["m1"]
+
+
+def test_mtgo_text_groups_main_maps_basics_and_separates_sideboard():
+    split = {"main": ["m1", "m2", "m3"], "basics": {"U": 6, "B": 5, "W": 0}, "side": ["s1", "s2"]}
+    text = build_mtgo_deck_text(split, CARDDATA)
+    lines = text.split("\n")
+    assert "1 Mana Drain" in lines
+    assert "2 Duress" in lines               # grouped by name
+    assert "6 Island" in lines and "5 Swamp" in lines
+    assert "0 Plains" not in text            # zero basics skipped
+    assert "" in lines                        # blank line separates sideboard
+    blank = lines.index("")
+    assert any("Negate" in l for l in lines[blank + 1:])   # sideboard after the blank line
+
+
+def test_mtgo_text_no_sideboard_block_when_side_empty():
+    split = {"main": ["m1"], "basics": {}, "side": []}
+    text = build_mtgo_deck_text(split, CARDDATA)
+    assert text == "1 Mana Drain"
+    assert "\n\n" not in text

--- a/tests/test_trophy_quiz_leaderboard.py
+++ b/tests/test_trophy_quiz_leaderboard.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from database.models_base import Base
+from database.db_session import AsyncSessionLocal
+from models.trophy_quiz_session import TrophyQuizSession
+from models.trophy_quiz_submission import TrophyQuizSubmission
+from services.leaderboard_service import get_trophy_quiz_points_leaderboard_data
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    temp_db.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+
+    yield engine
+
+    await engine.dispose()
+    os.unlink(temp_db.name)
+
+
+@pytest.mark.asyncio
+async def test_ranks_by_total_points(test_db):
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(TrophyQuizSession(
+                quiz_id="g-1", display_id=1, guild_id="g",
+                channel_id="c", draft_session_id="d",
+                decks=[], posted_by="m"
+            ))
+            session.add(TrophyQuizSubmission(
+                quiz_id="g-1", player_id="lo", display_name="Lo",
+                guesses=[], direction_correct=True, exact_points=[],
+                points_earned=4
+            ))
+            session.add(TrophyQuizSubmission(
+                quiz_id="g-1", player_id="hi", display_name="Hi",
+                guesses=[], direction_correct=True, exact_points=[],
+                points_earned=12
+            ))
+
+    async with AsyncSessionLocal() as session:
+        rows = await get_trophy_quiz_points_leaderboard_data("g", "lifetime", 10, session)
+
+    assert [r["player_id"] for r in rows] == ["hi", "lo"]
+    assert rows[0]["total_points"] == 12

--- a/tests/test_trophy_quiz_models.py
+++ b/tests/test_trophy_quiz_models.py
@@ -1,0 +1,38 @@
+import pytest, pytest_asyncio, tempfile, os
+from sqlalchemy.ext.asyncio import create_async_engine
+from database.models_base import Base
+from database.db_session import AsyncSessionLocal
+from models.trophy_quiz_session import TrophyQuizSession
+from models.trophy_quiz_submission import TrophyQuizSubmission
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db'); tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose(); os.unlink(tmp.name)
+
+
+@pytest.mark.asyncio
+async def test_round_trip(test_db):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            s.add(TrophyQuizSession(
+                quiz_id="g-1", display_id=1, guild_id="g", channel_id="c",
+                draft_session_id="d",
+                decks=[{"slot": "A", "drafter_id": "u1", "wins": 3},
+                       {"slot": "B", "drafter_id": "u2", "wins": 0}],
+                posted_by="mod"))
+            s.add(TrophyQuizSubmission(
+                quiz_id="g-1", player_id="p", display_name="P",
+                guesses=[3, 0], direction_correct=True, exact_points=[4, 4],
+                points_earned=12))
+    async with AsyncSessionLocal() as s:
+        sub = await s.get(TrophyQuizSubmission, ("g-1", "p"))
+        assert sub.points_earned == 12 and sub.direction_correct is True
+        quiz = await s.get(TrophyQuizSession, "g-1")
+        assert len(quiz.decks) == 2

--- a/tests/test_trophy_quiz_records.py
+++ b/tests/test_trophy_quiz_records.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from services.trophy_quiz_service import compute_records
+
+
+def _m(p1, p2, winner):
+    return SimpleNamespace(player1_id=p1, player2_id=p2, winner_id=winner)
+
+
+def test_counts_wins_matches_and_reported():
+    matches = [_m("a", "b", "a"), _m("a", "c", "a"), _m("a", "d", "a"),
+               _m("b", "c", "b"), _m("b", "d", "b")]
+    recs = compute_records(matches)
+    assert recs["a"] == {"wins": 3, "matches": 3, "reported": 3}
+    assert recs["b"]["wins"] == 2 and recs["b"]["matches"] == 3
+
+
+def test_unreported_match_lowers_reported_not_matches():
+    # a plays 3 but the middle one has no winner -> matches 3, reported 2, wins 2
+    matches = [_m("a", "b", "a"), _m("a", "c", None), _m("a", "d", "a")]
+    recs = compute_records(matches)
+    assert recs["a"] == {"wins": 2, "matches": 3, "reported": 2}
+    assert recs["c"] == {"wins": 0, "matches": 1, "reported": 0}

--- a/tests/test_trophy_quiz_scoring.py
+++ b/tests/test_trophy_quiz_scoring.py
@@ -1,0 +1,50 @@
+from services.trophy_quiz_service import score_submission, record_label
+
+
+def test_all_correct_maxes_at_10():
+    r = score_submission([3, 0], [3, 0])
+    assert r["direction_correct"] is True
+    assert r["direction_points"] == 4
+    assert r["exact_points"] == [3, 3]
+    assert r["total"] == 10
+
+
+def test_exact_is_flat_regardless_of_record():
+    # The whole point: extreme and middle exacts are worth the SAME (+3), so the
+    # max is constant (10) and a shared score can't reveal the records.
+    assert score_submission([3, 0], [3, 0])["exact_points"] == [3, 3]
+    assert score_submission([2, 1], [2, 1])["exact_points"] == [3, 3]
+    assert score_submission([2, 1], [2, 1])["total"] == 10
+
+
+def test_one_record_off():
+    # A=3-0 nailed (+3), B guessed 1-2 but actual 0-3 -> B wrong; direction right.
+    r = score_submission([3, 1], [3, 0])
+    assert r["direction_correct"] is True
+    assert r["exact_points"] == [3, 0]
+    assert r["total"] == 7
+
+
+def test_direction_only_no_exact():
+    r = score_submission([2, 1], [3, 0])
+    assert r["direction_correct"] is True
+    assert r["exact_points"] == [0, 0]
+    assert r["total"] == 4
+
+
+def test_wrong_direction_scores_zero():
+    r = score_submission([1, 2], [3, 0])
+    assert r["direction_correct"] is False
+    assert r["total"] == 0
+
+
+def test_tie_guess_no_direction_but_exact_still_counts():
+    # actual A=2-1, B=1-2; guess 2 & 2 -> tie (no direction), A exact (+3).
+    r = score_submission([2, 2], [2, 1])
+    assert r["direction_correct"] is False
+    assert r["exact_points"] == [3, 0]
+    assert r["total"] == 3
+
+
+def test_record_label():
+    assert [record_label(w) for w in (3, 2, 1, 0)] == ["3-0", "2-1", "1-2", "0-3"]

--- a/tests/test_trophy_quiz_selection.py
+++ b/tests/test_trophy_quiz_selection.py
@@ -1,0 +1,77 @@
+import random
+from services.trophy_quiz_service import select_two_decks
+
+
+def _draft_data(dm_ids):
+    users, carddata = {}, {}
+    for i, dm in enumerate(dm_ids):
+        cid = f"c{i}"
+        users[dm] = {"seatNum": i, "cards": [cid], "isBot": False}
+        carddata[cid] = {"name": f"Card{i}"}
+    return {"users": users, "carddata": carddata}
+
+
+def _matches(pairs):
+    from types import SimpleNamespace
+    return [SimpleNamespace(player1_id=a, player2_id=b, winner_id=w) for a, b, w in pairs]
+
+
+# 6 drafters, 3 rounds; d0 goes 3-0 (extreme), d5 goes 0-3 (extreme), rest middle.
+_WITH_EXTREME = [
+    ("d0", "d1", "d0"), ("d2", "d3", "d2"), ("d4", "d5", "d4"),
+    ("d0", "d2", "d0"), ("d1", "d4", "d1"), ("d3", "d5", "d3"),
+    ("d0", "d3", "d0"), ("d1", "d5", "d1"), ("d2", "d4", "d2"),
+]
+# 4 drafters, 3 rounds, all middle (d0,d1 = 2-1; d2,d3 = 1-2) -> no extreme.
+_NO_EXTREME = [
+    ("d0", "d2", "d0"), ("d0", "d3", "d0"), ("d1", "d0", "d1"),
+    ("d1", "d3", "d1"), ("d2", "d1", "d2"), ("d3", "d2", "d3"),
+]
+
+
+def _setup(n, rounds):
+    sign_ups = {f"d{i}": f"n{i}" for i in range(n)}
+    return sign_ups, _draft_data([f"dm{i}" for i in range(n)]), _matches(rounds)
+
+
+def test_picks_one_from_each_bucket():
+    sign_ups, draft_data, matches = _setup(6, _WITH_EXTREME)
+    decks = select_two_decks(draft_data, sign_ups, matches, random.Random(0))
+    assert decks is not None and len(decks) == 2
+    wins = sorted(d["wins"] for d in decks)
+    assert wins[0] <= 1 and wins[1] >= 2          # one worse, one better
+    assert all(d["pool"] for d in decks)
+
+
+def test_ineligible_when_no_extreme():
+    sign_ups, draft_data, matches = _setup(4, _NO_EXTREME)
+    assert select_two_decks(draft_data, sign_ups, matches, random.Random(0)) is None
+
+
+def test_extreme_not_forced_into_pair():
+    # Extreme/middle equally likely (~1/2), but not forced: some pairs are middle-only.
+    sign_ups, draft_data, matches = _setup(6, _WITH_EXTREME)
+    saw_no_extreme = False
+    for seed in range(30):
+        decks = select_two_decks(draft_data, sign_ups, matches, random.Random(seed))
+        assert decks is not None
+        if all(d["wins"] not in (0, 3) for d in decks):
+            saw_no_extreme = True
+    assert saw_no_extreme
+
+
+def test_excludes_drafter_with_unreported_match():
+    # d0 would be 3-0 but one match is unreported -> d0 dropped; d3 (0-3) keeps
+    # the pod eligible. d0 must never appear in the shown decks.
+    sign_ups = {f"d{i}": f"n{i}" for i in range(4)}
+    draft_data = _draft_data([f"dm{i}" for i in range(4)])
+    matches = _matches([
+        ("d0", "d1", "d0"), ("d2", "d3", "d2"),
+        ("d0", "d2", None),                       # d0's match UNREPORTED
+        ("d1", "d3", "d1"),
+        ("d0", "d3", "d0"), ("d1", "d2", "d1"),
+    ])
+    for seed in range(10):
+        decks = select_two_decks(draft_data, sign_ups, matches, random.Random(seed))
+        assert decks is not None
+        assert all(d["drafter_id"] != "d0" for d in decks)

--- a/tests/test_trophy_reveal_store.py
+++ b/tests/test_trophy_reveal_store.py
@@ -1,0 +1,37 @@
+import os, tempfile
+import pytest, pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+from database.db_session import AsyncSessionLocal
+from database.models_base import Base
+from services.trophy_quiz_reveal_store import record_reveal, has_revealed
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db'); tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose(); os.unlink(tmp.name)
+
+
+@pytest.mark.asyncio
+async def test_has_revealed_false_before_reveal(test_db):
+    assert await has_revealed("q1", "u1") is False
+
+
+@pytest.mark.asyncio
+async def test_record_then_has_revealed_true(test_db):
+    await record_reveal("q1", "u1")
+    assert await has_revealed("q1", "u1") is True
+    assert await has_revealed("q1", "u2") is False   # scoped per player
+    assert await has_revealed("q2", "u1") is False   # scoped per quiz
+
+
+@pytest.mark.asyncio
+async def test_record_reveal_is_idempotent(test_db):
+    await record_reveal("q1", "u1")
+    await record_reveal("q1", "u1")                   # no error, no duplicate
+    assert await has_revealed("q1", "u1") is True


### PR DESCRIPTION
**Stacked PR 2 of 3** — stacked on #333. The pure domain core (no Discord, no network).

### What's here
- **Models + migrations** — `TrophyQuizSession` / `TrophyQuizSubmission` / `TrophyQuizReveal`, `LeaderboardMessage` trophy columns; migrations `troph1quiz00` (tables + columns) and `trophreveal01` (reveals table), a linear chain off the current head.
- **`services/trophy_quiz_service.py`** — pure scoring (**+4** direction, flat **+3** exact → constant max 10, so a shared total can't leak whether a trophy was in the pod), per-drafter record computation (separating *matches* from *reported*), 2-deck extreme-pod selection (guard-clause gates, returns `None` when ineligible), `REVEAL_COST`/`apply_reveal_cost` (floored at 0).
- **`services/trophy_quiz_reveal_store.py`** — durable `has_revealed` / idempotent `record_reveal` (tolerates a concurrent duplicate via `IntegrityError` rollback).
- **`services/draft_log_store.py`** — `split_decklist` + `build_mtgo_deck_text` (MTGO main/basics//sideboard); `render_pool` refactored to share `_grouped_lines` (output byte-identical, per its existing tests).
- **Leaderboard** — a separate `trophy_quiz_points` category (the pick-quiz `quiz_points` board is untouched) + admin reset on channel move.

Everything here is a pure function or a plain model — no mocks needed in the tests: `tests/test_trophy_quiz_scoring.py`, `test_trophy_quiz_records.py`, `test_trophy_quiz_selection.py`, `test_decklist_split.py`, `test_trophy_quiz_leaderboard.py`, `test_trophy_quiz_models.py`, `test_trophy_reveal_store.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ