### PR TITLE
fix(seating): resolve duplicate display names to distinct Draftmancer ids

### DIFF
--- a/helpers/seating.py
+++ b/helpers/seating.py
@@ -1,0 +1,31 @@
+"""Pure seating helpers, kept dependency-free so they're fast to import and test
+(the DraftSetupManager module that uses this is heavy to import)."""
+from collections import defaultdict, deque
+
+
+def resolve_seating_ids(session_users, desired_username_order, bot_id):
+    """Map a desired username order to Draftmancer userIDs, robust to duplicate
+    display names.
+
+    Each occurrence of a name consumes a DISTINCT userID (in session order),
+    instead of a name->id dict that collapses duplicates — which would seat one
+    userID twice and omit the other same-named player. The bot is excluded.
+
+    Returns (user_id_order, missing_users).
+    """
+    by_name = defaultdict(deque)
+    for user in session_users:
+        user_id = user.get("userID")
+        username = user.get("userName")
+        if user_id != bot_id and username:
+            by_name[username].append(user_id)
+
+    user_id_order = []
+    missing_users = []
+    for username in desired_username_order:
+        queue = by_name.get(username)
+        if queue:
+            user_id_order.append(queue.popleft())
+        else:
+            missing_users.append(username)
+    return user_id_order, missing_users

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -19,6 +19,7 @@ from session import AsyncSessionLocal
 from sqlalchemy import select
 from helpers.digital_ocean_helper import DigitalOceanHelper
 from helpers.magicprotools_helper import MagicProtoolsHelper
+from helpers.seating import resolve_seating_ids
 from notification_service import send_ready_check_dms
 from services.draft_socket_client import DraftSocketClient
 from services.draft_log_store import post_team_logs
@@ -1742,27 +1743,15 @@ class DraftSetupManager:
                     self.logger.info(f"Found DraftBot ID: {bot_id} (will be excluded from seating)")
                     break
             
-            # Create mapping of usernames to userIDs, excluding the bot
-            username_to_userid = {}
-            for user in self.session_users:
-                user_id = user.get('userID')
-                username = user.get('userName')
-                
-                if user_id != bot_id and username:  # Exclude bot from mapping
-                    username_to_userid[username] = user_id
-                    self.logger.debug(f"Mapped {username} to {user_id}")
-            
-            # Convert the username order to userID order
-            user_id_order = []
-            missing_users = []
-            
-            for username in desired_username_order:
-                if username in username_to_userid:
-                    user_id_order.append(username_to_userid[username])
-                    self.logger.debug(f"Added {username} to seating order")
-                else:
-                    missing_users.append(username)
-                    self.logger.warning(f"Username '{username}' not found in session")
+            # Map the desired username order to userIDs. Each occurrence of a
+            # duplicate display name consumes a DISTINCT userID — a plain name->id
+            # dict would collapse duplicates, seating one userID twice and dropping
+            # the other same-named player.
+            user_id_order, missing_users = resolve_seating_ids(
+                self.session_users, desired_username_order, bot_id
+            )
+            for username in missing_users:
+                self.logger.warning(f"Username '{username}' not found in session")
             
             if not user_id_order:
                 self.logger.error("No valid userIDs found for the provided usernames")

--- a/tests/test_resolve_seating_ids.py
+++ b/tests/test_resolve_seating_ids.py
@@ -1,0 +1,40 @@
+"""Unit tests for resolve_seating_ids — mapping a desired username order to
+Draftmancer userIDs. The old name->id dict collapsed duplicate display names
+(one userID seated twice, the other player omitted); this maps each occurrence
+of a name to a DISTINCT userID (Codex review finding #2)."""
+
+from helpers.seating import resolve_seating_ids
+
+
+def _u(uid, name):
+    return {"userID": uid, "userName": name}
+
+
+def test_resolve_seating_ids_basic_order():
+    users = [_u("a", "Alice"), _u("b", "Bob"), _u("bot", "DraftBot")]
+    order, missing = resolve_seating_ids(users, ["Bob", "Alice"], "bot")
+    assert order == ["b", "a"]
+    assert missing == []
+
+
+def test_resolve_seating_ids_duplicate_names_get_distinct_ids():
+    # two players both named "Sam" must resolve to two DIFFERENT userIDs, both seated
+    users = [_u("1", "Sam"), _u("2", "Sam"), _u("bot", "DraftBot")]
+    order, missing = resolve_seating_ids(users, ["Sam", "Sam"], "bot")
+    assert order == ["1", "2"]
+    assert missing == []
+
+
+def test_resolve_seating_ids_excludes_bot_and_reports_missing():
+    users = [_u("bot", "DraftBot"), _u("a", "Alice")]
+    order, missing = resolve_seating_ids(users, ["Alice", "Ghost"], "bot")
+    assert order == ["a"]
+    assert missing == ["Ghost"]
+
+
+def test_resolve_seating_ids_more_names_than_users_of_that_name():
+    # three "Sam" seats but only two Sam users → the third is missing, not a reused id
+    users = [_u("1", "Sam"), _u("2", "Sam")]
+    order, missing = resolve_seating_ids(users, ["Sam", "Sam", "Sam"], None)
+    assert order == ["1", "2"]
+    assert missing == ["Sam"]


### PR DESCRIPTION
## Problem
`set_seating_order` mapped the desired username order to Draftmancer userIDs via a `name -> id` dict. Two players sharing a display name collapsed to one entry: one userID got seated twice, the other same-named player was dropped from the seating.

## Fix
Extract `resolve_seating_ids` into a new dependency-free `helpers/seating.py` (fast to import/test; the `DraftSetupManager` module is heavy). Each occurrence of a name now consumes a **distinct** userID in session order (a `defaultdict(deque)`), the bot is excluded, and unresolved names are reported as `missing_users` (logged as warnings) rather than silently reusing an id.

## Tests
`tests/test_resolve_seating_ids.py` (4) — basic order, duplicate names → distinct ids, bot excluded + missing reported, more names than users.

Part of a 4-PR stack (Codex review). Stacked on the team-balance-validation fix.
