### PR TITLE
fix(premade): map seating to sign_ups by user_id, not display name

### DIFF
--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -100,11 +100,13 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                 if session.session_type != "swiss":
                     sign_ups_list = list(session.sign_ups.keys())
                     if session.session_type == "premade":
-                        seating_order = await generate_seating_order(bot, session)
-
-                        # Update sign_ups to match seating order
-                        name_to_id = {name: user_id for user_id, name in session.sign_ups.items()}
-                        new_sign_ups = {name_to_id[name]: name for name in seating_order}
+                        # (user_id, decorated_display_name) pairs. Reorder sign_ups by
+                        # the user_id and keep the RAW stored names as values (the
+                        # decorated display name is only for the embed) — mapping by
+                        # name would KeyError on icon-decorated / markdown-escaped names.
+                        seating_pairs = await generate_seating_order(bot, session)
+                        new_sign_ups = {user_id: session.sign_ups[user_id] for user_id, _ in seating_pairs}
+                        seating_order = [name for _, name in seating_pairs]
 
                         await db_session.execute(update(DraftSession)
                                             .where(DraftSession.session_id == session.session_id)

--- a/tests/test_create_and_display_teams.py
+++ b/tests/test_create_and_display_teams.py
@@ -1,40 +1,38 @@
-"""TDD test for the team_creator.py UnboundLocalError bug.
+"""Tests for premade create_and_display_teams.
 
-When a premade (or any non-random/test/staked/winston) draft reaches
-create_and_display_teams, the function crashes at line 129/133 because
-`stake_info_by_player` is only initialized inside the conditional block at
-line 71. The function's broad `except Exception` swallows it and reports
-"An error occurred while creating teams" — leaving the draft stuck.
-
-Fired ≥16 times in prod across guild 1399789864961970337 and guild
-336345350535118849 — both are non-money servers that run premade drafts.
+Covers two prod regressions:
+1. UnboundLocalError on `stake_info_by_player` (initialized only inside a
+   conditional block) — premade drafts got stuck.
+2. KeyError in the seating name->id reverse lookup: generate_seating_order
+   returns DECORATED/escaped display names (role icons, markdown-escaped), which
+   after PR #332 no longer match the RAW names stored in sign_ups. The mapping
+   must use the user_id, not a name reverse-lookup (seen in prod today on
+   '👑 AlicanGokturk' and 'The\\_Tank').
 """
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-@pytest.mark.asyncio
-async def test_create_and_display_teams_does_not_raise_unbound_local_for_premade():
-    """For a premade draft, the function must complete without hitting
-    UnboundLocalError on `stake_info_by_player`."""
-    from services import team_creator
-
-    # 6-player premade with teams pre-assigned (matches the prod scenario)
-    sign_ups = {
-        "111": "PlayerA1", "222": "PlayerA2", "333": "PlayerA3",
-        "444": "PlayerB1", "555": "PlayerB2", "666": "PlayerB3",
-    }
+def _premade_session(sign_ups):
     session = MagicMock()
     session.session_type = "premade"
     session.session_id = "fake-session-123"
-    session.sign_ups = sign_ups
-    session.team_a = ["111", "222", "333"]
-    session.team_b = ["444", "555", "666"]
+    session.sign_ups = dict(sign_ups)
+    ids = list(sign_ups.keys())
+    session.team_a = ids[:3]
+    session.team_b = ids[3:]
     session.tracked_draft = False
     session.premade_match_id = None
+    return session
 
-    # Mock the DB plumbing: AsyncSessionLocal() → db_session, db_session.begin() → tx
+
+async def _run_premade(sign_ups, seating_return):
+    """Run create_and_display_teams for a premade draft with generate_seating_order
+    mocked to return `seating_return`. Returns (result, mock_logger, session)."""
+    from services import team_creator
+
+    session = _premade_session(sign_ups)
     select_result = MagicMock()
     select_result.scalars.return_value.first.return_value = session
 
@@ -45,7 +43,6 @@ async def test_create_and_display_teams_does_not_raise_unbound_local_for_premade
     begin_ctx.__aenter__ = AsyncMock(return_value=db_session_inner)
     begin_ctx.__aexit__ = AsyncMock(return_value=None)
     db_session_inner.begin = MagicMock(return_value=begin_ctx)
-
     session_ctx = MagicMock()
     session_ctx.__aenter__ = AsyncMock(return_value=db_session_inner)
     session_ctx.__aexit__ = AsyncMock(return_value=None)
@@ -64,12 +61,10 @@ async def test_create_and_display_teams_does_not_raise_unbound_local_for_premade
     persistent_view = MagicMock()
     persistent_view.session_type = "premade"
     persistent_view.children = []
-
     bot = MagicMock()
-    seating_order = list(sign_ups.values())
 
     with patch.object(team_creator, "AsyncSessionLocal", MagicMock(return_value=session_ctx)), \
-         patch.object(team_creator, "generate_seating_order", AsyncMock(return_value=seating_order)), \
+         patch.object(team_creator, "generate_seating_order", AsyncMock(return_value=seating_return)), \
          patch.object(team_creator, "_create_teams_embed", AsyncMock(return_value=MagicMock())), \
          patch.object(team_creator, "_create_channel_announcement_embed", AsyncMock(return_value=MagicMock())), \
          patch.object(team_creator, "_update_draft_manager", AsyncMock()), \
@@ -79,15 +74,47 @@ async def test_create_and_display_teams_does_not_raise_unbound_local_for_premade
         result = await team_creator.create_and_display_teams(
             bot, "fake-session-123", interaction, persistent_view,
         )
+    return result, mock_logger, session
 
-    # The function's broad `except Exception` swallows the UnboundLocalError
-    # and routes it to logger.exception. Assert no such call happened.
-    logged_errors = [str(call) for call in mock_logger.exception.call_args_list]
-    assert not any("stake_info_by_player" in msg for msg in logged_errors), (
-        "create_and_display_teams hit UnboundLocalError on stake_info_by_player "
-        f"for premade drafts: {logged_errors}"
-    )
-    assert result is True, (
-        "create_and_display_teams returned False, meaning the broad except caught "
-        "an exception — likely the stake_info_by_player UnboundLocalError"
-    )
+
+@pytest.mark.asyncio
+async def test_create_and_display_teams_does_not_raise_unbound_local_for_premade():
+    """For a premade draft, the function must complete without hitting
+    UnboundLocalError on `stake_info_by_player`."""
+    sign_ups = {
+        "111": "PlayerA1", "222": "PlayerA2", "333": "PlayerA3",
+        "444": "PlayerB1", "555": "PlayerB2", "666": "PlayerB3",
+    }
+    seating = [(uid, nm) for uid, nm in sign_ups.items()]
+    result, mock_logger, _ = await _run_premade(sign_ups, seating)
+
+    logged = [str(c) for c in mock_logger.exception.call_args_list]
+    assert not any("stake_info_by_player" in m for m in logged), logged
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_premade_seating_maps_by_id_not_decorated_name():
+    """generate_seating_order returns (user_id, decorated_name) pairs whose names
+    differ from the RAW sign_ups values (crown icon / markdown-escaped underscore).
+    Team creation must map by user_id and not KeyError, and must keep the RAW names
+    in sign_ups (preserving the PR #332 invariant), reordered to the seating."""
+    sign_ups = {  # RAW names, as stored post-#332
+        "111": "AlicanGokturk", "222": "The_Tank", "333": "PlayerA3",
+        "444": "PlayerB1", "555": "PlayerB2", "666": "PlayerB3",
+    }
+    seating = [  # (id, DECORATED name) — names NOT present as sign_ups values
+        ("111", "👑 AlicanGokturk"), ("444", "PlayerB1"),
+        ("222", "The\\_Tank"), ("555", "PlayerB2"),
+        ("333", "PlayerA3"), ("666", "PlayerB3"),
+    ]
+    result, mock_logger, session = await _run_premade(sign_ups, seating)
+
+    logged = [str(c) for c in mock_logger.exception.call_args_list]
+    assert not any("KeyError" in m or "AlicanGokturk" in m for m in logged), (
+        f"premade seating crashed on a decorated name: {logged}")
+    assert result is True
+    # sign_ups reordered by seating, keyed by id, values still the RAW names
+    assert set(session.sign_ups.keys()) == set(sign_ups)
+    assert all(session.sign_ups[uid] == sign_ups[uid] for uid in sign_ups)
+    assert list(session.sign_ups.keys()) == [uid for uid, _ in seating]

--- a/tests/test_premade_test_users.py
+++ b/tests/test_premade_test_users.py
@@ -82,7 +82,12 @@ async def test_seating_order_uses_sign_up_names_for_non_members():
     with patch.object(utils, "get_display_name", lambda member, g: member.display_name):
         order = await utils.generate_seating_order(bot, draft_session)
 
+    # generate_seating_order returns (user_id, display_name) pairs
     assert len(order) == 4, f"test users were dropped from seating: {order}"
-    assert "[TEST] Alpha User 2" in order
-    assert "[TEST] Bravo User 2" in order
-    assert "Member111" in order and "Member222" in order
+    ids = [uid for uid, _ in order]
+    names = [name for _, name in order]
+    assert "[TEST] Alpha User 2" in names
+    assert "[TEST] Bravo User 2" in names
+    assert "Member111" in names and "Member222" in names
+    # test users keep their id even though they're not guild members
+    assert "900000000000000001" in ids and "900000000000000002" in ids

--- a/utils.py
+++ b/utils.py
@@ -233,12 +233,18 @@ async def generate_seating_order(bot, draft_session, command_type=None):
             return get_display_name(member, guild)
         return (draft_session.sign_ups or {}).get(user_id, "Unknown User")
 
+    # Return (user_id, display_name) pairs. Callers reorder sign_ups by the
+    # user_id (never by the display name) — get_display_name adds role icons and
+    # markdown-escapes, so the decorated name doesn't match the raw sign_ups name
+    # and a name-keyed reverse lookup would KeyError.
     seating_order = []
     for i in range(max(len(team_a_pairs), len(team_b_pairs))):
         if i < len(team_a_pairs):
-            seating_order.append(display(*team_a_pairs[i]))
+            user_id, member = team_a_pairs[i]
+            seating_order.append((user_id, display(user_id, member)))
         if i < len(team_b_pairs):
-            seating_order.append(display(*team_b_pairs[i]))
+            user_id, member = team_b_pairs[i]
+            seating_order.append((user_id, display(user_id, member)))
 
     return seating_order
 


### PR DESCRIPTION
## Bug

Premade team creation crashed today (session `190190161458364416-1784903833`, 10:39–10:41, 4×) with a `KeyError` on player names `'👑 AlicanGokturk'` and `'The\_Tank'` — the draft got stuck.

`create_and_display_teams` (premade branch) reordered `sign_ups` by reverse-mapping the seating back to user-ids **by name**:

```python
seating_order = await generate_seating_order(bot, session)   # display names
name_to_id = {name: user_id for user_id, name in session.sign_ups.items()}
new_sign_ups = {name_to_id[name]: name for name in seating_order}   # ← KeyError
```

`generate_seating_order` builds names via `get_display_name()`, which **prepends role icons** (`👑`) and **markdown-escapes** (`The_Tank` → `The\_Tank`). Since **PR #332** switched premade sign-ups to store the **raw** name, the decorated seating name is no longer a key in `name_to_id` → `KeyError`.

It's **premade-only** (every other draft type reorders by `user_id` directly) and stayed latent until a premade included a player whose current display name actually differs from the raw stored name (a crown role, an escapable char).

## Fix

`generate_seating_order` now returns `(user_id, display_name)` pairs. The caller reorders `sign_ups` by **`user_id`** and keeps the raw stored names as values (the decorated name is only for the seating embed):

```python
seating_pairs = await generate_seating_order(bot, session)
new_sign_ups = {user_id: session.sign_ups[user_id] for user_id, _ in seating_pairs}
seating_order = [name for _, name in seating_pairs]
```

This removes the raw-vs-decorated name invariant entirely — icons, markdown-escaping, or a nickname changing between sign-up and fire can't break it again. `sign_ups` stays raw (preserving #332).

## Testing

- New `test_premade_seating_maps_by_id_not_decorated_name`: reproduces the prod scenario (`👑 AlicanGokturk` / `The\_Tank` seating names that aren't raw sign_ups values) — fails on the old code (KeyError → aborts), passes after; also asserts sign_ups stays keyed by id, raw-valued, and seating-ordered.
- Updated the existing premade test + `test_premade_test_users` for the new `(id, name)` return.
- `tests/test_create_and_display_teams.py` + `tests/test_premade_test_users.py`: **8 passed.** Only consumer of `generate_seating_order` is this one call site (verified); other draft types unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
