### PR TITLE
feat(mpt): attach each player's deck to draft-log links

### DIFF
--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -6,6 +6,7 @@ import aiohttp
 from typing import Dict, Any, Optional, List
 
 from .digital_ocean_helper import DigitalOceanHelper
+from services.draft_log_store import split_decklist, build_mtgo_deck_text
 
 
 class MagicProtoolsHelper:
@@ -158,9 +159,17 @@ class MagicProtoolsHelper:
             return None
 
     async def submit_to_api(self, user_id: str, draft_data: Dict[str, Any]) -> Optional[str]:
-        """Submit draft data directly to the MagicProTools API. Returns the MPT
-        URL if successful, None otherwise."""
-        return await self._submit_draft(user_id, draft_data, anonymize=False)
+        """Submit draft data to the MagicProTools API with the player's built deck
+        attached (best-effort), so the returned URL opens the draft with that deck.
+        Returns the MPT URL if successful, None otherwise."""
+        deck_text = None
+        try:
+            split = split_decklist(draft_data, user_id)
+            deck_text = build_mtgo_deck_text(split, draft_data.get("carddata", {})) or None
+        except Exception as e:
+            self.logger.warning(f"[MPT] deck build failed for user {user_id}, submitting draft-only: {e}")
+            deck_text = None
+        return await self._submit_draft(user_id, draft_data, deck_text=deck_text, anonymize=False)
     
     async def upload_draft_logs(
         self, 

--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -101,85 +101,66 @@ class MagicProtoolsHelper:
         
         return "\n".join(output)
     
-    async def submit_to_api(self, user_id: str, draft_data: Dict[str, Any]) -> Optional[str]:
-        """
-        Submit draft data directly to MagicProTools API
-        
-        Args:
-            user_id: The ID of the user for the draft log
-            draft_data: The draft log data
-            
-        Returns:
-            The MagicProTools URL if successful, None otherwise
-        """
+    async def _submit_draft(
+        self,
+        user_id: str,
+        draft_data: Dict[str, Any],
+        deck_text: Optional[str] = None,
+        anonymize: bool = False,
+    ) -> Optional[str]:
+        """Shared /api/draft/add POST core. Returns the raw MPT url (which carries
+        `&deck=` when deck_text is given), or None on any failure."""
         session_id = draft_data.get("sessionID", "unknown")
         user_name = draft_data.get("users", {}).get(user_id, {}).get("userName", "unknown")
-        
-        self.logger.info(f"[MPT] Submitting draft to MagicProTools API for user {user_name} (ID: {user_id}) in session {session_id}")
-        
         if not self.api_key:
-            self.logger.warning(f"[MPT] Missing MagicProTools API key, cannot submit directly for user {user_name}")
+            self.logger.warning(
+                f"[MPT] Missing API key, cannot submit for user {user_name} (session {session_id})"
+            )
             return None
-            
         try:
-            # Convert to MagicProTools format
-            self.logger.debug(f"[MPT] Converting draft to MagicProTools format for user {user_name}")
-            mpt_format = self.convert_to_magicprotools_format(draft_data, user_id)
-            
-            # Create the API request
-            url = "https://magicprotools.com/api/draft/add"
+            draft = self.convert_to_magicprotools_format(draft_data, user_id, anonymize=anonymize)
+            data = {"draft": draft, "apiKey": self.api_key, "platform": "mtgadraft"}
+            if deck_text:
+                data["deck"] = deck_text
             headers = {
                 "Accept": "application/json, text/plain, */*",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Referer": "https://draftmancer.com"
+                "Referer": "https://draftmancer.com",
             }
-            
-            # Use proper form data handling in aiohttp
-            data = {
-                "draft": mpt_format,
-                "apiKey": self.api_key,
-                "platform": "mtgadraft"
-            }
-            
-            # Log key information
-            self.logger.info(f"[MPT] Sending API request to {url} for user {user_name}")
-            
-            # Make the request using aiohttp's built-in form data handling
+            self.logger.info(
+                f"[MPT] Submitting draft for user {user_name} (session {session_id}, "
+                f"deck={'yes' if deck_text else 'no'}, anonymize={anonymize})"
+            )
             async with aiohttp.ClientSession() as session:
-                try:
-                    self.logger.debug(f"[MPT] Sending POST request for user {user_name}")
-                    async with session.post(url, headers=headers, data=data) as response:
-                        self.logger.info(f"[MPT] API response status: {response.status} for user {user_name}")
-                        
-                        if response.status == 200:
-                            json_response = await response.json()
-                            
-                            if "url" in json_response and not json_response.get("error"):
-                                result_url = json_response["url"]
-                                self.logger.info(f"[MPT] SUCCESS: Got direct URL for user {user_name}: {result_url}")
-                                return result_url
-                            else:
-                                error = json_response.get("error", "Unknown error")
-                                self.logger.warning(f"[MPT] API returned error for user {user_name}: {error}")
-                                self.logger.debug(f"[MPT] Full API response: {json_response}")
-                                return None
-                        else:
-                            self.logger.warning(f"[MPT] API returned non-200 status for user {user_name}: {response.status}")
-                            try:
-                                response_text = await response.text()
-                                self.logger.debug(f"[MPT] Response body: {response_text[:200]}...")
-                            except Exception as text_err:
-                                self.logger.debug(f"[MPT] Could not get response text: {text_err}")
-                            return None
-                except aiohttp.ClientError as ce:
-                    self.logger.error(f"[MPT] HTTP client error for user {user_name}: {ce}")
-                    return None
-            
-            return None  # Return None if unsuccessful
+                async with session.post("https://magicprotools.com/api/draft/add",
+                                        headers=headers, data=data) as resp:
+                    if resp.status != 200:
+                        self.logger.warning(
+                            f"[MPT] non-200 status {resp.status} for user {user_name} (session {session_id})"
+                        )
+                        try:
+                            self.logger.debug(f"[MPT] Response body: {(await resp.text())[:200]}")
+                        except Exception as text_err:
+                            self.logger.debug(f"[MPT] Could not read response body: {text_err}")
+                        return None
+                    body = await resp.json()
+            if body.get("error") or "url" not in body:
+                self.logger.warning(
+                    f"[MPT] bad body for user {user_name}: error={body.get('error')!r} "
+                    f"url_present={'url' in body}"
+                )
+                return None
+            result_url = body["url"]
+            self.logger.info(f"[MPT] SUCCESS: got url for user {user_name}: {result_url}")
+            return result_url
         except Exception as e:
-            self.logger.error(f"[MPT] Error submitting to MagicProTools API for user {user_name}: {e}")
-            self.logger.debug(f"[MPT] Exception details: {repr(e)}")
+            self.logger.error(f"[MPT] submit failed for user {user_name}: {e}")
             return None
+
+    async def submit_to_api(self, user_id: str, draft_data: Dict[str, Any]) -> Optional[str]:
+        """Submit draft data directly to the MagicProTools API. Returns the MPT
+        URL if successful, None otherwise."""
+        return await self._submit_draft(user_id, draft_data, anonymize=False)
     
     async def upload_draft_logs(
         self, 
@@ -251,38 +232,14 @@ class MagicProtoolsHelper:
     
     async def submit_deck_view(self, user_id: str, draft_data: Dict[str, Any], deck_text: str) -> Optional[str]:
         """Upload the anonymized draft + deck to MPT; return the /deck/show URL or None."""
-        if not self.api_key:
-            self.logger.warning(f"[MPT] No API key; cannot build deck view (user_id: {user_id})")
+        url = await self._submit_draft(user_id, draft_data, deck_text=deck_text, anonymize=True)
+        if not url:
             return None
-        try:
-            draft = self.convert_to_magicprotools_format(draft_data, user_id, anonymize=True)
-            data = {"draft": draft, "deck": deck_text, "apiKey": self.api_key, "platform": "mtgadraft"}
-            headers = {
-                "Accept": "application/json, text/plain, */*",
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Referer": "https://draftmancer.com",
-            }
-            async with aiohttp.ClientSession() as session:
-                async with session.post("https://magicprotools.com/api/draft/add",
-                                        headers=headers, data=data) as resp:
-                    if resp.status != 200:
-                        self.logger.warning(f"[MPT] deck view non-200: {resp.status} (user_id: {user_id})")
-                        return None
-                    body = await resp.json()
-            if body.get("error") or "url" not in body:
-                self.logger.warning(
-                    f"[MPT] deck view bad body: error={body.get('error')!r} url_present={'url' in body} "
-                    f"(user_id: {user_id})"
-                )
-                return None
-            token = self.extract_deck_token(body["url"])
-            if not token:
-                self.logger.warning(f"[MPT] deck view: no deck token in returned url (user_id: {user_id})")
-                return None
-            return f"https://magicprotools.com/deck/show?id={token}"
-        except Exception as e:
-            self.logger.error(f"[MPT] deck view submit failed: {e} (user_id: {user_id})")
+        token = self.extract_deck_token(url)
+        if not token:
+            self.logger.warning(f"[MPT] deck view: no deck token in returned url (user_id: {user_id})")
             return None
+        return f"https://magicprotools.com/deck/show?id={token}"
 
     def get_pack_first_picks(self, draft_data: Dict[str, Any], user_id: str) -> Dict[str, str]:
         """

--- a/tests/test_mpt_deck_view.py
+++ b/tests/test_mpt_deck_view.py
@@ -85,3 +85,70 @@ async def test_submit_deck_view_none_without_key():
     h = MagicProtoolsHelper()
     h.api_key = None
     assert await h.submit_deck_view("dmA", _draft_log(), "x") is None
+
+
+def _capturing_session(json_body):
+    """Like _ok_session but exposes the post mock so tests can inspect the POST body."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.json = AsyncMock(return_value=json_body)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    sess = MagicMock()
+    sess.post = MagicMock(return_value=cm)
+    outer = MagicMock()
+    outer.__aenter__ = AsyncMock(return_value=sess)
+    outer.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=outer), sess.post
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_returns_raw_url_and_includes_deck_field():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D&deck=TOK"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        url = await h._submit_draft("dmA", _draft_log(), deck_text="4 Lightning Bolt\n")
+    assert url == "https://magicprotools.com/draft/show?id=D&deck=TOK"
+    body = post.call_args.kwargs["data"]
+    assert body["deck"] == "4 Lightning Bolt\n"
+    assert body["apiKey"] == "k" and body["platform"] == "mtgadraft"
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_omits_deck_field_when_no_deck_text():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        url = await h._submit_draft("dmA", _draft_log())
+    assert url == "https://magicprotools.com/draft/show?id=D"
+    assert "deck" not in post.call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_passes_anonymize_flag():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        await h._submit_draft("dmA", _draft_log(), anonymize=True)
+    draft_field = post.call_args.kwargs["data"]["draft"]
+    assert "RealAlice" not in draft_field and "--> Drafter" in draft_field
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_none_without_key():
+    h = MagicProtoolsHelper()
+    h.api_key = None
+    assert await h._submit_draft("dmA", _draft_log()) is None
+
+
+@pytest.mark.asyncio
+async def test_submit_draft_none_on_error_body():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, _ = _capturing_session({"error": "bad"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        assert await h._submit_draft("dmA", _draft_log(), deck_text="x") is None

--- a/tests/test_mpt_deck_view.py
+++ b/tests/test_mpt_deck_view.py
@@ -21,7 +21,7 @@ def _draft_log():
         "sessionID": "s1", "time": 1000,
         "setRestriction": [],
         "users": {
-            "dmA": {"userName": "RealAlice", "picks": [
+            "dmA": {"userName": "RealAlice", "cards": ["c0"], "picks": [
                 {"packNum": 0, "pickNum": 0, "booster": ["c0", "c1"], "pick": [0]}]},
             "dmB": {"userName": "RealBob", "picks": [
                 {"packNum": 0, "pickNum": 0, "booster": ["c0", "c1"], "pick": [1]}]},
@@ -152,3 +152,41 @@ async def test_submit_draft_none_on_error_body():
     factory, _ = _capturing_session({"error": "bad"})
     with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
         assert await h._submit_draft("dmA", _draft_log(), deck_text="x") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_to_api_attaches_deck_built_from_pool_non_anonymized():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D&deck=TOK"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        url = await h.submit_to_api("dmA", _draft_log())
+    assert url == "https://magicprotools.com/draft/show?id=D&deck=TOK"
+    body = post.call_args.kwargs["data"]
+    assert body["deck"] == "1 Lightning Bolt"       # deck built from dmA's pool
+    assert "RealAlice" in body["draft"]              # non-anonymized (real names)
+
+
+@pytest.mark.asyncio
+async def test_submit_to_api_no_deck_field_for_empty_pool():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    log = _draft_log()
+    log["users"]["dmA"] = {"userName": "RealAlice", "picks": []}   # no cards → empty deck
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D"})
+    with patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        url = await h.submit_to_api("dmA", log)
+    assert url == "https://magicprotools.com/draft/show?id=D"
+    assert "deck" not in post.call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
+async def test_submit_to_api_degrades_to_draft_only_when_deck_build_raises():
+    h = MagicProtoolsHelper()
+    h.api_key = "k"
+    factory, post = _capturing_session({"url": "https://magicprotools.com/draft/show?id=D"})
+    with patch("helpers.magicprotools_helper.build_mtgo_deck_text", side_effect=RuntimeError("boom")), \
+         patch("helpers.magicprotools_helper.aiohttp.ClientSession", factory):
+        url = await h.submit_to_api("dmA", _draft_log())
+    assert url == "https://magicprotools.com/draft/show?id=D"   # still submits
+    assert "deck" not in post.call_args.kwargs["data"]          # deck omitted on build failure


### PR DESCRIPTION
## What

Per-player MagicProTools links in the draft-logs now open the draft **with that player's built deck attached** (`…/draft/show?id=<draft>&deck=<deck>`). This unifies the two MPT upload paths that previously duplicated the `/api/draft/add` POST.

## Why

The trophy quiz already uploaded draft **+ deck** to MPT (anonymized, `/deck/show`), while the draft logs uploaded the draft **only** (real names, `/draft/show`). MPT returns a `&deck=` token whenever a `deck` field is posted, so attaching each player's deck enriches the existing draft-log link for free — and lets the two paths share one upload core.

## How

- **Extract `_submit_draft(user_id, draft_data, deck_text=None, anonymize=False)`** — the shared `/api/draft/add` POST core. Returns the raw MPT `url`; includes a `deck` form field only when `deck_text` is truthy; `None` on any failure.
- **`submit_to_api`** now builds the player's deck internally (`build_mtgo_deck_text(split_decklist(...), carddata)`), best-effort, and delegates `anonymize=False`. Its returned URL now carries `&deck=` — draft **+** deck, real names.
- **`submit_deck_view`** delegates `anonymize=True` and extracts the `/deck/show` token (unchanged behavior for the trophy quiz).

Both draft-log call sites (`generate_magicprotools_embed` and `upload_draft_logs`) get enriched links with **zero caller changes**. The quiz pack-visualization caller (which passes stripped draft data) degrades cleanly to draft-only.

## Best-effort / non-anonymized

- Draft logs stay **non-anonymized** (players' own logs).
- Deck attachment is best-effort: an empty pool → no deck field; a deck-build exception → draft-only submission. If MPT submission itself fails, the existing import-URL fallback still applies.

## Testing

- New `_submit_draft` tests: raw-url return, deck field present/omitted, `anonymize` pass-through, all failure modes.
- New `submit_to_api` tests: deck built from pool + non-anonymized, empty pool → no deck, build exception → draft-only.
- Existing `submit_deck_view` tests unchanged and green.
- `tests/test_mpt_deck_view.py` + `tests/test_draft_log_store.py`: **24 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
