### PR TITLE
fix(seating): don't seat premade team members who left sign_ups

### DIFF
--- a/tests/test_premade_test_users.py
+++ b/tests/test_premade_test_users.py
@@ -91,3 +91,33 @@ async def test_seating_order_uses_sign_up_names_for_non_members():
     assert "Member111" in names and "Member222" in names
     # test users keep their id even though they're not guild members
     assert "900000000000000001" in ids and "900000000000000002" in ids
+
+
+# ---- generate_seating_order excludes stale team members (Codex #1) ---------------
+
+@pytest.mark.asyncio
+async def test_seating_order_excludes_team_ids_removed_from_sign_ups():
+    """A player removed from sign_ups but still left in team_a/team_b (the leave
+    flow doesn't clean the team lists) must not be seated — otherwise the caller's
+    reorder_sign_ups does sign_ups[stale_id] and KeyErrors at premade fire."""
+    import utils
+
+    draft_session = MagicMock()
+    draft_session.guild_id = "1"
+    draft_session.team_a = ["111", "999"]   # 999 left the draft but stayed in team_a
+    draft_session.team_b = ["222"]
+    draft_session.sign_ups = {"111": "A", "222": "B"}   # 999 is gone
+
+    member = MagicMock()
+    member.display_name = "Ghost"
+    guild = MagicMock()
+    guild.get_member.return_value = member
+    bot = MagicMock()
+    bot.get_guild.return_value = guild
+
+    with patch.object(utils, "get_display_name", lambda m, g: m.display_name):
+        order = await utils.generate_seating_order(bot, draft_session)
+
+    ids = [uid for uid, _ in order]
+    assert "999" not in ids                              # stale id not seated
+    assert set(ids) <= set(draft_session.sign_ups)       # every seated id is in sign_ups

--- a/utils.py
+++ b/utils.py
@@ -231,10 +231,15 @@ def reorder_sign_ups(sign_ups, ordered_ids):
 async def generate_seating_order(bot, draft_session, command_type=None):
     guild = bot.get_guild(int(draft_session.guild_id))
 
+    # Only seat team members who are still signed up. A player who leaves is
+    # removed from sign_ups but may remain in team_a/team_b; seating a stale id
+    # would then KeyError in the caller's reorder_sign_ups (sign_ups[stale_id]).
+    sign_ups = draft_session.sign_ups or {}
+
     # Pair each user id with its member object; test users resolve to None and
     # fall back to their sign_ups display name instead of being dropped.
-    team_a_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_a]
-    team_b_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_b]
+    team_a_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_a if user_id in sign_ups]
+    team_b_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_b if user_id in sign_ups]
 
     random.shuffle(team_a_pairs)
     random.shuffle(team_b_pairs)


### PR DESCRIPTION
## Problem
Premade drafts crashed on team creation (prod: `KeyError` on `'👑 AlicanGokturk'` / `'The\_Tank'`). Root cause of *this* branch: when a player leaves a premade draft, the leave handlers pop them from `sign_ups` but never remove them from the `team_a`/`team_b` JSON columns. `generate_seating_order` then dereferences `sign_ups[stale_id]` → `KeyError`.

## Fix
`generate_seating_order` now filters `team_a`/`team_b` to ids still present in `sign_ups` before building the seating. This is a robust catch-all: it covers every leave path and any pre-existing bad data, without touching each leave handler.

## Test
`tests/test_premade_test_users.py::test_seating_order_excludes_team_ids_removed_from_sign_ups` — a stale team id is not seated, and every seated id ⊆ `sign_ups`.

Part of a 4-PR stack fixing the premade seating region (Codex review). Stacked on #350.
