### PR TITLE
fix(mpt): stop shadowing upload_draft_logs accumulator

### DIFF
--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -214,13 +214,13 @@ class MagicProtoolsHelper:
                 user_filename = f"DraftLog_{user_id}.txt"
                 
                 # Upload to DO Spaces
-                result = await self.do_helper.upload_text(
+                upload = await self.do_helper.upload_text(
                     mpt_format,
                     base_path,
                     user_filename
                 )
 
-                if result.success:
+                if upload.success:
                     # Get the public URL
                     txt_key = f"{base_path}/{user_filename}"
                     txt_url = self.do_helper.get_public_url(txt_key)

--- a/tests/test_upload_draft_logs.py
+++ b/tests/test_upload_draft_logs.py
@@ -1,0 +1,55 @@
+import urllib.parse
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from helpers.magicprotools_helper import MagicProtoolsHelper
+from helpers.digital_ocean_helper import UploadResult
+
+
+def _two_user_log():
+    return {
+        "sessionID": "s1", "time": 1000, "setRestriction": [],
+        "users": {
+            "dmA": {"userName": "Alice", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c0"], "pick": [0]}]},
+            "dmB": {"userName": "Bob", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c0"], "pick": [0]}]},
+        },
+        "carddata": {"c0": {"name": "Lightning Bolt", "set": "lea"}},
+    }
+
+
+def _helper_with_uploads_ok():
+    h = MagicProtoolsHelper()
+    h.api_key = None  # skip direct API submission -> deterministic import-URL fallback
+    h.do_helper = MagicMock()
+    h.do_helper.upload_text = AsyncMock(return_value=UploadResult(success=True, object_path="k"))
+    h.do_helper.get_public_url = lambda key: f"https://cdn/{key}"
+    return h
+
+
+@pytest.mark.asyncio
+async def test_upload_draft_logs_accumulates_every_user():
+    """The returned map must contain an entry per player. Regression guard for a
+    shadowed accumulator that used to drop everyone after the first player and
+    return the last UploadResult instead of the dict."""
+    h = _helper_with_uploads_ok()
+
+    result = await h.upload_draft_logs(_two_user_log(), "s1", "team")
+
+    assert set(result.keys()) == {"dmA", "dmB"}
+    assert result["dmA"]["name"] == "Alice"
+    assert result["dmB"]["name"] == "Bob"
+    assert result["dmA"]["txt_url"] == "https://cdn/draft_logs/team/s1/DraftLog_dmA.txt"
+
+
+@pytest.mark.asyncio
+async def test_upload_draft_logs_uses_import_url_fallback_without_api_key():
+    h = _helper_with_uploads_ok()
+
+    result = await h.upload_draft_logs(_two_user_log(), "s1", "team")
+
+    txt_url = "https://cdn/draft_logs/team/s1/DraftLog_dmB.txt"
+    expected = f"https://magicprotools.com/draft/import?url={urllib.parse.quote(txt_url)}"
+    assert result["dmB"]["mpt_url"] == expected


### PR DESCRIPTION
## Bug

`upload_draft_logs` (`helpers/magicprotools_helper.py`) reuses one variable name for two purposes:

```python
result = {}                                       # the per-user accumulator
for user_id, user_data in draft_data["users"].items():
    ...
    result = await self.do_helper.upload_text(...) # ❗ clobbers the accumulator
    if result.success:
        ...
        result[user_id] = { ... }                  # ❗ item-assign on an UploadResult
```

`UploadResult` is a plain `@dataclass` with no `__setitem__`, so `result[user_id] = {...}` raises `TypeError: 'UploadResult' object does not support item assignment` on the **first** player. The surrounding `except Exception` swallows it, logs `"Error generating and uploading MagicProTools format logs: ..."`, and returns the `UploadResult` object instead of the documented `Dict[str, Dict[str, str]]`.

### Impact

- Every draft silently logs one swallowed exception.
- The DO-Spaces `.txt` archive ends up holding **at most the first player's log** — everyone after the first is dropped.
- Low blast radius (which is why it survived): the user-facing draft-log embed comes from a **separate** path (`generate_magicprotools_embed` → `submit_to_api`), and the only caller of `upload_draft_logs` (`process_draft_logs_for_magicprotools`) checks the return value for truthiness only — a returned dataclass is truthy, so it reported success.

## Fix

Rename the loop-local upload result to `upload` so it no longer shadows the accumulator. One-line change.

## Testing

New `tests/test_upload_draft_logs.py`:
- `test_upload_draft_logs_accumulates_every_user` — two players, asserts the returned map has an entry per player (fails on the old code with `'UploadResult' object is not subscriptable`).
- `test_upload_draft_logs_uses_import_url_fallback_without_api_key` — verifies the import-URL fallback when no API key is set.

Both fail on the pre-fix code (the captured log shows the exact swallowed `TypeError`) and pass after the rename. `tests/test_upload_draft_logs.py` + `tests/test_mpt_deck_view.py`: **8 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
