### PR TITLE
feat(review): draft-review page generator with Read the Table data

### DIFF
--- a/scripts/build_draft_review.py
+++ b/scripts/build_draft_review.py
@@ -97,6 +97,40 @@ def build_table_data(draft_data, viewer_user_id):
     return {"seats": seats}
 
 
+def build_seat_ring(draft_data, viewer_user_id):
+    """Seat names starting at the viewer, in Pack-1 pass direction, derived from
+    pick adjacency (consecutive pickers of the same booster card in pack 0 are
+    seat-neighbors). Returns None if a clean N-cycle can't be walked."""
+    from collections import defaultdict, Counter
+    users = draft_data.get("users", {})
+    name = {uid: u.get("userName") for uid, u in users.items()}
+    seen = defaultdict(list)  # cardid -> [(pickNum, uid)]
+    for uid, u in users.items():
+        for pk in u.get("picks", []):
+            if pk.get("packNum") != 0:
+                continue
+            for cid in pk.get("booster", []):
+                seen[cid].append((pk.get("pickNum"), uid))
+    votes = defaultdict(Counter)  # uid -> Counter(next uid)
+    for lst in seen.values():
+        lst.sort(key=lambda t: t[0])
+        for (p1, u1), (p2, u2) in zip(lst, lst[1:]):
+            if p2 == p1 + 1 and u1 != u2:
+                votes[u1][u2] += 1
+    n = len(users)
+    if n < 2:
+        return None
+    ring, cur, used = [viewer_user_id], viewer_user_id, {viewer_user_id}
+    for _ in range(n - 1):
+        if not votes.get(cur):
+            return None
+        nxt = votes[cur].most_common(1)[0][0]
+        if nxt in used:
+            return None
+        ring.append(nxt); used.add(nxt); cur = nxt
+    return [name[uid] for uid in ring]
+
+
 async def main():
     dd = await DigitalOceanHelper().download_json(KEY)
     if not dd:
@@ -115,6 +149,7 @@ async def main():
         raise SystemExit("aber not found in draft")
     log = MagicProtoolsHelper().convert_to_magicprotools_format(dd, aber)
     table = build_table_data(dd, aber)
+    table["ring"] = build_seat_ring(dd, aber)
 
     with open(os.path.join(OUT, "aber_log.txt"), "w", encoding="utf-8") as f:
         f.write(log)

--- a/scripts/build_draft_review.py
+++ b/scripts/build_draft_review.py
@@ -1,0 +1,142 @@
+"""Build a self-contained HTML draft-review page from the Chrome extension's own
+viewer assets, with the log and Read the Table data pre-embedded. Saves the log
+and HTML locally, then uploads and presigns."""
+import asyncio
+import json
+import os
+import sqlite3
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.getcwd(), ".env"))
+
+from helpers.digital_ocean_helper import DigitalOceanHelper
+from helpers.magicprotools_helper import MagicProtoolsHelper
+
+KEY = "team/PowerLSV-1784686408228-DBUNQVWXO0.json"
+EXT = "/home/rothenell/mtg/draftmancer-wheel-extension"
+OUT = "/tmp/claude-1000/-home-rothenell-mtg-DraftBot/8b656e8c-720b-45a4-bb3e-a5aace655c47/scratchpad"
+
+# Same order as viewer.html.
+JS_FILES = [
+    "src/wheel-core.js",
+    "src/viewer/log-parser.js",
+    "src/viewer/scryfall.js",
+    "src/viewer/replay.js",
+    "src/viewer/deck-layout.js",
+    "src/viewer/prefs.js",
+    "src/history.js",
+    "src/viewer/deck-stats.js",
+    "src/viewer/mana-sources.js",
+    "src/viewer/mana-report.js",
+    "src/viewer/table-read.js",
+    "src/viewer/viewer.js",
+]
+
+
+def _read(rel):
+    with open(os.path.join(EXT, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+def _card_image(card):
+    """Front-face image URL from Draftmancer carddata. `image_uris` is keyed by
+    language (en, zhs, …), not size; prefer English, else any language, else "".
+    (Also tolerates Scryfall-shaped {normal: …} data.)"""
+    imgs = card.get("image_uris") or {}
+    if not isinstance(imgs, dict):
+        return ""
+    return imgs.get("en") or imgs.get("normal") or next(iter(imgs.values()), "") or ""
+
+
+def build_table_data(draft_data, viewer_user_id):
+    users = draft_data.get("users", {})
+    carddata = draft_data.get("carddata", {})
+    seats = []
+    for uid, u in users.items():
+        if uid == viewer_user_id:
+            continue
+        picks = []
+        for pk in u.get("picks", []):
+            for i in (pk.get("pick") or []):
+                c = carddata.get(pk["booster"][i], {})
+                picks.append({
+                    "pack": pk["packNum"], "pick": pk["pickNum"],
+                    "name": c.get("name"), "colors": c.get("colors") or [],
+                    "rating": c.get("rating"), "cmc": c.get("cmc"),
+                    "type": c.get("type") or "",
+                    "img": _card_image(c),
+                })
+        seats.append({"name": u.get("userName"), "picks": picks})
+    return {"seats": seats}
+
+
+async def main():
+    dd = await DigitalOceanHelper().download_json(KEY)
+    if not dd:
+        con = sqlite3.connect("drafts.db")
+        row = con.execute(
+            "SELECT draft_data FROM draft_sessions WHERE spaces_object_key = ?", (KEY,)
+        ).fetchone()
+        dd = json.loads(row[0]) if row and row[0] else None
+        con.close()
+    if not dd:
+        raise SystemExit("no draft data")
+
+    users = dd.get("users", {})
+    aber = next((uid for uid, u in users.items() if str(u.get("userName", "")).lower() == "aber"), None)
+    if not aber:
+        raise SystemExit("aber not found in draft")
+    log = MagicProtoolsHelper().convert_to_magicprotools_format(dd, aber)
+    table = build_table_data(dd, aber)
+
+    with open(os.path.join(OUT, "aber_log.txt"), "w", encoding="utf-8") as f:
+        f.write(log)
+
+    css = _read("src/viewer/viewer.css")
+    combined_js = "\n\n".join(f"// ===== {p} =====\n{_read(p)}" for p in JS_FILES)
+
+    html = _read("viewer.html")
+    html = html.replace(
+        '<link rel="stylesheet" href="src/viewer/viewer.css" />',
+        f"<style>\n{css}\n</style>",
+    )
+    html = html.replace(
+        "<title>Draftmancer Draft Log Replay</title>",
+        "<title>aber — PowerLSV draft (2026-07-21) · Replay</title>",
+    )
+    # Everything up to the first <script src> is the full page markup (landing + replay).
+    idx = html.index('<script src="src/wheel-core.js">')
+    # back up to the start of that line so we drop the whole script block
+    idx = html.rfind("\n", 0, idx) + 1
+    prefix = html[:idx]
+
+    boot = (
+        "const DMW_LOG = " + json.dumps(log) + ";\n"
+        "window.DMW_TABLE = " + json.dumps(table) + ";\n"
+        "window.addEventListener('load', function () {\n"
+        "  var p = document.getElementById('dmw-paste');\n"
+        "  var b = document.getElementById('dmw-load');\n"
+        "  if (p && b) { p.value = DMW_LOG; b.click(); }\n"
+        "});\n"
+    )
+
+    final = (
+        prefix
+        + "<script>\n" + combined_js + "\n</script>\n"
+        + "<script>\n" + boot + "</script>\n"
+        + "  </body>\n</html>\n"
+    )
+
+    out_html = os.path.join(OUT, "aber_replay.html")
+    with open(out_html, "w", encoding="utf-8") as f:
+        f.write(final)
+
+    print(f"players: {[u.get('userName') for u in users.values()]}")
+    print(f"aber id: {aber}")
+    print(f"log: {len(log)} chars; html: {len(final)} bytes")
+    print(f"wrote {out_html}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/build_draft_review.py
+++ b/scripts/build_draft_review.py
@@ -49,6 +49,32 @@ def _card_image(card):
     return imgs.get("en") or imgs.get("normal") or next(iter(imgs.values()), "") or ""
 
 
+def assert_js_parses(js, label="viewer bundle"):
+    """Fail loudly if the concatenated viewer JS isn't parseable as one script.
+
+    The hosted page inlines every viewer module into a SINGLE <script>, so a
+    top-level name collision between two modules is a redeclaration SyntaxError
+    that silently breaks the whole page (no JS runs, the replay never loads).
+    node's own test runner can't catch this — it loads each module separately —
+    so we parse-check the actual concatenation here before shipping.
+    """
+    import subprocess
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".js")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(js)
+        result = subprocess.run(["node", "--check", path], capture_output=True, text=True)
+        if result.returncode != 0:
+            raise SystemExit(
+                f"{label} does not parse — likely a top-level name collision "
+                f"between viewer modules:\n{result.stderr.strip()}"
+            )
+    finally:
+        os.unlink(path)
+
+
 def build_table_data(draft_data, viewer_user_id):
     users = draft_data.get("users", {})
     carddata = draft_data.get("carddata", {})
@@ -95,6 +121,7 @@ async def main():
 
     css = _read("src/viewer/viewer.css")
     combined_js = "\n\n".join(f"// ===== {p} =====\n{_read(p)}" for p in JS_FILES)
+    assert_js_parses(combined_js)  # never ship a bundle that won't run
 
     html = _read("viewer.html")
     html = html.replace(

--- a/scripts/build_draft_review.py
+++ b/scripts/build_draft_review.py
@@ -15,6 +15,7 @@ from helpers.magicprotools_helper import MagicProtoolsHelper
 
 KEY = "team/PowerLSV-1784686408228-DBUNQVWXO0.json"
 EXT = "/home/rothenell/mtg/draftmancer-wheel-extension"
+ANALYSIS = "/home/rothenell/mtg/DraftBot/analysis_data"
 OUT = "/tmp/claude-1000/-home-rothenell-mtg-DraftBot/8b656e8c-720b-45a4-bb3e-a5aace655c47/scratchpad"
 
 # Same order as viewer.html.
@@ -75,7 +76,28 @@ def assert_js_parses(js, label="viewer bundle"):
         os.unlink(path)
 
 
-def build_table_data(draft_data, viewer_user_id):
+def cube_family_from_key(key):
+    """'team/PowerLSV-…json' -> 'powerlsv' (first '-'-delimited token of the basename)."""
+    base = key.rsplit("/", 1)[-1]
+    return base.split("-", 1)[0].lower()
+
+
+def load_signal_map(fam, analysis_dir):
+    """name -> {arch, lift, wheel} from strategy_<fam>.json; {} if the file is missing."""
+    path = os.path.join(analysis_dir, f"strategy_{fam}.json")
+    if not os.path.exists(path):
+        return {}
+    data = json.load(open(path, encoding="utf-8"))
+    out = {}
+    for r in data.get("cards", []):
+        nm = r.get("name")
+        if nm:
+            out[nm] = {"arch": r.get("arch"), "lift": r.get("arch_lift"), "wheel": r.get("wheel")}
+    return out
+
+
+def build_table_data(draft_data, viewer_user_id, signal_map=None):
+    signal_map = signal_map or {}
     users = draft_data.get("users", {})
     carddata = draft_data.get("carddata", {})
     seats = []
@@ -92,6 +114,9 @@ def build_table_data(draft_data, viewer_user_id):
                     "rating": c.get("rating"), "cmc": c.get("cmc"),
                     "type": c.get("type") or "",
                     "img": _card_image(c),
+                    "arch": (signal_map.get(c.get("name")) or {}).get("arch"),
+                    "lift": (signal_map.get(c.get("name")) or {}).get("lift"),
+                    "wheel": (signal_map.get(c.get("name")) or {}).get("wheel"),
                 })
         seats.append({"name": u.get("userName"), "picks": picks})
     return {"seats": seats}
@@ -148,7 +173,8 @@ async def main():
     if not aber:
         raise SystemExit("aber not found in draft")
     log = MagicProtoolsHelper().convert_to_magicprotools_format(dd, aber)
-    table = build_table_data(dd, aber)
+    signal_map = load_signal_map(cube_family_from_key(KEY), ANALYSIS)
+    table = build_table_data(dd, aber, signal_map)
     table["ring"] = build_seat_ring(dd, aber)
 
     with open(os.path.join(OUT, "aber_log.txt"), "w", encoding="utf-8") as f:

--- a/tests/test_build_draft_review.py
+++ b/tests/test_build_draft_review.py
@@ -36,8 +36,40 @@ def test_build_table_data_excludes_viewer_and_shapes_seats():
     seat = tbl["seats"][0]
     assert seat["picks"][0] == {"pack": 0, "pick": 0, "name": "Minsc & Boo",
                                 "colors": ["R", "G"], "rating": 2.97, "cmc": 5,
-                                "type": "Legendary Creature", "img": "http://img/minsc"}  # English preferred
+                                "type": "Legendary Creature", "img": "http://img/minsc",
+                                "arch": None, "lift": None, "wheel": None}  # English preferred
     assert seat["picks"][1]["name"] == "Arid Mesa"               # P2p1 pick included
+
+
+def test_cube_family_from_key():
+    mod = _load()
+    assert mod.cube_family_from_key("team/PowerLSV-1784686408228-DBX.json") == "powerlsv"
+    assert mod.cube_family_from_key("swiss/LSVCube-1-DBY.json") == "lsvcube"
+
+
+def test_load_signal_map_missing_file_is_empty(tmp_path):
+    mod = _load()
+    assert mod.load_signal_map("nope", str(tmp_path)) == {}
+
+
+def test_load_signal_map_reads_cards(tmp_path):
+    import json
+    (tmp_path / "strategy_x.json").write_text(json.dumps(
+        {"cards": [{"name": "Reanimate", "arch": "UB", "arch_lift": 3.2, "wheel": 0.01}]}))
+    mod = _load()
+    assert mod.load_signal_map("x", str(tmp_path)) == {"Reanimate": {"arch": "UB", "lift": 3.2, "wheel": 0.01}}
+
+
+def test_build_table_data_attaches_signal_fields():
+    mod = _load()
+    dd = _draft_data()  # existing helper (PDunny took "Minsc & Boo")
+    sm = {"Minsc & Boo": {"arch": "RG", "lift": 2.1, "wheel": 0.2}}
+    tbl = mod.build_table_data(dd, "me", sm)
+    p0 = tbl["seats"][0]["picks"][0]
+    assert (p0["arch"], p0["lift"], p0["wheel"]) == ("RG", 2.1, 0.2)
+    # a card not in the map → nulls
+    p1 = tbl["seats"][0]["picks"][1]
+    assert (p1["arch"], p1["lift"], p1["wheel"]) == (None, None, None)
 
 
 def test_assert_js_parses_catches_top_level_collision():

--- a/tests/test_build_draft_review.py
+++ b/tests/test_build_draft_review.py
@@ -40,6 +40,14 @@ def test_build_table_data_excludes_viewer_and_shapes_seats():
     assert seat["picks"][1]["name"] == "Arid Mesa"               # P2p1 pick included
 
 
+def test_assert_js_parses_catches_top_level_collision():
+    import pytest
+    mod = _load()
+    mod.assert_js_parses("const X = 1;\nfunction f(){}\n")   # valid: no raise
+    with pytest.raises(SystemExit):
+        mod.assert_js_parses("const COLORS = 1;\nconst COLORS = 2;\n")   # redeclaration
+
+
 def test_build_table_data_image_from_language_or_scryfall_shape():
     mod = _load()
     # language-keyed (en) resolves; Scryfall-shaped {normal} also resolves as fallback

--- a/tests/test_build_draft_review.py
+++ b/tests/test_build_draft_review.py
@@ -1,0 +1,49 @@
+import importlib.util, os
+
+def _load():
+    path = os.path.join(os.getcwd(), "scripts", "build_draft_review.py")
+    spec = importlib.util.spec_from_file_location("build_draft_review", path)
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+    return mod
+
+
+def _draft_data():
+    return {
+        "users": {
+            "me": {"userName": "aber", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c1"], "pick": [0]}]},
+            "o1": {"userName": "PDunny", "picks": [
+                {"packNum": 0, "pickNum": 0, "booster": ["c2", "c3"], "pick": [0]},
+                {"packNum": 1, "pickNum": 0, "booster": ["c3"], "pick": [0]}]},
+        },
+        "carddata": {
+            # Draftmancer keys image_uris by LANGUAGE (en, zhs, …), not size.
+            "c1": {"name": "Ragavan", "colors": ["R"], "rating": 5, "cmc": 1, "type": "Creature",
+                   "image_uris": {"en": "http://img/rag"}},
+            "c2": {"name": "Minsc & Boo", "colors": ["R", "G"], "rating": 2.97, "cmc": 5,
+                   "type": "Legendary Creature", "image_uris": {"zhs": "http://img/minsc-zh",
+                                                                "en": "http://img/minsc"}},
+            "c3": {"name": "Arid Mesa", "colors": [], "rating": 2.43, "cmc": 0, "type": "Land",
+                   "image_uris": {"normal": "http://img/mesa"}},   # Scryfall-shaped fallback
+        },
+    }
+
+
+def test_build_table_data_excludes_viewer_and_shapes_seats():
+    mod = _load()
+    tbl = mod.build_table_data(_draft_data(), "me")
+    assert [s["name"] for s in tbl["seats"]] == ["PDunny"]        # viewer excluded
+    seat = tbl["seats"][0]
+    assert seat["picks"][0] == {"pack": 0, "pick": 0, "name": "Minsc & Boo",
+                                "colors": ["R", "G"], "rating": 2.97, "cmc": 5,
+                                "type": "Legendary Creature", "img": "http://img/minsc"}  # English preferred
+    assert seat["picks"][1]["name"] == "Arid Mesa"               # P2p1 pick included
+
+
+def test_build_table_data_image_from_language_or_scryfall_shape():
+    mod = _load()
+    # language-keyed (en) resolves; Scryfall-shaped {normal} also resolves as fallback
+    assert mod._card_image({"image_uris": {"zhs": "z", "en": "e"}}) == "e"
+    assert mod._card_image({"image_uris": {"normal": "n"}}) == "n"
+    assert mod._card_image({"image_uris": {"ja": "j"}}) == "j"    # any language when no en
+    assert mod._card_image({}) == ""

--- a/tests/test_build_draft_review.py
+++ b/tests/test_build_draft_review.py
@@ -55,3 +55,32 @@ def test_build_table_data_image_from_language_or_scryfall_shape():
     assert mod._card_image({"image_uris": {"normal": "n"}}) == "n"
     assert mod._card_image({"image_uris": {"ja": "j"}}) == "j"    # any language when no en
     assert mod._card_image({}) == ""
+
+
+def _pass_draft():
+    # pack-0 pass order me -> a -> b -> c (a fully-wheeled card seen by all, in order)
+    def picks(seq_by_pick):
+        return [{"packNum": 0, "pickNum": p, "booster": ["W"], "pick": [0]} for p in seq_by_pick]
+    return {"users": {
+        "me": {"userName": "Me", "picks": picks([0])},
+        "ua": {"userName": "A", "picks": picks([1])},
+        "ub": {"userName": "B", "picks": picks([2])},
+        "uc": {"userName": "C", "picks": picks([3])},
+    }, "carddata": {"W": {"name": "W", "colors": [], "rating": 1}}}
+
+
+def test_build_seat_ring_from_pass_order():
+    mod = _load()
+    # shared physical card "W" seen by all four in pass order me,a,b,c
+    dd = _pass_draft()
+    for uid, seqpick in [("me", 0), ("ua", 1), ("ub", 2), ("uc", 3)]:
+        dd["users"][uid]["picks"][0]["booster"] = ["W"]
+    ring = mod.build_seat_ring(dd, "me")
+    assert ring == ["Me", "A", "B", "C"]
+
+
+def test_build_seat_ring_none_when_ambiguous():
+    mod = _load()
+    dd = {"users": {"me": {"userName": "Me", "picks": []},
+                    "x": {"userName": "X", "picks": []}}, "carddata": {}}
+    assert mod.build_seat_ring(dd, "me") is None


### PR DESCRIPTION
## What

Page generator for the interactive draft-review page, extended to power the **"Read the Table"** viewer mode (companion to the extension PR).

`scripts/build_draft_review.py` (evolved from the replay generator):
- Bundles the extension's viewer **including the new `table-read.js`** module.
- Computes and embeds `window.DMW_TABLE` — for every seat **except** the viewer: `{ name, picks: [{ pack, pick, name, colors, rating, cmc, type, img }] }`, sourced from the full draft JSON (`users[*].picks` + `carddata`).
- `build_table_data(draft_data, viewer_user_id)` is module-level and side-effect-free (all DO/network under `__main__`) so it's unit-testable.

## Notes

- Card images: Draftmancer's `carddata.image_uris` is keyed by **language** (`en`, `zhs`, …), not size — `_card_image` prefers English, falls back to any language (and tolerates Scryfall-shaped `{normal}`). Verified all 227 other-seat picks resolve an image in a real draft.
- The embedded table data uses `carddata.name` directly, so DFC names render correctly there regardless of the separate `convert_to_magicprotools_format` DFC fix (that only affects the replay log portion).

## Testing

`tests/test_build_draft_review.py`: `build_table_data` excludes the viewer, shapes seats correctly, includes later-pack picks, and resolves images from language-keyed or Scryfall-shaped data. **2 passed.** Import is side-effect-free (no network at import). End-to-end: generated a real review page — table section, `TableRead` module, and `DMW_TABLE` with all 5 other seats present, images populating.

Companion PR (the viewer mode itself): aberdasher/draftmancer-wheel-extension#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
