### PR TITLE
feat(debt): rank Most Outstanding by debt involvement, pin to every page

### DIFF
--- a/debt_views/helpers.py
+++ b/debt_views/helpers.py
@@ -88,15 +88,17 @@ _MEDALS = ("🥇", "🥈", "🥉")
 
 
 def _build_most_outstanding_field(guild, top_creditors):
-    """Return (name, value) for the 🏆 Most Outstanding leaderboard field, or
-    None when there are no net creditors."""
+    """Return (name, value) for the 🏆 Most Outstanding leaderboard field, or None
+    when nobody is involved in outstanding debts. Ranks by the number of debt
+    relationships each player is involved in (owed + owing)."""
     if not top_creditors:
         return None
     lines = []
-    for rank, (player_id, net) in enumerate(top_creditors):
+    for rank, (player_id, count) in enumerate(top_creditors):
         medal = _MEDALS[rank] if rank < len(_MEDALS) else f"{rank + 1}."
         name = get_member_name(guild, player_id)
-        lines.append(f"{medal} {name} — {net} tix")
+        unit = "debt" if count == 1 else "debts"
+        lines.append(f"{medal} {name} — {count} {unit}")
     return "🏆 Most Outstanding", "\n".join(lines)
 
 
@@ -143,10 +145,9 @@ def build_guild_debt_embed_pages(guild: discord.Guild, rows: list, per_page: int
             color=discord.Color.orange()
         )
 
-        if page_num == 0:
-            leaderboard = _build_most_outstanding_field(guild, top_creditors)
-            if leaderboard:
-                embed.add_field(name=leaderboard[0], value=leaderboard[1], inline=False)
+        leaderboard = _build_most_outstanding_field(guild, top_creditors)
+        if leaderboard:
+            embed.add_field(name=leaderboard[0], value=leaderboard[1], inline=False)
 
         debt_lines = []
         for row in page_rows:

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -1048,13 +1048,52 @@ async def get_top_net_creditors(guild_id: str, limit: int = 3) -> list:
         return [(row.player_id, row.net) for row in result.all()]
 
 
+async def get_most_involved_players(guild_id: str, limit: int = 3) -> list:
+    """Players ranked by how many distinct debt relationships they're involved in
+    (owed + owing), most first.
+
+    The ledger is double-entry, so grouping by player_id counts both debts the
+    player owes and debts owed to them. Only relationships with a non-zero net
+    balance count. Ties broken by larger total outstanding amount, then player_id.
+
+    Returns a list of (player_id, count) tuples, length 0..limit.
+    """
+    async with db_session() as session:
+        pairs = (
+            select(
+                DebtLedger.player_id.label("player_id"),
+                DebtLedger.counterparty_id.label("counterparty_id"),
+                func.sum(DebtLedger.amount).label("balance"),
+            )
+            .where(DebtLedger.guild_id == guild_id)
+            .group_by(DebtLedger.player_id, DebtLedger.counterparty_id)
+            .having(func.sum(DebtLedger.amount) != 0)
+            .subquery()
+        )
+        query = (
+            select(
+                pairs.c.player_id,
+                func.count().label("debt_count"),
+            )
+            .group_by(pairs.c.player_id)
+            .order_by(
+                func.count().desc(),
+                func.sum(func.abs(pairs.c.balance)).desc(),
+                pairs.c.player_id.asc(),
+            )
+            .limit(limit)
+        )
+        result = await session.execute(query)
+        return [(row.player_id, row.debt_count) for row in result.all()]
+
+
 async def get_most_outstanding_creditors(guild_id: str, limit: int = 3) -> list:
     """Top creditors for the debt-summary leaderboard, gated to staked servers.
 
     Returns [] on non-money servers so the section never renders there and no
-    query runs. On money servers, delegates to get_top_net_creditors.
+    query runs. On money servers, delegates to get_most_involved_players.
     """
     from config import is_money_server
     if not is_money_server(guild_id):
         return []
-    return await get_top_net_creditors(guild_id, limit)
+    return await get_most_involved_players(guild_id, limit)

--- a/tests/test_debt_leaderboard.py
+++ b/tests/test_debt_leaderboard.py
@@ -17,17 +17,24 @@ def _patch_names():
     return patch("debt_views.helpers.get_member_name", lambda guild, uid: f"User-{uid}")
 
 
-def test_top_creditors_field_is_prepended_on_first_page():
+def test_top_involved_field_is_prepended():
     rows = [_row("bob", "alice", -120)]
     with _patch_names():
         pages = build_guild_debt_embed_pages(
-            _guild(), rows, top_creditors=[("alice", 150), ("bob", 80)])
+            _guild(), rows, top_creditors=[("alice", 3), ("bob", 2)])
     first = pages[0].fields[0]
     assert first.name == "🏆 Most Outstanding"
-    assert "🥇 User-alice — 150 tix" in first.value
-    assert "🥈 User-bob — 80 tix" in first.value
+    assert "🥇 User-alice — 3 debts" in first.value
+    assert "🥈 User-bob — 2 debts" in first.value
     # It comes before the outstanding-debts field.
     assert pages[0].fields[1].name.startswith("Outstanding Debts")
+
+
+def test_singular_debt_label():
+    rows = [_row("bob", "alice", -120)]
+    with _patch_names():
+        pages = build_guild_debt_embed_pages(_guild(), rows, top_creditors=[("alice", 1)])
+    assert "🥇 User-alice — 1 debt" in pages[0].fields[0].value
 
 
 def test_no_field_when_top_creditors_none():
@@ -44,11 +51,12 @@ def test_no_field_when_top_creditors_empty():
     assert all(f.name != "🏆 Most Outstanding" for f in pages[0].fields)
 
 
-def test_field_only_on_first_page():
-    # 12 rows, per_page=10 -> 2 pages; leaderboard only on page 0.
+def test_field_on_every_page():
+    # 12 rows, per_page=10 -> 2 pages; leaderboard on BOTH pages now.
     rows = [_row(f"d{i}", f"c{i}", -(i + 1)) for i in range(12)]
     with _patch_names():
         pages = build_guild_debt_embed_pages(
-            _guild(), rows, per_page=10, top_creditors=[("alice", 150)])
+            _guild(), rows, per_page=10, top_creditors=[("alice", 5)])
+    assert len(pages) == 2
     assert pages[0].fields[0].name == "🏆 Most Outstanding"
-    assert all(f.name != "🏆 Most Outstanding" for f in pages[1].fields)
+    assert pages[1].fields[0].name == "🏆 Most Outstanding"

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -1591,7 +1591,7 @@ class TestGetDebtHistory:
 
 
 from unittest.mock import patch
-from services.debt_service import get_top_net_creditors, get_most_outstanding_creditors
+from services.debt_service import get_top_net_creditors, get_most_outstanding_creditors, get_most_involved_players
 
 
 class TestTopNetCreditors:
@@ -1656,7 +1656,69 @@ class TestTopNetCreditors:
 
     @pytest.mark.asyncio
     async def test_gate_delegates_on_money_server(self, test_db):
-        await self._owe("gY", "bob", "alice", 99)
+        # alice involved in 2 debts, so she tops the involvement ranking
+        await self._owe("gY", "alice", "bob", 40)
+        await self._owe("gY", "alice", "carol", 60)
         with patch("config.is_money_server", return_value=True):
             result = await get_most_outstanding_creditors("gY", limit=3)
-        assert result == [("alice", 99)]
+        assert result[0] == ("alice", 2)
+
+
+class TestMostInvolvedPlayers:
+    """Tests for the involvement-count leaderboard query."""
+
+    async def _owe(self, guild, debtor, creditor, amount):
+        await create_ledger_entries(
+            guild_id=guild, debtor_id=debtor, creditor_id=creditor,
+            amount=amount, source_type="draft", source_id=f"s-{debtor}-{creditor}-{amount}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_counts_both_directions(self, test_db):
+        g = "mi1"
+        await self._owe(g, "alice", "bob", 10)     # alice owes bob
+        await self._owe(g, "alice", "carol", 20)   # alice owes carol
+        await self._owe(g, "dave", "alice", 30)    # dave owes alice
+        result = await get_most_involved_players(g, limit=5)
+        counts = dict(result)
+        assert counts["alice"] == 3   # 2 owing + 1 owed
+        assert counts["bob"] == 1
+        assert counts["carol"] == 1
+        assert counts["dave"] == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_net_zero_relationships(self, test_db):
+        g = "mi2"
+        await self._owe(g, "alice", "bob", 50)
+        await self._owe(g, "bob", "alice", 50)   # cancels out
+        result = await get_most_involved_players(g, limit=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_orders_by_count_then_amount(self, test_db):
+        g = "mi3"
+        await self._owe(g, "alice", "x", 5)
+        await self._owe(g, "alice", "y", 5)      # alice: 2 debts
+        await self._owe(g, "bob", "z", 999)      # bob: 1 debt, big
+        result = await get_most_involved_players(g, limit=5)
+        assert result[0] == ("alice", 2)          # count beats amount
+        assert ("bob", 1) in result
+
+    @pytest.mark.asyncio
+    async def test_amount_tiebreak_on_equal_counts(self, test_db):
+        g = "mi4"
+        await self._owe(g, "alice", "p", 10)
+        await self._owe(g, "bob", "q", 500)       # both 1 debt; bob larger
+        result = await get_most_involved_players(g, limit=5)
+        order = [pid for pid, _ in result]
+        assert order.index("bob") < order.index("alice")
+
+    @pytest.mark.asyncio
+    async def test_respects_limit_and_guild(self, test_db):
+        g = "mi5"
+        await self._owe(g, "a", "b", 10)
+        await self._owe(g, "a", "c", 10)          # a: 2
+        await self._owe(g, "d", "e", 10)
+        await self._owe("other", "z", "y", 99)    # different guild
+        result = await get_most_involved_players(g, limit=1)
+        assert result == [("a", 2)]


### PR DESCRIPTION
## What

Two changes to the guild debt summary panel's **🏆 Most Outstanding** leaderboard:
1. It now ranks players by the **number of debt relationships they're involved in** (owed + owing) instead of by net tix, and shows that count (`N debts` / `1 debt`).
2. It's pinned to the **top of every page** (previously only page 1).

## How

- **New query** `get_most_involved_players(guild_id, limit=3)` in `services/debt_service.py`: per player, counts distinct counterparties with a **non-zero net balance**. The ledger is double-entry, so grouping by `player_id` captures both directions (debts owed and owing) in one pass. Ordered by count desc → total outstanding amount desc → `player_id` asc (deterministic ties).
- `get_most_outstanding_creditors` (the money-server-gated entry point used by all 4 panel call sites) now **delegates** to it — so callers are untouched. `get_top_net_creditors` stays as a tested utility.
- `_build_most_outstanding_field` renders `{medal} {name} — {count} debts`. `build_guild_debt_embed_pages` drops the `page_num == 0` guard so the field is first on every page.

## Scope preserved

Money-server gate, `limit=3`, the `🏆 Most Outstanding` title, and the public function/param names are unchanged. No schema change, no caller changes.

## Testing

- `get_most_involved_players`: both-direction counting, net-zero exclusion, count-then-amount ordering, amount tiebreak, limit + guild scoping.
- Updated gating test asserts the new `(id, count)` shape on money servers.
- `test_debt_leaderboard.py`: field renders `N debts` (+ `1 debt` singular) and appears on **every** page.
- Full affected suite: **76 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
