### PR TITLE
Trophy Quiz (3/3): the feature — views, /post_trophy_quiz command, scheduler

### DIFF
--- a/cogs/trophy_quiz_commands.py
+++ b/cogs/trophy_quiz_commands.py
@@ -1,0 +1,365 @@
+import random
+from datetime import datetime, timedelta
+from io import BytesIO
+from typing import List, Optional, Tuple
+
+import discord
+from discord.ext import commands
+from loguru import logger
+from sqlalchemy import and_, func, select, update
+
+from database.db_session import db_session
+from helpers.magicprotools_helper import MagicProtoolsHelper
+from helpers.pile_compositor import PileImageBuilder
+from models import DraftSession, MatchResult, TrophyQuizSession
+from services.draft_data_loader import load_from_spaces
+from services.draft_log_store import map_discord_to_draftmancer, split_decklist, build_mtgo_deck_text
+from services.trophy_quiz_service import select_two_decks
+from quiz_views_module.trophy_quiz_views import TrophyQuizView
+from utils import safe_pin
+
+ELIGIBLE_DRAFT_DAYS = 365  # Look back 1 year for eligible drafts
+MAX_POST_ATTEMPTS = 5  # trophy quiz: try up to N eligible drafts if prep fails
+
+
+async def _generate_next_display_id(guild_id: str) -> int:
+    """
+    Generate the next sequential display ID for a guild.
+    Returns the next available ID (max + 1), or 1 if no trophy quizzes exist.
+    """
+    async with db_session() as session:
+        stmt = select(func.max(TrophyQuizSession.display_id)).where(
+            TrophyQuizSession.guild_id == str(guild_id)
+        )
+        result = await session.execute(stmt)
+        max_id = result.scalar()
+        return (max_id or 0) + 1
+
+
+async def _select_eligible_draft(
+    guild_id: str, rng=random, exclude_draft_ids=None
+) -> Tuple[Optional[DraftSession], Optional[List[dict]], Optional[dict]]:
+    """
+    Select an eligible draft and its 2-deck trophy quiz pair.
+
+    Eligible = spaces_object_key set, session_type != "swiss", within
+    ELIGIBLE_DRAFT_DAYS, and draft_session_id not already used for a trophy
+    quiz in this guild. Lazily checks drafts (in random order), loading each
+    draft's log + match results and running select_two_decks, stopping at the
+    first draft that yields a non-None deck pair (select_two_decks already
+    enforces the fully-reported / extreme / bucket rules).
+
+    Returns (DraftSession, deck_pair, draft_data) or (None, None, None) if no
+    eligible draft yields a valid pair. draft_data is returned alongside so
+    callers can build MPT deck links without reloading it from Spaces.
+    """
+    cutoff = datetime.now() - timedelta(days=ELIGIBLE_DRAFT_DAYS)
+    exclude_draft_ids = exclude_draft_ids or set()
+
+    async with db_session() as session:
+        used_stmt = select(TrophyQuizSession.draft_session_id).where(
+            TrophyQuizSession.guild_id == str(guild_id)
+        )
+        used_result = await session.execute(used_stmt)
+        used_draft_ids = {row[0] for row in used_result.fetchall()} | set(exclude_draft_ids)
+
+        stmt = select(DraftSession).where(
+            and_(
+                DraftSession.guild_id == str(guild_id),
+                DraftSession.spaces_object_key.isnot(None),
+                DraftSession.session_type != "swiss",
+                DraftSession.draft_start_time >= cutoff,
+            )
+        )
+        result = await session.execute(stmt)
+        eligible_drafts = [
+            draft for draft in result.scalars().all()
+            if draft.session_id not in used_draft_ids
+        ]
+
+    if not eligible_drafts:
+        logger.warning(f"No eligible drafts found for trophy quiz in guild {guild_id}")
+        return None, None, None
+
+    rng.shuffle(eligible_drafts)
+
+    drafts_checked = 0
+    for draft in eligible_drafts:
+        drafts_checked += 1
+        try:
+            draft_data = await load_from_spaces(draft.spaces_object_key)
+            if not draft_data:
+                continue
+
+            async with db_session() as session:
+                matches_result = await session.execute(
+                    select(MatchResult).where(MatchResult.session_id == draft.session_id)
+                )
+                match_results = list(matches_result.scalars().all())
+
+            sign_ups = draft.sign_ups or {}
+            deck_pair = select_two_decks(draft_data, sign_ups, match_results, rng)
+            if deck_pair is None:
+                continue
+
+            logger.info(
+                f"Selected draft {draft.session_id} (cube: {draft.cube}) for trophy quiz "
+                f"after checking {drafts_checked} drafts"
+            )
+            return draft, deck_pair, draft_data
+
+        except Exception as e:
+            logger.warning(f"Error preparing trophy quiz decks for draft {draft.session_id}: {e}")
+            continue
+
+    logger.warning(
+        f"No eligible draft yielded a valid trophy quiz pair for guild {guild_id} "
+        f"(checked {drafts_checked} drafts)"
+    )
+    return None, None, None
+
+
+class TrophyQuizCommands(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def _create_and_post_trophy_quiz(
+        self,
+        guild_id: str,
+        channel: discord.TextChannel,
+        draft_session: DraftSession,
+        deck_pair: List[dict],
+        posted_by: str,
+        draft_data: dict,
+    ) -> Optional[discord.Message]:
+        """
+        Create the TrophyQuizSession in the database and post the quiz message.
+
+        Resolves each deck's MagicProTools deck-view link first (via
+        Draftmancer id + MPT submission); aborts (no session created, no
+        message posted) if either deck's link fails to build.
+
+        Returns the posted message, or None on failure.
+        """
+        channel_id = str(channel.id)
+        quiz_id = f"{guild_id}-{int(datetime.now().timestamp())}"
+
+        try:
+            display_id = await _generate_next_display_id(guild_id)
+        except Exception as e:
+            logger.error(f"Failed to generate display_id: {e}")
+            return None  # Abort quiz creation
+
+        mapping = map_discord_to_draftmancer(draft_data, draft_session.sign_ups or {})
+        carddata = draft_data.get("carddata", {})
+        splits = {
+            deck["drafter_id"]: split_decklist(draft_data, mapping[deck["drafter_id"]])
+            for deck in deck_pair
+            if mapping.get(deck["drafter_id"])
+        }
+
+        mpt = MagicProtoolsHelper()
+        for deck in deck_pair:
+            dm_id = mapping.get(deck["drafter_id"])
+            split = splits.get(deck["drafter_id"])
+            deck_text = build_mtgo_deck_text(split, carddata) if split else None
+            url = await mpt.submit_deck_view(dm_id, draft_data, deck_text) if deck_text else None
+            if not url:
+                logger.error(
+                    f"[trophy-quiz] MPT deck view failed for draft {draft_session.session_id} "
+                    f"drafter {deck['drafter_id']} (dm {dm_id}); aborting"
+                )
+                return None  # Abort quiz creation - no session, no post
+            deck["mpt_url"] = url
+
+        # Pile images are kept in a list parallel to deck_pair/decks, never
+        # attached to the deck dicts, so the raw bytes can't leak into the
+        # DB row or the TrophyQuizView metadata.
+        pile = PileImageBuilder()
+        pile_images = []
+        for deck in deck_pair:
+            split = splits.get(deck["drafter_id"])
+            image = await pile.build(split["main"], split["side"], carddata) if split else None
+            if not image:
+                logger.error(
+                    f"[trophy-quiz] pile image failed for draft {draft_session.session_id} "
+                    f"drafter {deck['drafter_id']} (dm {mapping.get(deck['drafter_id'])}); aborting"
+                )
+                return None  # abort: no session, no post (triggers try-next-draft)
+            pile_images.append(image.getvalue())
+
+        # Assign slots A/B; keep the pool text (and mpt_url) the view renders from.
+        decks = [{"slot": "A", **deck_pair[0]}, {"slot": "B", **deck_pair[1]}]
+
+        async with db_session() as session:
+            quiz_session = TrophyQuizSession(
+                quiz_id=quiz_id,
+                display_id=display_id,
+                guild_id=str(guild_id),
+                channel_id=channel_id,
+                draft_session_id=draft_session.session_id,
+                decks=decks,
+                posted_by=str(posted_by),
+            )
+            session.add(quiz_session)
+            await session.commit()
+
+        logger.info(f"Created trophy quiz session {quiz_id} with display_id=#{display_id}")
+
+        embed = self.create_trophy_quiz_embed(draft_session, display_id)
+        view = TrophyQuizView(quiz_id, decks)
+
+        image_embeds, files = [], []
+        for deck, image_bytes in zip(decks, pile_images):
+            fname = f"deck_{deck['slot'].lower()}_{quiz_id}.jpg"
+            files.append(discord.File(fp=BytesIO(image_bytes), filename=fname))
+            img_embed = discord.Embed(title=f"Deck {deck['slot']}", color=discord.Color.gold())
+            img_embed.set_image(url=f"attachment://{fname}")
+            image_embeds.append(img_embed)
+
+        try:
+            message = await channel.send(embeds=[embed, *image_embeds], files=files, view=view)
+        except Exception as e:
+            logger.error(f"Failed to post trophy quiz message: {e}", exc_info=True)
+            return None
+
+        try:
+            async with db_session() as session:
+                await session.execute(
+                    update(TrophyQuizSession)
+                    .where(TrophyQuizSession.quiz_id == quiz_id)
+                    .values(message_id=str(message.id))
+                )
+                await session.commit()
+            logger.info(f"Posted trophy quiz message {message.id} in channel {channel_id}")
+        except Exception as e:
+            # The quiz is already live (posted above) — a failure to stamp
+            # message_id must not be reported to the mod as a failed post.
+            # Only the share deep-link degrades (falls back to "Trophy Quiz #N").
+            logger.error(
+                f"[trophy-quiz] failed to record message_id for quiz {quiz_id} "
+                f"(message {message.id} posted successfully): {e}", exc_info=True
+            )
+
+        await safe_pin(message)
+
+        return message
+
+    async def _select_prep_and_post(
+        self, guild_id: str, channel: discord.TextChannel, posted_by: str
+    ) -> Optional[discord.Message]:
+        """Select an eligible draft, prep it (MPT links + pile images), and post.
+        If prep fails, exclude that draft and try the next eligible one, up to
+        MAX_POST_ATTEMPTS."""
+        exclude: set = set()
+        for attempt in range(MAX_POST_ATTEMPTS):
+            draft_session, deck_pair, draft_data = await _select_eligible_draft(
+                guild_id, exclude_draft_ids=exclude
+            )
+            if not draft_session:
+                break
+            message = await self._create_and_post_trophy_quiz(
+                guild_id=guild_id,
+                channel=channel,
+                draft_session=draft_session,
+                deck_pair=deck_pair,
+                posted_by=posted_by,
+                draft_data=draft_data,
+            )
+            if message:
+                return message
+            logger.warning(
+                f"[trophy-quiz] prep failed for draft {draft_session.session_id}; "
+                f"trying next eligible draft (attempt {attempt + 1}/{MAX_POST_ATTEMPTS})"
+            )
+            exclude.add(draft_session.session_id)
+        logger.error(
+            f"[trophy-quiz] no eligible draft could be prepped for guild {guild_id} "
+            f"after {MAX_POST_ATTEMPTS} attempts"
+        )
+        return None
+
+    def create_trophy_quiz_embed(self, draft_session: DraftSession, display_id: Optional[int] = None) -> discord.Embed:
+        """Create the public trophy quiz embed."""
+        title = "🏆 Trophy Record Quiz"
+        if display_id:
+            title = f"🏆 Trophy Record Quiz #{display_id}"
+
+        embed = discord.Embed(
+            title=title,
+            description=(
+                "Two decks from the same pod: **one finished with a winning record "
+                "(2-1 or 3-0), the other with a losing record (1-2 or 0-3)** — but which "
+                "is which?\n\n"
+                "Pick a record for **Deck A** and **Deck B** below, then hit **Submit**!"
+            ),
+            color=discord.Color.gold(),
+        )
+
+        # Deliberately no cube/date on the public embed — those are a lookup key
+        # to the pod (find who trophied without reading the decks). Keep it anonymous.
+
+        footer_text = "Guess both records, submit, and share your score!"
+        if display_id:
+            footer_text = f"Trophy Quiz #{display_id} • {footer_text}"
+        embed.set_footer(text=footer_text)
+
+        return embed
+
+    @discord.slash_command(
+        name='post_trophy_quiz',
+        description='[MOD] Post a trophy record quiz for the channel',
+        guild_ids=None
+    )
+    @commands.has_permissions(manage_roles=True)  # Mod permission check
+    async def post_trophy_quiz(self, ctx):
+        """Post a public trophy record quiz that all users can participate in."""
+        logger.info(f"Post trophy quiz command received from user {ctx.author.id} in guild {ctx.guild.id}")
+        await ctx.response.defer(ephemeral=True)
+
+        try:
+            message = await self._select_prep_and_post(str(ctx.guild.id), ctx.channel, str(ctx.author.id))
+        except Exception as e:
+            # Mirror the scheduler's guard: an unexpected raise must still be
+            # flagged to the mod (the interaction is already deferred), not
+            # propagate and leave a silently-expired command.
+            logger.error(f"Error posting trophy quiz for guild {ctx.guild.id}: {e}", exc_info=True)
+            message = None
+
+        if not message:
+            await ctx.followup.send(
+                "No eligible draft could be turned into a trophy quiz right now "
+                "(couldn't build the deck views/images). Please try again.",
+                ephemeral=True,
+            )
+            return
+        await ctx.followup.send("✅ Trophy quiz posted!", ephemeral=True)
+
+    async def post_scheduled_trophy_quiz(self, channel_id) -> bool:
+        """
+        Post a trophy quiz as part of scheduled task (called by unified scheduler).
+        Returns True if successful, False otherwise.
+        """
+        try:
+            logger.info(f"Scheduled trophy quiz posting to channel {channel_id}")
+
+            channel = self.bot.get_channel(int(channel_id))
+            if not channel:
+                logger.error(f"Channel {channel_id} not found")
+                return False
+
+            guild = channel.guild
+            if not guild:
+                logger.error(f"Guild not found for channel {channel_id}")
+                return False
+
+            message = await self._select_prep_and_post(str(guild.id), channel, "scheduler")
+            return message is not None
+
+        except Exception as e:
+            logger.error(f"Error posting scheduled trophy quiz to channel {channel_id}: {e}", exc_info=True)
+            return False
+
+
+def setup(bot):
+    bot.add_cog(TrophyQuizCommands(bot))

--- a/cogs/unified_scheduler_cog.py
+++ b/cogs/unified_scheduler_cog.py
@@ -1,4 +1,5 @@
 import discord
+import random
 from discord.ext import commands, tasks
 from datetime import datetime
 from loguru import logger
@@ -7,6 +8,13 @@ import pytz
 from database.db_session import db_session
 from models.draft_logs import LogChannel, PostSchedule
 from models.quiz_scheduling import QuizChannel, QuizSchedule
+
+
+def choose_scheduled_quiz_poster(rng, pick_poster, trophy_poster):
+    """Randomized [primary, fallback] poster order for a scheduled quiz slot."""
+    posters = [pick_poster, trophy_poster]
+    rng.shuffle(posters)
+    return posters
 
 
 class UnifiedSchedulerCog(commands.Cog):
@@ -101,11 +109,26 @@ class UnifiedSchedulerCog(commands.Cog):
                         if current_time == schedule.post_time:
                             logger.info(f"Posting quiz in channel {quiz_channel.channel_id} at {current_time} {quiz_channel.time_zone}")
 
-                            # Get the quiz commands cog and call its post method
-                            quiz_commands_cog = self.bot.get_cog("QuizCommands")
-                            if quiz_commands_cog:
-                                success = await quiz_commands_cog.post_scheduled_quiz(quiz_channel.channel_id)
-                                if success:
+                            # Get the quiz commands cogs and build the candidate posters
+                            pick_cog = self.bot.get_cog("QuizCommands")
+                            trophy_cog = self.bot.get_cog("TrophyQuizCommands")
+                            posters = []
+                            if pick_cog:
+                                posters.append(lambda: pick_cog.post_scheduled_quiz(quiz_channel.channel_id))
+                            if trophy_cog:
+                                posters.append(lambda: trophy_cog.post_scheduled_trophy_quiz(quiz_channel.channel_id))
+
+                            if posters:
+                                if len(posters) == 2:
+                                    posters = choose_scheduled_quiz_poster(random.Random(), *posters)
+
+                                posted = False
+                                for poster in posters:
+                                    if await poster():
+                                        posted = True
+                                        break
+
+                                if posted:
                                     # Update last_post timestamp
                                     quiz_channel.last_post = datetime.now()
                                     session.add(quiz_channel)

--- a/quiz_views_module/trophy_quiz_views.py
+++ b/quiz_views_module/trophy_quiz_views.py
@@ -1,0 +1,418 @@
+import asyncio
+
+import discord
+from loguru import logger
+from sqlalchemy import update
+from database.db_session import db_session
+from models import TrophyQuizSession, TrophyQuizSubmission
+from services.trophy_quiz_service import score_submission, record_label, REVEAL_COST, apply_reveal_cost
+from services.trophy_quiz_reveal_store import has_revealed, record_reveal
+from helpers.display_names import get_display_name
+
+# Record dropdown options: (wins, label). Values are the win count as a string
+# ("3".."0"), matched against services.trophy_quiz_service record semantics.
+RECORD_OPTIONS = [(3, "3-0"), (2, "2-1"), (1, "1-2"), (0, "0-3")]
+
+
+def build_reveal_lines(decks, guesses, result, revealed: bool = False) -> list:
+    """Per-deck reveal + a better-deck/points summary line.
+
+    decks: the 2 stored deck dicts (slot/drafter_id/wins).
+    guesses: [winsA, winsB] the player submitted.
+    result: the dict returned by services.trophy_quiz_service.score_submission.
+    revealed: when True, appends a pay-to-reveal-names penalty line and the
+        penalized final score.
+    """
+    lines = []
+    for deck, guess in zip(decks, guesses):
+        trophy = " 🏆" if deck["wins"] == 3 else ""
+        lines.append(
+            f"**Deck {deck['slot']}** — <@{deck['drafter_id']}> went "
+            f"**{record_label(deck['wins'])}**{trophy} "
+            f"(you guessed {record_label(guess)})"
+        )
+    better = max(decks, key=lambda d: d["wins"])
+    lines.append(
+        f"Better deck: **Deck {better['slot']}** — "
+        f"direction {'✅' if result['direction_correct'] else '❌'} "
+        f"(+{result['direction_points']}), exact {sum(result['exact_points'])} → "
+        f"**{result['total']} pts**"
+    )
+    if revealed:
+        final = apply_reveal_cost(result["total"], revealed)
+        lines.append(f"🔎 Revealed player names (−{REVEAL_COST}) → **{final} pts**")
+    return lines
+
+
+def _build_pilots_line(decks: list) -> str:
+    """The "🔎 Piloted by — Deck A: @x, Deck B: @y" line shared by the Play
+    button's re-show-on-revealed path and the reveal button's own reply."""
+    names = ", ".join(f"Deck {d['slot']}: <@{d['drafter_id']}>" for d in decks)
+    return f"🔎 Piloted by — {names}"
+
+
+def _build_emoji_line(result) -> str:
+    """Leak-safe per-deck emoji: 🟩 only when BOTH the overall direction call and
+    that deck's exact record were correct, else ⬛. Never reveals which deck or
+    what the actual records were — just correct/incorrect."""
+    return "".join(
+        "🟩" if result["direction_correct"] and pts > 0 else "⬛"
+        for pts in result["exact_points"]
+    )
+
+
+class TrophyRecordSelect(discord.ui.Select):
+    """Record dropdown for one deck slot ('A' or 'B').
+
+    Lives on the per-user ephemeral TrophyGuessView, so it has no shared
+    state and Discord auto-generates its custom_id (ephemeral views don't
+    persist)."""
+
+    def __init__(self, slot: str, parent_view, row: int = None):
+        self.slot = slot
+        self.parent_view = parent_view
+
+        options = [
+            discord.SelectOption(label=label, value=str(wins))
+            for wins, label in RECORD_OPTIONS
+        ]
+
+        super().__init__(
+            placeholder=f"Deck {slot}: pick a record",
+            options=options,
+            row=row,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        """Store the selection (keyed by slot; the view is private to one user)
+        and acknowledge the interaction."""
+        if self.values:
+            self.parent_view.selections[self.slot] = int(self.values[0])
+            logger.debug(
+                f"User {interaction.user.id} selected {self.values[0]} for Deck {self.slot} "
+                f"(trophy quiz {self.parent_view.quiz_id})"
+            )
+        await interaction.response.defer()
+
+
+class TrophyShareView(discord.ui.View):
+    """View with a button to share trophy quiz results publicly.
+
+    Leak-safe: the public share posts ONLY the player's total + a 🟩/⬛ per-deck
+    emoji line and the quiz link — never drafter names or actual records. Since
+    the max score is a constant 10 regardless of the actual records, the total
+    itself reveals nothing either.
+    """
+
+    def __init__(self, user: discord.User, emoji_line: str, total_points: int, quiz_id: str = None, display_id: int = None):
+        super().__init__(timeout=300)  # 5 minute timeout
+        self.user = user
+        self.emoji_line = emoji_line
+        self.total_points = total_points
+        self.quiz_id = quiz_id
+        self.display_id = display_id
+
+    async def _format_quiz_reference(self) -> str:
+        if not self.display_id:
+            return "the Trophy Quiz"
+        if not self.quiz_id:
+            return f"Trophy Quiz #{self.display_id}"
+        async with db_session() as session:
+            quiz_session = await session.get(TrophyQuizSession, self.quiz_id)
+        if quiz_session and quiz_session.message_id:
+            message_link = (
+                f"https://discord.com/channels/{quiz_session.guild_id}/"
+                f"{quiz_session.channel_id}/{quiz_session.message_id}"
+            )
+            return f"[Trophy Quiz #{self.display_id}]({message_link})"
+        return f"Trophy Quiz #{self.display_id}"
+
+    @discord.ui.button(
+        label="📤 Share Results Publicly",
+        style=discord.ButtonStyle.primary,
+        custom_id="share_trophy_quiz_results",
+    )
+    async def share_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Post results publicly to the channel — score + emoji line only."""
+        if interaction.user.id != self.user.id:
+            await interaction.response.send_message(
+                "You can only share your own results!",
+                ephemeral=True,
+            )
+            return
+
+        quiz_ref = await self._format_quiz_reference()
+        quiz_num = f" #{self.display_id}" if self.display_id else ""
+        share_text = f"🏆 Trophy Quiz{quiz_num}\n{self.emoji_line} {self.total_points} pts"
+        display_name = get_display_name(self.user)
+
+        message = (
+            f"**{display_name}** scored **{self.total_points} points** on {quiz_ref}!\n"
+            f"\n```\n{share_text}\n```"
+        )
+
+        button.disabled = True
+        button.label = "✓ Shared!"
+
+        await interaction.response.edit_message(view=self)
+        # Post as a standalone channel message, NOT interaction.followup.send:
+        # a followup on a component interaction is delivered as a reply to the
+        # button's message (the ephemeral reveal), and Discord surfaces that
+        # reveal's drafter names / actual records in the reply preview to
+        # everyone. channel.send carries no reference, so nothing leaks.
+        await interaction.channel.send(message)
+
+        logger.info(
+            f"User {self.user.id} ({get_display_name(self.user)}) shared trophy quiz "
+            f"results publicly: {self.total_points} points"
+        )
+
+
+async def _load_display_id(quiz_id: str):
+    async with db_session() as session:
+        quiz_session = await session.get(TrophyQuizSession, quiz_id)
+    return quiz_session.display_id if quiz_session else None
+
+
+async def _send_trophy_reveal(interaction, quiz_id: str, decks: list, guesses: list, result: dict, revealed: bool = False, prefix: str = ""):
+    """Send the ephemeral reveal + share-button reply for a scored submission.
+    Shared by the Play button's already-submitted path and the guess view's
+    Submit — both need to show a per-user private reveal."""
+    lines = build_reveal_lines(decks, guesses, result, revealed=revealed)
+    emoji_line = _build_emoji_line(result)
+    display_id = await _load_display_id(quiz_id)
+    total = apply_reveal_cost(result["total"], revealed)
+
+    await interaction.response.send_message(
+        prefix + "\n".join(lines),
+        ephemeral=True,
+        view=TrophyShareView(
+            user=interaction.user,
+            emoji_line=emoji_line,
+            total_points=total,
+            quiz_id=quiz_id,
+            display_id=display_id,
+        ),
+    )
+
+
+async def _show_existing_trophy_result(interaction, quiz_id: str, decks: list, submission: TrophyQuizSubmission):
+    """Show a player's prior submission result (one-submission-per-player guard).
+
+    Recompute the full result dict (incl. direction_points) via score_submission
+    from the stored guesses/actual wins rather than storing it redundantly — it's
+    deterministic and matches submission.points_earned.
+    """
+    result = score_submission(submission.guesses, [deck["wins"] for deck in decks])
+    revealed = await has_revealed(quiz_id, submission.player_id)
+    await _send_trophy_reveal(
+        interaction, quiz_id, decks, submission.guesses, result,
+        revealed=revealed,
+        prefix="*(You already submitted this quiz)*\n",
+    )
+
+
+async def _handle_if_already_submitted(interaction, quiz_id: str, decks: list, user_id: str) -> bool:
+    """One-submission-per-player guard shared by the Play button and the guess
+    view's Submit: look up a prior submission and, if found, show its result.
+    Returns True when the caller should stop (a result was already shown)."""
+    async with db_session() as session:
+        existing = await session.get(TrophyQuizSubmission, (quiz_id, user_id))
+    if not existing:
+        return False
+    await _show_existing_trophy_result(interaction, quiz_id, decks, existing)
+    return True
+
+
+class TrophyQuizView(discord.ui.View):
+    """
+    Persistent public view on the trophy quiz message: a "Play" button that opens
+    each player's own private ephemeral guess view, a "View Decklists" button, and
+    the two MPT deck link buttons. Holds NO shared record dropdowns — shared
+    selects on one public message collide across concurrent users; each player
+    instead gets an isolated TrophyGuessView. Survives restarts (timeout=None).
+    """
+
+    def __init__(self, quiz_id: str, decks: list):
+        super().__init__(timeout=None)  # Persistent across restarts
+        self.quiz_id = quiz_id
+        self.decks = decks
+
+        for deck in decks:
+            url = deck.get("mpt_url")
+            if url:
+                self.add_item(discord.ui.Button(
+                    label=f"🔗 View Deck {deck['slot']}",
+                    style=discord.ButtonStyle.link,
+                    url=url,
+                ))
+
+    def to_metadata(self) -> dict:
+        """Convert view properties to a dictionary for JSON storage (sticky message system)."""
+        return {
+            "quiz_id": self.quiz_id,
+            "decks": self.decks,
+            "view_type": "trophy_quiz",
+        }
+
+    @classmethod
+    async def from_metadata(cls, bot, metadata: dict):
+        """Recreate TrophyQuizView from stored metadata (sticky message system)."""
+        quiz_id = metadata.get("quiz_id")
+        decks = metadata.get("decks")
+        if decks is None:
+            async with db_session() as session:
+                quiz_session = await session.get(TrophyQuizSession, quiz_id)
+            decks = quiz_session.decks if quiz_session else []
+        return cls(quiz_id=quiz_id, decks=decks)
+
+    @discord.ui.button(
+        label="🎯 Play",
+        style=discord.ButtonStyle.success,
+        custom_id="trophy_quiz_play",
+    )
+    async def play_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Open this player's private ephemeral guess view (or their prior result
+        if they already submitted). Per-user ephemeral components never collide."""
+        user_id = str(interaction.user.id)
+
+        if await _handle_if_already_submitted(interaction, self.quiz_id, self.decks, user_id):
+            return
+
+        revealed = await has_revealed(self.quiz_id, user_id)
+        content = "Guess each deck's record, then hit **Submit**:"
+        if revealed:
+            content = f"{_build_pilots_line(self.decks)}\n{content}"
+        await interaction.response.send_message(
+            content,
+            view=TrophyGuessView(self.quiz_id, self.decks, interaction.user, revealed=revealed),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="View Decklists",
+        style=discord.ButtonStyle.secondary,
+        custom_id="trophy_quiz_view_decklists",
+    )
+    async def view_decklists_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Show both decks' full pools, ephemerally. Reads the STORED pool text
+        (never re-renders via render_pool at view time)."""
+        embed = discord.Embed(title="🃏 Decklists", color=discord.Color.blurple())
+        for deck in self.decks:
+            pool_text = deck.get("pool") or "*No pool available.*"
+            embed.add_field(name=f"Deck {deck['slot']}", value=pool_text[:1024], inline=False)
+
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class TrophyGuessView(discord.ui.View):
+    """Per-user ephemeral view: the two record dropdowns + Submit. Minted fresh
+    per Play click, so each player has isolated selects and state — concurrent
+    users never collide. Not persistent (5-minute timeout)."""
+
+    def __init__(self, quiz_id: str, decks: list, user, revealed: bool = False):
+        super().__init__(timeout=300)
+        self.quiz_id = quiz_id
+        self.decks = decks
+        self.user = user
+        self.revealed = revealed
+        self.submitted = False  # set once this view's Submit succeeds (guards post-submit reveal)
+        self.selections = {}  # {slot: guessed_wins} — one user, so keyed by slot
+        # Serializes Reveal/Submit on this view instance so the two handlers never
+        # interleave: a concurrent Reveal-then-Submit (or double-click Submit) can
+        # otherwise dodge the reveal penalty or hit a composite-PK IntegrityError.
+        self._lock = asyncio.Lock()
+
+        for i, deck in enumerate(decks):
+            self.add_item(TrophyRecordSelect(slot=deck["slot"], parent_view=self, row=i))
+
+        if revealed:
+            for child in self.children:
+                if getattr(child, "custom_id", None) == "trophy_quiz_reveal_names":
+                    child.disabled = True
+
+    @discord.ui.button(
+        label=f"🔎 Reveal names (−{REVEAL_COST} pts)",
+        style=discord.ButtonStyle.secondary,
+        custom_id="trophy_quiz_reveal_names",
+        row=2,
+    )
+    async def reveal_names_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Pay REVEAL_COST (applied on submit): persist the reveal (so re-opening
+        remembers it), then show both decks' pilots privately."""
+        # Locked against submit_button on this same view instance: without this,
+        # a concurrent Reveal + Submit (or double-click) could interleave —
+        # Submit reading has_revealed()/self.submitted before this handler's
+        # commit lands, dodging the penalty or desyncing the displayed score.
+        async with self._lock:
+            # Post-submit, revealing is moot (the result already shows the pilots) and
+            # must not record a reveal — that would desync the displayed total from the
+            # already-stored, unpenalized points_earned. A submitted player can only reach
+            # this button on the same view they submitted from (Play blocks a new one), so
+            # an in-memory flag suffices. Show names, no charge.
+            note = "" if self.submitted else f"\n*(−{REVEAL_COST} points will apply when you submit.)*"
+            if not self.submitted:
+                await record_reveal(self.quiz_id, str(interaction.user.id))
+                self.revealed = True
+            button.disabled = True
+            await interaction.response.edit_message(view=self)
+            await interaction.followup.send(
+                f"{_build_pilots_line(self.decks)}{note}",
+                ephemeral=True,
+            )
+
+    @discord.ui.button(
+        label="Submit",
+        style=discord.ButtonStyle.success,
+        custom_id="trophy_quiz_guess_submit",
+        row=2,
+    )
+    async def submit_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Validate both records chosen, score, persist (once per player), and
+        reply ephemerally with the reveal + a share button."""
+        # Locked against reveal_names_button on this same view instance — see
+        # that handler's comment for the interleaving this prevents.
+        async with self._lock:
+            user_id = str(interaction.user.id)
+
+            # One submission per player: short-circuit if one already exists.
+            if await _handle_if_already_submitted(interaction, self.quiz_id, self.decks, user_id):
+                return
+
+            slots = [deck["slot"] for deck in self.decks]
+            if any(slot not in self.selections for slot in slots):
+                await interaction.response.send_message(
+                    "Please select a record for both decks before submitting!",
+                    ephemeral=True,
+                )
+                return
+
+            guesses = [self.selections[slot] for slot in slots]
+            result = score_submission(guesses, [deck["wins"] for deck in self.decks])
+            revealed = await has_revealed(self.quiz_id, user_id)
+            final_points = apply_reveal_cost(result["total"], revealed)
+
+            async with db_session() as session:
+                submission = TrophyQuizSubmission(
+                    quiz_id=self.quiz_id,
+                    player_id=user_id,
+                    display_name=get_display_name(interaction.user),
+                    guesses=guesses,
+                    direction_correct=result["direction_correct"],
+                    exact_points=result["exact_points"],
+                    points_earned=final_points,
+                )
+                session.add(submission)
+
+                await session.execute(
+                    update(TrophyQuizSession)
+                    .where(TrophyQuizSession.quiz_id == self.quiz_id)
+                    .values(total_participants=TrophyQuizSession.total_participants + 1)
+                )
+
+                await session.commit()
+
+            logger.info(f"User {user_id} submitted trophy quiz {self.quiz_id}: {final_points} points (revealed={revealed})")
+
+            self.submitted = True  # guard: a post-submit reveal click on this view must not record/charge
+            await _send_trophy_reveal(interaction, self.quiz_id, self.decks, guesses, result, revealed=revealed)

--- a/tests/test_scheduler_quiz_choice.py
+++ b/tests/test_scheduler_quiz_choice.py
@@ -1,0 +1,8 @@
+import random
+from cogs.unified_scheduler_cog import choose_scheduled_quiz_poster
+
+
+def test_returns_both_in_some_order():
+    a, b = object(), object()
+    order = choose_scheduled_quiz_poster(random.Random(0), a, b)
+    assert set(order) == {a, b} and len(order) == 2

--- a/tests/test_trophy_quiz_command.py
+++ b/tests/test_trophy_quiz_command.py
@@ -1,0 +1,441 @@
+import os
+import random
+import tempfile
+from datetime import datetime
+from io import BytesIO
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import cogs.trophy_quiz_commands as trophy_quiz_commands
+from database.db_session import AsyncSessionLocal
+from database.models_base import Base
+from models import DraftSession, MatchResult, TrophyQuizSession
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db'); tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose(); os.unlink(tmp.name)
+
+
+def _draft_data(dm_ids):
+    """Mirrors tests/test_trophy_quiz_selection.py's fixture builder."""
+    users, carddata = {}, {}
+    for i, dm in enumerate(dm_ids):
+        cid = f"c{i}"
+        users[dm] = {"seatNum": i, "cards": [cid], "isBot": False}
+        carddata[cid] = {"name": f"Card{i}"}
+    return {"users": users, "carddata": carddata}
+
+
+def _fake_jpeg():
+    """A minimal in-memory JPEG-like BytesIO for stubbing PileImageBuilder.build."""
+    buf = BytesIO()
+    buf.write(b"\xff\xd8fakejpeg")
+    buf.seek(0)
+    return buf
+
+
+def test_embed_states_one_winning_one_losing_record():
+    """The public embed must make clear one deck has a winning record and the
+    other a losing record (without revealing which is which)."""
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    embed = cog.create_trophy_quiz_embed(DraftSession(session_id="d", guild_id="g"), display_id=1)
+    text = embed.description.lower()
+    assert "winning record" in text and "losing record" in text
+    assert "2-1 or 3-0" in text and "1-2 or 0-3" in text
+
+
+# 6 drafters, 3 rounds; d0 goes 3-0 (extreme), d5 goes 0-3 (extreme), rest middle.
+# select_two_decks succeeds for this pod (has an extreme, has a better + worse bucket).
+_WITH_EXTREME = [
+    ("d0", "d1", "d0"), ("d2", "d3", "d2"), ("d4", "d5", "d4"),
+    ("d0", "d2", "d0"), ("d1", "d4", "d1"), ("d3", "d5", "d3"),
+    ("d0", "d3", "d0"), ("d1", "d5", "d1"), ("d2", "d4", "d2"),
+]
+# 4 drafters, 3 rounds, all middle records -> no extreme -> select_two_decks returns None.
+_NO_EXTREME = [
+    ("d0", "d2", "d0"), ("d0", "d3", "d0"), ("d1", "d0", "d1"),
+    ("d1", "d3", "d1"), ("d2", "d1", "d2"), ("d3", "d2", "d3"),
+]
+
+
+async def _seed_draft(session_id, guild_id, n, rounds, **overrides):
+    sign_ups = {f"d{i}": f"n{i}" for i in range(n)}
+    draft_data = _draft_data([f"dm{i}" for i in range(n)])
+    kwargs = dict(
+        session_id=session_id,
+        guild_id=guild_id,
+        spaces_object_key=f"key-{session_id}",
+        session_type="random",
+        draft_start_time=datetime.now(),
+        sign_ups=sign_ups,
+        cube="TestCube",
+    )
+    kwargs.update(overrides)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            s.add(DraftSession(**kwargs))
+            for i, (a, b, w) in enumerate(rounds):
+                s.add(MatchResult(session_id=session_id, match_number=i, player1_id=a, player2_id=b, winner_id=w))
+    return draft_data
+
+
+@pytest.mark.asyncio
+async def test_select_eligible_draft_skips_ineligible_draft(test_db):
+    guild_id = "g1"
+    ineligible_data = await _seed_draft("d-ineligible", guild_id, 4, _NO_EXTREME)
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+
+    data_by_key = {
+        "key-d-ineligible": ineligible_data,
+        "key-d-eligible": eligible_data,
+    }
+
+    async def fake_load(object_key):
+        return data_by_key[object_key]
+
+    with patch("cogs.trophy_quiz_commands.load_from_spaces", AsyncMock(side_effect=fake_load)):
+        draft, decks, draft_data = await trophy_quiz_commands._select_eligible_draft(guild_id, rng=random.Random(0))
+
+    assert draft is not None
+    assert draft.session_id == "d-eligible"
+    assert decks is not None and len(decks) == 2
+    assert all(deck.get("pool") for deck in decks)
+    assert draft_data == eligible_data
+
+
+@pytest.mark.asyncio
+async def test_select_eligible_draft_none_when_already_recorded(test_db):
+    guild_id = "g1"
+    await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            s.add(TrophyQuizSession(
+                quiz_id="g1-1",
+                display_id=1,
+                guild_id=guild_id,
+                channel_id="c",
+                draft_session_id="d-eligible",
+                decks=[
+                    {"slot": "A", "drafter_id": "d0", "wins": 3, "pool": "x"},
+                    {"slot": "B", "drafter_id": "d5", "wins": 0, "pool": "y"},
+                ],
+                posted_by="mod",
+            ))
+
+    with patch("cogs.trophy_quiz_commands.load_from_spaces", AsyncMock()) as mock_load:
+        draft, decks, draft_data = await trophy_quiz_commands._select_eligible_draft(guild_id, rng=random.Random(0))
+
+    assert draft is None
+    assert decks is None
+    assert draft_data is None
+    mock_load.assert_not_called()
+
+
+class _FakeChannel:
+    """Minimal stand-in for a discord.TextChannel: records sent payloads and
+    returns a message whose .pin() is a no-op AsyncMock."""
+
+    def __init__(self, channel_id=999):
+        self.id = channel_id
+        self.sent = []
+
+    async def send(self, **kwargs):
+        self.sent.append(kwargs)
+        message = AsyncMock()
+        message.id = 555
+        message.pin = AsyncMock()
+        return message
+
+
+async def _select_eligible_with_data(guild_id, draft_data, rng_seed=0):
+    """Seed-and-select helper: patches load_from_spaces to return draft_data
+    for any key, then runs the real _select_eligible_draft selection."""
+    with patch("cogs.trophy_quiz_commands.load_from_spaces", AsyncMock(return_value=draft_data)):
+        return await trophy_quiz_commands._select_eligible_draft(guild_id, rng=random.Random(rng_seed))
+
+
+@pytest.mark.asyncio
+async def test_create_and_post_trophy_quiz_aborts_when_mpt_submission_fails(test_db):
+    guild_id = "g1"
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+
+    draft, deck_pair, draft_data = await _select_eligible_with_data(guild_id, eligible_data)
+    assert draft is not None  # sanity: selection itself succeeded
+
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    with patch(
+        "helpers.magicprotools_helper.MagicProtoolsHelper.submit_deck_view",
+        AsyncMock(return_value=None),
+    ):
+        message = await cog._create_and_post_trophy_quiz(
+            guild_id=guild_id,
+            channel=channel,
+            draft_session=draft,
+            deck_pair=deck_pair,
+            posted_by="mod",
+            draft_data=draft_data,
+        )
+
+    assert message is None
+    assert channel.sent == []  # never posted
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(select(TrophyQuizSession))
+        assert result.scalars().all() == []  # never persisted
+
+
+@pytest.mark.asyncio
+async def test_create_and_post_trophy_quiz_sets_mpt_url_on_success(test_db):
+    guild_id = "g1"
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+
+    draft, deck_pair, draft_data = await _select_eligible_with_data(guild_id, eligible_data)
+    assert draft is not None  # sanity: selection itself succeeded
+
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    mpt_url = "https://magicprotools.com/deck/show?id=T"
+    with patch(
+        "helpers.magicprotools_helper.MagicProtoolsHelper.submit_deck_view",
+        AsyncMock(return_value=mpt_url),
+    ), patch(
+        "cogs.trophy_quiz_commands.PileImageBuilder.build",
+        AsyncMock(side_effect=lambda *a, **k: _fake_jpeg()),
+    ):
+        message = await cog._create_and_post_trophy_quiz(
+            guild_id=guild_id,
+            channel=channel,
+            draft_session=draft,
+            deck_pair=deck_pair,
+            posted_by="mod",
+            draft_data=draft_data,
+        )
+
+    assert message is not None
+    assert len(channel.sent) == 1
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(select(TrophyQuizSession))
+        quiz = result.scalar_one()
+        assert len(quiz.decks) == 2
+        assert all(d["mpt_url"] == mpt_url for d in quiz.decks)
+        assert all("image" not in d for d in quiz.decks)
+
+
+@pytest.mark.asyncio
+async def test_create_and_post_aborts_when_pile_image_fails(test_db):
+    guild_id = "g1"
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+    draft, deck_pair, draft_data = await _select_eligible_with_data(guild_id, eligible_data)
+    assert draft is not None
+
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    with patch("helpers.magicprotools_helper.MagicProtoolsHelper.submit_deck_view",
+               AsyncMock(return_value="https://magicprotools.com/deck/show?id=T")), \
+         patch("cogs.trophy_quiz_commands.PileImageBuilder.build",
+               AsyncMock(return_value=None)):
+        message = await cog._create_and_post_trophy_quiz(
+            guild_id=guild_id, channel=channel, draft_session=draft,
+            deck_pair=deck_pair, posted_by="mod", draft_data=draft_data,
+        )
+
+    assert message is None
+    assert channel.sent == []
+    async with AsyncSessionLocal() as s:
+        assert (await s.execute(select(TrophyQuizSession))).scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_create_and_post_attaches_two_images_on_success(test_db):
+    guild_id = "g1"
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+    draft, deck_pair, draft_data = await _select_eligible_with_data(guild_id, eligible_data)
+
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    with patch("helpers.magicprotools_helper.MagicProtoolsHelper.submit_deck_view",
+               AsyncMock(return_value="https://magicprotools.com/deck/show?id=T")), \
+         patch("cogs.trophy_quiz_commands.PileImageBuilder.build",
+               AsyncMock(side_effect=lambda *a, **k: _fake_jpeg())):
+        message = await cog._create_and_post_trophy_quiz(
+            guild_id=guild_id, channel=channel, draft_session=draft,
+            deck_pair=deck_pair, posted_by="mod", draft_data=draft_data,
+        )
+
+    assert message is not None
+    assert len(channel.sent) == 1
+    sent = channel.sent[0]
+    assert len(sent["files"]) == 2                      # two image attachments
+    assert len(sent["embeds"]) == 3                     # prompt + Deck A + Deck B
+
+
+@pytest.mark.asyncio
+async def test_mpt_and_image_receive_split_deck(test_db):
+    guild_id = "g1"
+    eligible_data = await _seed_draft("d-eligible", guild_id, 6, _WITH_EXTREME)
+    # Built decklist with a DISTINCT sideboard card + basics, so the MTGO text is
+    # provably the built deck (main + basics // sideboard), not the raw pool.
+    eligible_data["carddata"]["sb"] = {"name": "Negate"}
+    for uid, u in eligible_data["users"].items():
+        pooled = list(u["cards"])                       # each user's single drafted card
+        u["cards"] = pooled + ["sb"]
+        u["decklist"] = {"main": pooled, "side": ["sb"], "lands": {"U": 3}}
+
+    draft, deck_pair, draft_data = await _select_eligible_with_data(guild_id, eligible_data)
+
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    seen_deck_texts = []
+
+    async def fake_submit(self, dm_id, dd, deck_text):
+        seen_deck_texts.append(deck_text)
+        return "https://magicprotools.com/deck/show?id=T"
+
+    build_calls = []
+
+    async def fake_build(self, main_ids, side_ids, carddata):
+        build_calls.append((main_ids, side_ids))
+        return _fake_jpeg()
+
+    with patch("helpers.magicprotools_helper.MagicProtoolsHelper.submit_deck_view", fake_submit), \
+         patch("cogs.trophy_quiz_commands.PileImageBuilder.build", fake_build):
+        message = await cog._create_and_post_trophy_quiz(
+            guild_id=guild_id, channel=channel, draft_session=draft,
+            deck_pair=deck_pair, posted_by="mod", draft_data=draft_data,
+        )
+
+    assert message is not None
+    assert len(seen_deck_texts) == 2
+    for text in seen_deck_texts:
+        assert "\n\n" in text                       # MTGO sideboard separated by a blank line
+        main_part, side_part = text.split("\n\n", 1)
+        assert "Negate" in side_part                # sideboard card lands in the sideboard section
+        assert "Negate" not in main_part            # ...and not in the main deck
+        assert "3 Island" in main_part              # basics (U:3) rendered into the main deck
+    # image built from the split's main/side lists (side = the "sb" card)
+    assert len(build_calls) == 2
+    assert all(isinstance(m, list) and s == ["sb"] for m, s in build_calls)
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.deferred = False
+
+    async def defer(self, **kwargs):
+        self.deferred = True
+
+
+class _FakeFollowup:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, content=None, **kwargs):
+        self.sent.append(content)
+
+
+class _FakeCtx:
+    """Minimal stand-in for an ApplicationContext used by post_trophy_quiz."""
+
+    def __init__(self, guild_id="g1", author_id=1):
+        self.guild = AsyncMock(); self.guild.id = guild_id
+        self.author = AsyncMock(); self.author.id = author_id
+        self.channel = _FakeChannel()
+        self.response = _FakeResponse()
+        self.followup = _FakeFollowup()
+
+
+@pytest.mark.asyncio
+async def test_post_trophy_quiz_surfaces_error_when_create_raises(test_db):
+    """An unexpected raise inside the build path must be flagged to the mod as an
+    ephemeral error, not propagate past the deferred interaction."""
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    ctx = _FakeCtx()
+
+    with patch.object(
+        trophy_quiz_commands,
+        "_select_eligible_draft",
+        AsyncMock(return_value=(AsyncMock(), [{"drafter_id": "u1"}], {})),
+    ), patch.object(
+        cog, "_create_and_post_trophy_quiz",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        # Must not raise out of the command.
+        await trophy_quiz_commands.TrophyQuizCommands.post_trophy_quiz.callback(cog, ctx)
+
+    assert any(
+        "No eligible draft could be turned into a trophy quiz right now" in (c or "")
+        for c in ctx.followup.sent
+    )
+
+
+@pytest.mark.asyncio
+async def test_try_next_draft_skips_failed_prep(test_db, monkeypatch):
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+
+    # Two candidate drafts; first prep returns None (fail), second returns a message.
+    d1 = trophy_quiz_commands.DraftSession(session_id="d1", guild_id="g1")
+    d2 = trophy_quiz_commands.DraftSession(session_id="d2", guild_id="g1")
+    selections = [ (d1, [{"drafter_id": "u"}], {}), (d2, [{"drafter_id": "u"}], {}) ]
+
+    async def fake_select(guild_id, rng=random, exclude_draft_ids=None):
+        exclude_draft_ids = exclude_draft_ids or set()
+        for draft, dp, dd in selections:
+            if draft.session_id not in exclude_draft_ids:
+                return draft, dp, dd
+        return None, None, None
+
+    posted = {}
+    async def fake_create(self, guild_id, channel, draft_session, deck_pair, posted_by, draft_data):
+        if draft_session.session_id == "d1":
+            return None                      # prep failed
+        posted["id"] = draft_session.session_id
+        return AsyncMock()
+
+    monkeypatch.setattr(trophy_quiz_commands, "_select_eligible_draft", fake_select)
+    monkeypatch.setattr(trophy_quiz_commands.TrophyQuizCommands,
+                        "_create_and_post_trophy_quiz", fake_create)
+
+    msg = await cog._select_prep_and_post("g1", channel, "mod")
+    assert msg is not None
+    assert posted["id"] == "d2"              # skipped d1, posted d2
+
+
+@pytest.mark.asyncio
+async def test_try_next_draft_bounded_then_gives_up(test_db, monkeypatch):
+    cog = trophy_quiz_commands.TrophyQuizCommands(bot=None)
+    channel = _FakeChannel()
+    calls = {"n": 0}
+
+    async def fake_select(guild_id, rng=random, exclude_draft_ids=None):
+        calls["n"] += 1
+        d = trophy_quiz_commands.DraftSession(session_id=f"d{calls['n']}", guild_id="g1")
+        return d, [{"drafter_id": "u"}], {}
+
+    async def fake_create(self, *a, **k):
+        return None                          # every prep fails
+
+    monkeypatch.setattr(trophy_quiz_commands, "_select_eligible_draft", fake_select)
+    monkeypatch.setattr(trophy_quiz_commands.TrophyQuizCommands,
+                        "_create_and_post_trophy_quiz", fake_create)
+
+    msg = await cog._select_prep_and_post("g1", channel, "mod")
+    assert msg is None
+    assert calls["n"] == trophy_quiz_commands.MAX_POST_ATTEMPTS   # bounded

--- a/tests/test_trophy_quiz_reveal.py
+++ b/tests/test_trophy_quiz_reveal.py
@@ -1,0 +1,33 @@
+from services.trophy_quiz_service import apply_reveal_cost, REVEAL_COST, score_submission
+from quiz_views_module.trophy_quiz_views import build_reveal_lines
+
+
+def test_reveal_cost_constant():
+    assert REVEAL_COST == 2
+
+
+def test_apply_reveal_cost_floors_at_zero():
+    assert apply_reveal_cost(10, False) == 10
+    assert apply_reveal_cost(10, True) == 8
+    assert apply_reveal_cost(4, True) == 2
+    assert apply_reveal_cost(1, True) == 0
+    assert apply_reveal_cost(0, True) == 0
+
+
+def test_reveal_lines_unchanged_when_not_revealed():
+    decks = [{"slot": "A", "drafter_id": "u1", "wins": 3},
+             {"slot": "B", "drafter_id": "u2", "wins": 0}]
+    result = score_submission([3, 0], [3, 0])
+    assert build_reveal_lines(decks, [3, 0], result) == build_reveal_lines(decks, [3, 0], result, revealed=False)
+    text = "\n".join(build_reveal_lines(decks, [3, 0], result, revealed=False))
+    assert "Revealed" not in text
+
+
+def test_reveal_lines_show_penalty_and_final_when_revealed():
+    decks = [{"slot": "A", "drafter_id": "u1", "wins": 3},
+             {"slot": "B", "drafter_id": "u2", "wins": 0}]
+    result = score_submission([3, 0], [3, 0])   # base total 10
+    lines = build_reveal_lines(decks, [3, 0], result, revealed=True)
+    text = "\n".join(lines)
+    assert "Revealed" in text and "-2" in text.replace("−", "-")
+    assert "8" in text                            # penalized final

--- a/tests/test_trophy_quiz_views.py
+++ b/tests/test_trophy_quiz_views.py
@@ -1,0 +1,177 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+from quiz_views_module.trophy_quiz_views import (
+    build_reveal_lines,
+    TrophyQuizView,
+    TrophyGuessView,
+    TrophyShareView,
+)
+from services.trophy_quiz_service import score_submission
+
+
+_DECKS = [
+    {"slot": "A", "drafter_id": "u1", "wins": 3, "pool": "1 Bolt", "mpt_url": "https://magicprotools.com/deck/show?id=A"},
+    {"slot": "B", "drafter_id": "u2", "wins": 0, "pool": "1 Elf", "mpt_url": "https://magicprotools.com/deck/show?id=B"},
+]
+
+
+@pytest.mark.asyncio
+async def test_public_view_has_no_selects_only_a_play_button():
+    """The public message must NOT carry record dropdowns — shared selects on one
+    message collide across concurrent users. Only a Play button (+ View Decklists
+    + link buttons) belongs on the public view."""
+    view = TrophyQuizView("q1", _DECKS)
+    assert not any(isinstance(c, discord.ui.Select) for c in view.children)
+    play = [c for c in view.children if getattr(c, "custom_id", None) == "trophy_quiz_play"]
+    assert len(play) == 1
+
+
+@pytest.mark.asyncio
+async def test_guess_view_has_two_record_selects_and_submit():
+    """Each player gets their OWN ephemeral guess view with the two record
+    dropdowns + Submit (isolated per user)."""
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    selects = [c for c in gv.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 2
+    labels = [getattr(c, "label", None) for c in gv.children]
+    assert "Submit" in labels
+    # ephemeral, non-persistent view
+    assert gv.timeout is not None
+
+
+@pytest.mark.asyncio
+async def test_guess_view_has_reveal_submit_lock():
+    """Reveal and Submit must be serialized on a given view instance: a
+    concurrent Reveal-then-Submit (or double-click Submit) can otherwise
+    interleave and dodge the reveal penalty or hit a composite-PK
+    IntegrityError. The race itself isn't deterministically unit-testable;
+    this guards the lock's presence alongside the existing reveal/submit
+    tests."""
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    assert isinstance(gv._lock, asyncio.Lock)
+
+
+def test_reveal_marks_trophy_direction_and_points():
+    decks = [{"slot": "A", "drafter_id": "u1", "wins": 3},
+             {"slot": "B", "drafter_id": "u2", "wins": 0}]
+    guesses = [3, 0]
+    # direction ok (+4), both exact (+3 each, flat) -> total 10 (constant max, see
+    # services/trophy_quiz_service.py DIRECTION_POINTS/EXACT_POINTS).
+    result = score_submission(guesses, [3, 0])
+    lines = build_reveal_lines(decks, guesses, result)
+    text = "\n".join(lines)
+    assert "Deck A" in text and "3-0" in text and "🏆" in text and "<@u1>" in text
+    assert "Deck B" in text and "0-3" in text
+    assert "Deck A" in lines[-1]        # better-deck summary names Deck A
+    assert "10" in text                 # total shown
+
+
+@pytest.mark.asyncio
+async def test_view_has_two_deck_link_buttons():
+    decks = [
+        {"slot": "A", "drafter_id": "u1", "wins": 3, "pool": "1 Bolt", "mpt_url": "https://magicprotools.com/deck/show?id=A"},
+        {"slot": "B", "drafter_id": "u2", "wins": 0, "pool": "1 Elf", "mpt_url": "https://magicprotools.com/deck/show?id=B"},
+    ]
+    view = TrophyQuizView("q1", decks)
+    link_urls = [c.url for c in view.children if getattr(c, "url", None)]
+    assert "https://magicprotools.com/deck/show?id=A" in link_urls
+    assert "https://magicprotools.com/deck/show?id=B" in link_urls
+
+
+@pytest.mark.asyncio
+async def test_share_posts_standalone_not_as_reply_to_reveal():
+    """The public share must be a standalone channel message, NOT an interaction
+    followup — a followup on a component interaction is posted as a reply to the
+    button's message (the ephemeral reveal), whose preview leaks the drafter
+    names / actual records to everyone. Regression guard for that leak."""
+    user = SimpleNamespace(id=42, display_name="Alice", name="alice")
+    view = TrophyShareView(user=user, emoji_line="🟩⬛", total_points=7)
+
+    channel = SimpleNamespace(send=AsyncMock())
+    interaction = SimpleNamespace(
+        user=user,
+        channel=channel,
+        response=SimpleNamespace(edit_message=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    await view.share_button.callback(interaction)
+
+    # Public post goes to the channel directly (no reply reference to the reveal).
+    channel.send.assert_awaited_once()
+    interaction.followup.send.assert_not_called()
+    posted = channel.send.await_args.args[0] if channel.send.await_args.args else channel.send.await_args.kwargs.get("content")
+    # Leak-safe: score + emoji only, never drafter names or records.
+    assert "7" in posted and "🟩⬛" in posted
+
+
+@pytest.mark.asyncio
+async def test_guess_view_has_reveal_button_enabled_by_default():
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    assert gv.revealed is False
+    reveal = next(c for c in gv.children if getattr(c, "custom_id", None) == "trophy_quiz_reveal_names")
+    assert reveal.disabled is False
+
+
+@pytest.mark.asyncio
+async def test_guess_view_reveal_button_predisabled_when_already_revealed():
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user, revealed=True)
+    assert gv.revealed is True
+    reveal = next(c for c in gv.children if getattr(c, "custom_id", None) == "trophy_quiz_reveal_names")
+    assert reveal.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_reveal_button_records_and_shows_names(monkeypatch):
+    from quiz_views_module import trophy_quiz_views as tv
+    recorded = []
+    async def fake_record(qid, pid): recorded.append((qid, pid))
+    monkeypatch.setattr(tv, "record_reveal", fake_record)
+
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    reveal = next(c for c in gv.children if getattr(c, "custom_id", None) == "trophy_quiz_reveal_names")
+    interaction = SimpleNamespace(
+        user=user,
+        response=SimpleNamespace(edit_message=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    await reveal.callback(interaction)
+    assert gv.revealed is True and reveal.disabled is True
+    assert recorded == [("q1", "1")]                     # persisted on click
+    sent = interaction.followup.send.await_args
+    text = (sent.args[0] if sent.args else sent.kwargs.get("content")) or ""
+    assert "<@u1>" in text and "<@u2>" in text
+
+
+@pytest.mark.asyncio
+async def test_reveal_after_submit_does_not_record(monkeypatch):
+    """Clicking Reveal on the same view after submitting must NOT record a reveal
+    (that would desync the displayed total from the already-stored score)."""
+    from quiz_views_module import trophy_quiz_views as tv
+    recorded = []
+    async def fake_record(qid, pid): recorded.append((qid, pid))
+    monkeypatch.setattr(tv, "record_reveal", fake_record)
+
+    user = SimpleNamespace(id=1, display_name="A", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    gv.submitted = True                                  # already submitted on this view
+    reveal = next(c for c in gv.children if getattr(c, "custom_id", None) == "trophy_quiz_reveal_names")
+    interaction = SimpleNamespace(
+        user=user,
+        response=SimpleNamespace(edit_message=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    await reveal.callback(interaction)
+    assert recorded == []                                # no charge post-submit
+    sent = interaction.followup.send.await_args
+    text = (sent.args[0] if sent.args else sent.kwargs.get("content")) or ""
+    assert "<@u1>" in text and "<@u2>" in text           # names still shown (free, already visible)
+    assert "will apply" not in text                      # no penalty note

--- a/utils.py
+++ b/utils.py
@@ -11,8 +11,9 @@ from models.leaderboard_message import LeaderboardMessage
 from models.win_streak_history import WinStreakHistory
 from models.perfect_streak_history import PerfectStreakHistory
 from models.draft_streak_history import DraftStreakHistory
-from models import QuizSession
+from models import QuizSession, TrophyQuizSession
 from quiz_views_module.quiz_views import QuizPublicView
+from quiz_views_module.trophy_quiz_views import TrophyQuizView
 from services.draft_analysis import DraftAnalysis
 from cogs.leaderboard import create_leaderboard_embed, TimeframeView
 from draft_organization.tournament import Tournament
@@ -2257,6 +2258,36 @@ async def re_register_views(bot):
                 logger.warning(f"Quiz message or channel not found for quiz: {quiz_session.quiz_id}")
             except Exception as e:
                 logger.error(f"Failed to re-register quiz view: {quiz_session.quiz_id}, error: {e}", exc_info=True)
+
+        # Re-register trophy quiz views for all recent trophy quizzes so their
+        # persistent dropdowns/buttons keep working after a restart (mirrors the
+        # pick-quiz re-registration above).
+        async with db_session.begin():
+            stmt = select(TrophyQuizSession).where(
+                TrophyQuizSession.posted_at >= cutoff_date
+            ).order_by(desc(TrophyQuizSession.posted_at))
+            result = await db_session.execute(stmt)
+            trophy_quiz_sessions = result.scalars().all()
+
+        logger.info(f"Found {len(trophy_quiz_sessions)} recent trophy quiz sessions to re-register")
+
+        for trophy_quiz in trophy_quiz_sessions:
+            if not trophy_quiz.message_id or not trophy_quiz.channel_id:
+                continue
+
+            channel = bot.get_channel(int(trophy_quiz.channel_id))
+            if not channel:
+                continue
+
+            try:
+                message = await channel.fetch_message(int(trophy_quiz.message_id))
+                view = TrophyQuizView(trophy_quiz.quiz_id, trophy_quiz.decks)
+                await message.edit(view=view)
+                logger.info(f"Re-registered trophy quiz view for quiz: {trophy_quiz.quiz_id}")
+            except discord.NotFound:
+                logger.warning(f"Trophy quiz message or channel not found for quiz: {trophy_quiz.quiz_id}")
+            except Exception as e:
+                logger.error(f"Failed to re-register trophy quiz view: {trophy_quiz.quiz_id}, error: {e}", exc_info=True)
 
         # Cleanup: Unpin quiz messages older than the rejoin cutoff
         logger.info("Cleaning up old quiz messages (unpinning messages older than rejoin cutoff)")


### PR DESCRIPTION
**Stacked PR 3 of 3** — stacked on #334. The Discord-facing feature (the imperative shell) that consumes the foundation + helpers below it.

### What's here
- **`quiz_views_module/trophy_quiz_views.py`** — the public message carries only a **Play** button + View Decklists + MPT deck-link buttons (no shared select menus, so concurrent users can't collide); Play opens a **per-user ephemeral guess view** (two record dropdowns + Submit) with a per-view `asyncio.Lock` serializing that user's Reveal/Submit. Includes the two MV pile images, **Reveal names (−2, durable)** — persisted on click so re-opening remembers it — and a **leak-safe share** (standalone `channel.send`, score + emoji only).
- **`cogs/trophy_quiz_commands.py`** — `/post_trophy_quiz`; the build/post path resolves MPT links **and** builds both pile images *before* any DB write or `channel.send` (so an abort needs no rollback), attaches two image embeds, and **tries the next eligible draft** (bounded) when a draft can't be prepped.
- **`cogs/unified_scheduler_cog.py`** — scheduled posts pick a quiz type at random with fallback.
- **`utils.py`** — re-registers the persistent trophy view on restart.

### Engineering notes for reviewers
- **Ordering over rollback:** all fallible prep (MPT, images) completes before the first irreversible effect (persist/post); abort = `return None`, nothing to undo.
- **Durable state at the point of decision:** the reveal is written on click and read back via `has_revealed` at submit — the ephemeral view's memory is never trusted for the penalty.
- Image bytes are kept in a list parallel to the persisted `decks` (never stored in the DB row / view metadata).

Tests: `tests/test_trophy_quiz_views.py`, `test_trophy_quiz_command.py`, `test_scheduler_quiz_choice.py`, `test_trophy_quiz_reveal.py`. Full suite (all layers composed): 694 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ