### PR TITLE
refactor(seating): extract reorder_sign_ups helper (DRY premade + swiss)

### DIFF
--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -120,8 +120,8 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                 else:
                     sign_ups_list = list(session.sign_ups.keys())
                     random.shuffle(sign_ups_list)
-                    seating_order = [session.sign_ups[user_id] for user_id in sign_ups_list]
                     new_sign_ups = reorder_sign_ups(session.sign_ups, sign_ups_list)
+                    seating_order = list(new_sign_ups.values())
                     await db_session.execute(update(DraftSession)
                                         .where(DraftSession.session_id == session.session_id)
                                         .values(sign_ups=new_sign_ups))

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -14,7 +14,7 @@ from sqlalchemy import update, select
 
 from session import AsyncSessionLocal, DraftSession, StakeInfo
 from models.draft_session import DraftSession as DraftSessionModel
-from utils import split_into_teams, generate_seating_order, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
+from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
 from services.draft_setup_manager import DraftSetupManager
 from services.state_manager import state_manager
 from services.stake_service import calculate_and_store_stakes
@@ -105,7 +105,7 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                         # decorated display name is only for the embed) — mapping by
                         # name would KeyError on icon-decorated / markdown-escaped names.
                         seating_pairs = await generate_seating_order(bot, session)
-                        new_sign_ups = {user_id: session.sign_ups[user_id] for user_id, _ in seating_pairs}
+                        new_sign_ups = reorder_sign_ups(session.sign_ups, [user_id for user_id, _ in seating_pairs])
                         seating_order = [name for _, name in seating_pairs]
 
                         await db_session.execute(update(DraftSession)
@@ -121,7 +121,7 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                     sign_ups_list = list(session.sign_ups.keys())
                     random.shuffle(sign_ups_list)
                     seating_order = [session.sign_ups[user_id] for user_id in sign_ups_list]
-                    new_sign_ups = {user_id: session.sign_ups[user_id] for user_id in sign_ups_list}
+                    new_sign_ups = reorder_sign_ups(session.sign_ups, sign_ups_list)
                     await db_session.execute(update(DraftSession)
                                         .where(DraftSession.session_id == session.session_id)
                                         .values(sign_ups=new_sign_ups))

--- a/tests/test_reorder_sign_ups.py
+++ b/tests/test_reorder_sign_ups.py
@@ -1,0 +1,27 @@
+"""Unit tests for reorder_sign_ups — the shared 'reorder sign_ups by an ordered
+id list' helper used by the premade and swiss seating paths. It reorders by user
+id (never by display name), which is what keeps decorated/escaped names from
+breaking the mapping (see PR #349)."""
+
+from utils import reorder_sign_ups
+
+
+def test_reorder_sign_ups_orders_by_id_and_preserves_names():
+    sign_ups = {"1": "Alice", "2": "Bob", "3": "Carol"}
+    out = reorder_sign_ups(sign_ups, ["3", "1", "2"])
+    assert list(out.keys()) == ["3", "1", "2"]      # reordered to the id list
+    assert out == {"3": "Carol", "1": "Alice", "2": "Bob"}   # names unchanged
+
+
+def test_reorder_sign_ups_returns_a_new_dict():
+    sign_ups = {"1": "Alice"}
+    out = reorder_sign_ups(sign_ups, ["1"])
+    assert out is not sign_ups
+
+
+def test_reorder_sign_ups_keys_by_id_even_when_names_collide():
+    # two players with the same display name must not collapse — keyed by id
+    sign_ups = {"1": "Sam", "2": "Sam"}
+    out = reorder_sign_ups(sign_ups, ["2", "1"])
+    assert list(out.keys()) == ["2", "1"]
+    assert len(out) == 2

--- a/utils.py
+++ b/utils.py
@@ -217,6 +217,17 @@ async def split_into_teams(bot, draft_session_id):
                 else:
                     print(f"No sign-ups found for session {draft_session_id}")
 
+def reorder_sign_ups(sign_ups, ordered_ids):
+    """Return a new sign_ups dict reordered to `ordered_ids`, keyed by user id
+    with the stored names unchanged.
+
+    Reordering by user id (never by display name) is what keeps decorated or
+    markdown-escaped display names from breaking the mapping — see PR #349. Used
+    by both the premade and swiss seating paths.
+    """
+    return {user_id: sign_ups[user_id] for user_id in ordered_ids}
+
+
 async def generate_seating_order(bot, draft_session, command_type=None):
     guild = bot.get_guild(int(draft_session.guild_id))
 


### PR DESCRIPTION
## What

Follow-up to #349. The **premade** and **swiss** seating paths in `create_and_display_teams` both reorder `sign_ups` by an ordered id list with the identical comprehension:

```python
{user_id: session.sign_ups[user_id] for user_id in <ordered ids>}
```

Extract it into `reorder_sign_ups(sign_ups, ordered_ids)` (in `utils.py`) and use it at both sites.

## Why

Not just tidiness: it puts the **"reorder by user id, never by display name"** invariant in **one place** — the very invariant whose violation caused the premade `KeyError` in #349 (decorated/markdown-escaped names not matching raw `sign_ups`). Consolidating makes it harder to reintroduce that mistake.

Random/staked are deliberately **not** folded in — they don't reorder `sign_ups` at all, so forcing them into the abstraction would be over-DRYing.

## Testing

- New `tests/test_reorder_sign_ups.py`: orders by the id list, preserves names, returns a new dict, and (the point) keys by id so two players with the same display name don't collapse.
- Existing seating tests unchanged and green: `test_reorder_sign_ups` + `test_create_and_display_teams` + `test_premade_test_users` → **11 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M93PtX5TcUdgYhG93JeRvZ
