### PR TITLE
fix(mpt): don't double-append DFC back face when name is already combined

### DIFF
--- a/helpers/magicprotools_helper.py
+++ b/helpers/magicprotools_helper.py
@@ -85,10 +85,13 @@ class MagicProtoolsHelper:
                     # Get card name
                     card_name = draft_log['carddata'][card_id]['name']
                     
-                    # Handle split/double-faced cards
+                    # Handle split/double-faced cards. Some card data already
+                    # carries the combined "Front // Back" name, so only append
+                    # the back face when the name isn't already combined.
                     if 'back' in draft_log['carddata'][card_id]:
                         back_name = draft_log['carddata'][card_id]['back']['name']
-                        card_name = f"{card_name} // {back_name}"
+                        if back_name and '//' not in card_name:
+                            card_name = f"{card_name} // {back_name}"
                     
                     # Check if this card was picked
                     if idx in picked_indices:
@@ -216,10 +219,12 @@ class MagicProtoolsHelper:
                     card_id = pick['booster'][first_picked_idx]
                     card_name = draft_data['carddata'][card_id]['name']
                     
-                    # Handle split/double-faced cards
+                    # Handle split/double-faced cards. Skip appending when the
+                    # name is already the combined "Front // Back" form.
                     if 'back' in draft_data['carddata'][card_id]:
                         back_name = draft_data['carddata'][card_id]['back']['name']
-                        card_name = f"{card_name} // {back_name}"
+                        if back_name and '//' not in card_name:
+                            card_name = f"{card_name} // {back_name}"
                     
                     pack_first_picks[str(pack_num)] = card_name
             

--- a/tests/test_mpt_deck_view.py
+++ b/tests/test_mpt_deck_view.py
@@ -46,6 +46,40 @@ def test_non_anonymized_output_unchanged():
     assert "--> RealAlice" in out and "    RealBob" in out
 
 
+def _draft_log_with_dfc():
+    return {
+        "sessionID": "s1", "time": 1000, "setRestriction": [],
+        "users": {
+            "dmA": {"userName": "A", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["dfc", "front"], "pick": [0]}]},
+        },
+        "carddata": {
+            # name ALREADY contains the combined "Front // Back" AND has a back face
+            "dfc": {"name": "The Legend of Roku // Avatar Roku",
+                    "back": {"name": "Avatar Roku"}, "set": "tla"},
+            # front-only name with a back face — should be combined exactly once
+            "front": {"name": "Delver of Secrets",
+                      "back": {"name": "Insectile Aberration"}, "set": "isd"},
+        },
+    }
+
+
+def test_dfc_name_not_tripled_when_already_combined():
+    h = _helper()
+    out = h.convert_to_magicprotools_format(_draft_log_with_dfc(), "dmA")
+    # back face must not be appended a second time
+    assert "Avatar Roku // Avatar Roku" not in out
+    assert "The Legend of Roku // Avatar Roku" in out            # present exactly once, combined
+    # a front-only name still gets its back appended once
+    assert "Delver of Secrets // Insectile Aberration" in out
+
+
+def test_pack_first_picks_dfc_name_not_tripled():
+    h = _helper()
+    picks = h.get_pack_first_picks(_draft_log_with_dfc(), "dmA")
+    assert picks["0"] == "The Legend of Roku // Avatar Roku"
+
+
 def _ok_session(json_body):
     resp = MagicMock()
     resp.status = 200


### PR DESCRIPTION
## Bug

Double-faced / flip cards can fail to resolve — e.g. **The Legend of Roku // Avatar Roku** — because `convert_to_magicprotools_format` (and `get_pack_first_picks`) emit a **tripled** name.

Some Draftmancer card data stores the already-combined name in the `name` field:
```
carddata["…"] = { "name": "The Legend of Roku // Avatar Roku", "back": { "name": "Avatar Roku" }, … }
```
The converter appended `"// {back}"` unconditionally:
```python
card_name = carddata[cid]["name"]          # "The Legend of Roku // Avatar Roku"
if "back" in carddata[cid]:
    card_name = f"{card_name} // {back}"    # -> "The Legend of Roku // Avatar Roku // Avatar Roku"
```

### Impact

Anything that consumes the MPT-format output and matches by name breaks on the tripled string. Concretely, the extension's replay viewer keys card data by the full name and looks the card up on Scryfall by its front face; Scryfall returns the card under its real `Front // Back` canonical name, which never matches the tripled key → **no image, card shows as text**. It also produces malformed card names in every MPT upload (draft-log links, trophy-quiz deck views) and in first-pick displays.

## Fix

Only append the back face when the name isn't already combined (`"//" not in card_name`), in both `convert_to_magicprotools_format` and `get_pack_first_picks`. A front-only name still gets its back appended exactly once.

## Testing

New tests in `tests/test_mpt_deck_view.py`:
- `test_dfc_name_not_tripled_when_already_combined` — an already-combined DFC name is not doubled; a front-only name is still combined once.
- `test_pack_first_picks_dfc_name_not_tripled` — same for the first-pick path.

Both fail on the pre-fix code (assert the tripled name) and pass after. `tests/test_mpt_deck_view.py`: **16 passed**. Verified end-to-end against Scryfall: the four DFCs in the affected draft now resolve to their real `Front // Back` cards with images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
