### PR TITLE
feat(trophy): deck links in daily and weekly trophy summaries

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -11,7 +11,9 @@ from stats_display import get_stats_embed_for_player
 from loguru import logger
 from discord.ext import commands
 from legacy_stats import get_legacy_player_stats, get_legacy_head_to_head_stats
-from helpers.display_names import get_display_name
+from helpers.display_names import get_display_name, get_display_name_by_id
+from models.match import MatchResult
+from helpers.trophy_deck_links import session_trophy_links, render_grouped_trophy_decks
 from helpers.permissions import has_bot_manager_role
 
 
@@ -313,20 +315,27 @@ async def scheduled_posts(bot):
                     top_drafters = username_counts.most_common(10)
 
 
-                    drafter_counts = Counter()
+                    match_rows = (await db_session.execute(
+                        select(MatchResult).where(
+                            MatchResult.session_id.in_([s.session_id for s in sessions])
+                        )
+                    )).scalars().all()
+                    matches_by_session = {}
+                    for m in match_rows:
+                        matches_by_session.setdefault(m.session_id, []).append(m)
+
+                    trophies = []
                     for session in sessions:
-                        if session.trophy_drafters:
-                            drafter_counts.update(session.trophy_drafters)
-
-                    # Filter and sort drafters who have two or more trophies
-                    filtered_trophy_drafters = {drafter: count for drafter, count in drafter_counts.items() if count >= 2}
-                    sorted_trophy_drafters = sorted(filtered_trophy_drafters.items(), key=lambda item: item[1], reverse=True)
-
-                    # Format the drafter names and their counts for display
-                    if sorted_trophy_drafters:
-                        undefeated_drafters_field_value = "\n".join([f"{index + 1}. {drafter} x{count}" for index, (drafter, count) in enumerate(sorted_trophy_drafters)])
-                    else:
-                        undefeated_drafters_field_value = "No drafters with 2 or more trophies."
+                        trophies.extend(session_trophy_links(
+                            matches_by_session.get(session.session_id, []),
+                            session.magicprotools_links,
+                        ))
+                    undefeated_drafters_field_value = render_grouped_trophy_decks(
+                        trophies,
+                        name_by_id=lambda pid: get_display_name_by_id(pid, guild),
+                        min_count=2,
+                        sort_by_count=True,
+                    )
 
                     total_drafts = len(sessions)
 
@@ -381,13 +390,26 @@ async def scheduled_posts(bot):
                     top_five_drafters = username_counts.most_common(5)
 
 
-                    drafter_counts = Counter()
-                    for session in sessions:
-                        undefeated_drafters = list(session.trophy_drafters) if session.trophy_drafters else []
-                        drafter_counts.update(undefeated_drafters)
+                    match_rows = (await db_session.execute(
+                        select(MatchResult).where(
+                            MatchResult.session_id.in_([s.session_id for s in sessions])
+                        )
+                    )).scalars().all()
+                    matches_by_session = {}
+                    for m in match_rows:
+                        matches_by_session.setdefault(m.session_id, []).append(m)
 
-                    # Format the drafter names and their counts for display
-                    undefeated_drafters_field_value = "\n".join([f"{drafter} x{count}" if count > 1 else drafter for drafter, count in drafter_counts.items()])
+                    trophies = []
+                    for session in sessions:
+                        trophies.extend(session_trophy_links(
+                            matches_by_session.get(session.session_id, []),
+                            session.magicprotools_links,
+                        ))
+                    undefeated_drafters_field_value = render_grouped_trophy_decks(
+                        trophies,
+                        name_by_id=lambda pid: get_display_name_by_id(pid, guild),
+                        min_count=1,
+                    )
 
 
                     total_drafts = len(sessions)

--- a/helpers/trophy_deck_links.py
+++ b/helpers/trophy_deck_links.py
@@ -1,0 +1,77 @@
+"""Map trophy (3-0) finishers to their stored MagicProTools deck links and render
+grouped summary lines. Pure functions so the daily/weekly cron summaries can be
+unit-tested in isolation."""
+from collections import Counter, OrderedDict
+
+
+def session_trophy_links(matches, magicprotools_links):
+    """`(drafter_id, link_or_None)` for drafters with exactly 3 wins in one session.
+
+    matches: iterable of objects with a `winner_id` attribute.
+    magicprotools_links: {drafter_id: {"link": url, ...}} or None.
+    """
+    win_counts = Counter(m.winner_id for m in matches if m.winner_id)
+    links = magicprotools_links or {}
+    return [
+        (pid, (links.get(pid) or {}).get("link"))
+        for pid, count in win_counts.items()
+        if count == 3
+    ]
+
+
+def _deck_token(link, index=None):
+    label = "deck" if index is None else f"deck {index}"
+    return f"[{label}]({link})" if link else label
+
+
+def _truncate_lines(lines, max_len):
+    """Join lines with newlines within max_len; if they overflow, keep a prefix and
+    append '…and K more' for the dropped remainder."""
+    if not lines:
+        return ""
+    if len("\n".join(lines)) <= max_len:
+        return "\n".join(lines)
+    kept = []
+    for i, line in enumerate(lines):
+        if i < len(lines) - 1:
+            trial = "\n".join(kept + [line, f"…and {len(lines) - i - 1} more"])
+        else:
+            trial = "\n".join(kept + [line])          # last line needs no marker
+        if len(trial) <= max_len:
+            kept.append(line)
+        else:
+            marker = f"…and {len(lines) - i} more"
+            return "\n".join(kept + [marker]) if kept else marker
+    return "\n".join(kept)
+
+
+def render_grouped_trophy_decks(trophies, name_by_id, min_count=1, sort_by_count=False, max_len=1024):
+    """Render grouped trophy deck lines.
+
+    trophies: [(drafter_id, link_or_None), ...] across the window (order preserved).
+    name_by_id: callable drafter_id -> display name.
+    Groups by drafter_id; one line per drafter with >= min_count trophies:
+      1 trophy : 'Name — [deck](l)'   (unlinked 'deck' when link is None)
+      N trophies:'Name xN — [deck 1](l1), [deck 2](l2), ...'
+    sort_by_count: order lines by trophy count descending when True.
+    Returns lines joined by newlines, truncated to max_len with a trailing
+    '…and K more' when needed; '' when nothing qualifies.
+    """
+    grouped = OrderedDict()
+    for pid, link in trophies:
+        grouped.setdefault(pid, []).append(link)
+
+    items = [(pid, links) for pid, links in grouped.items() if len(links) >= min_count]
+    if sort_by_count:
+        items.sort(key=lambda kv: len(kv[1]), reverse=True)
+
+    lines = []
+    for pid, links in items:
+        name = name_by_id(pid)
+        if len(links) == 1:
+            lines.append(f"{name} — {_deck_token(links[0])}")
+        else:
+            tokens = ", ".join(_deck_token(link, i + 1) for i, link in enumerate(links))
+            lines.append(f"{name} x{len(links)} — {tokens}")
+
+    return _truncate_lines(lines, max_len)

--- a/tests/test_trophy_deck_links.py
+++ b/tests/test_trophy_deck_links.py
@@ -1,0 +1,67 @@
+from helpers.trophy_deck_links import session_trophy_links, render_grouped_trophy_decks
+
+
+class _M:
+    def __init__(self, winner_id):
+        self.winner_id = winner_id
+
+
+def _matches(winner_ids):
+    return [_M(w) for w in winner_ids]
+
+
+def _name(pid):
+    return {"a": "Alice", "b": "Bob"}.get(pid, pid)
+
+
+def test_session_trophy_links_only_three_win_ids():
+    matches = _matches(["a", "a", "a", "b", "b", None])   # a=3 wins, b=2, one no-winner
+    links = {"a": {"link": "http://x/a"}, "b": {"link": "http://x/b"}}
+    assert session_trophy_links(matches, links) == [("a", "http://x/a")]
+
+
+def test_session_trophy_links_missing_link_is_none():
+    matches = _matches(["a", "a", "a"])
+    assert session_trophy_links(matches, {}) == [("a", None)]
+    assert session_trophy_links(matches, None) == [("a", None)]
+
+
+def test_render_single_trophy():
+    assert render_grouped_trophy_decks([("a", "L1")], _name) == "Alice — [deck](L1)"
+
+
+def test_render_single_trophy_missing_link():
+    assert render_grouped_trophy_decks([("a", None)], _name) == "Alice — deck"
+
+
+def test_render_multiple_trophies_grouped():
+    out = render_grouped_trophy_decks([("a", "L1"), ("a", "L2"), ("b", "L3")], _name)
+    assert out == "Alice x2 — [deck 1](L1), [deck 2](L2)\nBob — [deck](L3)"
+
+
+def test_render_min_count_filters_singletons():
+    out = render_grouped_trophy_decks([("a", "L1"), ("a", "L2"), ("b", "L3")], _name, min_count=2)
+    assert out == "Alice x2 — [deck 1](L1), [deck 2](L2)"
+
+
+def test_render_missing_link_unlinked_token_keeps_count():
+    out = render_grouped_trophy_decks([("a", "L1"), ("a", None)], _name)
+    assert out == "Alice x2 — [deck 1](L1), deck 2"
+
+
+def test_render_sort_by_count_desc():
+    trophies = [("b", "L3"), ("a", "L1"), ("a", "L2")]   # b (1) appears before a (2)
+    out = render_grouped_trophy_decks(trophies, _name, sort_by_count=True)
+    assert out.splitlines()[0].startswith("Alice x2")
+
+
+def test_render_empty():
+    assert render_grouped_trophy_decks([], _name) == ""
+
+
+def test_render_truncates_with_more_marker():
+    url = "http://magicprotools.com/draft/show?id=" + "X" * 30
+    trophies = [(str(i), url) for i in range(50)]
+    out = render_grouped_trophy_decks(trophies, lambda p: f"Player{p}", max_len=200)
+    assert len(out) <= 200
+    assert out.rstrip().endswith("more")


### PR DESCRIPTION
## What

Adds each trophy drafter's **deck link** to the trophy listings in both Open Queue summaries:
- **Daily** — `daily_random_results` → "Trophy Drafters" field (`#team-draft-results`, 9:15am ET).
- **Weekly** — "Multiple Weekly Trophies" field (keeps its 2+-trophy filter).

Each 3-0 finish links to that player's stored MagicProTools URL — which, once #342 is deployed, opens the draft with their deck attached.

## Rendering

Grouped per drafter:
- 1 trophy → `Name — [deck](link)`
- N trophies → `Name xN — [deck 1](l1), [deck 2](l2)`
- Missing link (push failed / older draft) → unlinked `deck` token, count preserved.

## How

- New pure, unit-tested module `helpers/trophy_deck_links.py`:
  - `session_trophy_links(matches, magicprotools_links)` — the `(drafter_id, link|None)` pairs for a session's 3-0 finishers, derived from `MatchResult` win counts (robust, discord-ID-based — not name matching).
  - `render_grouped_trophy_decks(trophies, name_by_id, min_count, sort_by_count, max_len=1024)` — groups by drafter and renders the lines, with a **1024-char guard** (`…and K more`) so a busy week never exceeds Discord's field cap.
- `commands.py` wires both summaries: one `MatchResult.session_id.in_(...)` query per window, mapped to links via `magicprotools_links`, names via `get_display_name_by_id`. Weekly uses `min_count=2, sort_by_count=True`; daily `min_count=1`.

## Scope preserved

Trophy qualification, schedules, and channels are unchanged. The `magicprotools_links` deck content depends on #342 for future drafts; historical links stay draft-only (still valid). Built off `main`, independent.

## Testing

`tests/test_trophy_deck_links.py` — 10 tests: 3-0 filtering, missing-link → None, single/multi grouping, min-count filter, sort-by-count, unlinked-token count preservation, and the truncation guard. **10 passed.** `commands.py` py_compiles; imports resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
