### PR TITLE
fix(stakes): render bet lines from structured pairs, not string reparse

### DIFF
--- a/helpers/seating.py
+++ b/helpers/seating.py
@@ -1,0 +1,31 @@
+"""Pure seating helpers, kept dependency-free so they're fast to import and test
+(the DraftSetupManager module that uses this is heavy to import)."""
+from collections import defaultdict, deque
+
+
+def resolve_seating_ids(session_users, desired_username_order, bot_id):
+    """Map a desired username order to Draftmancer userIDs, robust to duplicate
+    display names.
+
+    Each occurrence of a name consumes a DISTINCT userID (in session order),
+    instead of a name->id dict that collapses duplicates — which would seat one
+    userID twice and omit the other same-named player. The bot is excluded.
+
+    Returns (user_id_order, missing_users).
+    """
+    by_name = defaultdict(deque)
+    for user in session_users:
+        user_id = user.get("userID")
+        username = user.get("userName")
+        if user_id != bot_id and username:
+            by_name[username].append(user_id)
+
+    user_id_order = []
+    missing_users = []
+    for username in desired_username_order:
+        queue = by_name.get(username)
+        if queue:
+            user_id_order.append(queue.popleft())
+        else:
+            missing_users.append(username)
+    return user_id_order, missing_users

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -19,6 +19,7 @@ from session import AsyncSessionLocal
 from sqlalchemy import select
 from helpers.digital_ocean_helper import DigitalOceanHelper
 from helpers.magicprotools_helper import MagicProtoolsHelper
+from helpers.seating import resolve_seating_ids
 from notification_service import send_ready_check_dms
 from services.draft_socket_client import DraftSocketClient
 from services.draft_log_store import post_team_logs
@@ -1742,27 +1743,15 @@ class DraftSetupManager:
                     self.logger.info(f"Found DraftBot ID: {bot_id} (will be excluded from seating)")
                     break
             
-            # Create mapping of usernames to userIDs, excluding the bot
-            username_to_userid = {}
-            for user in self.session_users:
-                user_id = user.get('userID')
-                username = user.get('userName')
-                
-                if user_id != bot_id and username:  # Exclude bot from mapping
-                    username_to_userid[username] = user_id
-                    self.logger.debug(f"Mapped {username} to {user_id}")
-            
-            # Convert the username order to userID order
-            user_id_order = []
-            missing_users = []
-            
-            for username in desired_username_order:
-                if username in username_to_userid:
-                    user_id_order.append(username_to_userid[username])
-                    self.logger.debug(f"Added {username} to seating order")
-                else:
-                    missing_users.append(username)
-                    self.logger.warning(f"Username '{username}' not found in session")
+            # Map the desired username order to userIDs. Each occurrence of a
+            # duplicate display name consumes a DISTINCT userID — a plain name->id
+            # dict would collapse duplicates, seating one userID twice and dropping
+            # the other same-named player.
+            user_id_order, missing_users = resolve_seating_ids(
+                self.session_users, desired_username_order, bot_id
+            )
+            for username in missing_users:
+                self.logger.warning(f"Username '{username}' not found in session")
             
             if not user_id_order:
                 self.logger.error("No valid userIDs found for the provided usernames")

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -14,7 +14,7 @@ from sqlalchemy import update, select
 
 from session import AsyncSessionLocal, DraftSession, StakeInfo
 from models.draft_session import DraftSession as DraftSessionModel
-from utils import split_into_teams, generate_seating_order, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
+from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
 from services.draft_setup_manager import DraftSetupManager
 from services.state_manager import state_manager
 from services.stake_service import calculate_and_store_stakes
@@ -105,7 +105,7 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                         # decorated display name is only for the embed) — mapping by
                         # name would KeyError on icon-decorated / markdown-escaped names.
                         seating_pairs = await generate_seating_order(bot, session)
-                        new_sign_ups = {user_id: session.sign_ups[user_id] for user_id, _ in seating_pairs}
+                        new_sign_ups = reorder_sign_ups(session.sign_ups, [user_id for user_id, _ in seating_pairs])
                         seating_order = [name for _, name in seating_pairs]
 
                         await db_session.execute(update(DraftSession)
@@ -121,7 +121,7 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                     sign_ups_list = list(session.sign_ups.keys())
                     random.shuffle(sign_ups_list)
                     seating_order = [session.sign_ups[user_id] for user_id in sign_ups_list]
-                    new_sign_ups = {user_id: session.sign_ups[user_id] for user_id in sign_ups_list}
+                    new_sign_ups = reorder_sign_ups(session.sign_ups, sign_ups_list)
                     await db_session.execute(update(DraftSession)
                                         .where(DraftSession.session_id == session.session_id)
                                         .values(sign_ups=new_sign_ups))

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -59,6 +59,26 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                     await interaction.followup.send("There must be an even number of players to fire.")
                     return False
 
+                if session.session_type == 'premade':
+                    # Drop team members who left (removed from sign_ups but still in
+                    # team_a/team_b) so a stale id can't KeyError downstream, then
+                    # require the teams to be non-empty and equal — an even total
+                    # alone allows a lopsided split (e.g. 2-vs-0).
+                    team_a = [uid for uid in (session.team_a or []) if uid in session.sign_ups]
+                    team_b = [uid for uid in (session.team_b or []) if uid in session.sign_ups]
+                    if not team_a or not team_b or len(team_a) != len(team_b):
+                        await interaction.followup.send(
+                            "Premade teams must be non-empty and equal size "
+                            f"(currently {len(team_a)} vs {len(team_b)})."
+                        )
+                        return False
+                    if team_a != list(session.team_a or []) or team_b != list(session.team_b or []):
+                        session.team_a = team_a
+                        session.team_b = team_b
+                        await db_session.execute(update(DraftSession)
+                                            .where(DraftSession.session_id == session.session_id)
+                                            .values(team_a=team_a, team_b=team_b))
+
                 # Update session timing and stage
                 session.teams_start_time = datetime.now()
                 if session.session_type == 'premade':

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -14,7 +14,7 @@ from sqlalchemy import update, select
 
 from session import AsyncSessionLocal, DraftSession, StakeInfo
 from models.draft_session import DraftSession as DraftSessionModel
-from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
+from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_stake_pairs, check_weekly_limits, add_links_to_embed_safely
 from services.draft_setup_manager import DraftSetupManager
 from services.state_manager import state_manager
 from services.stake_service import calculate_and_store_stakes
@@ -223,13 +223,12 @@ async def _add_stake_info_to_embed(embed, session, stake_info_by_player):
     if not stake_info_by_player:
         return
 
-    stake_lines, total_stakes = await get_formatted_stake_pairs(session.session_id, session.sign_ups)
+    stake_pairs, total_stakes = await get_stake_pairs(session.session_id, session.sign_ups)
 
-    formatted_lines = []
-    for line in stake_lines:
-        parts = line.split(': ')
-        names = parts[0].split(' vs ')
-        formatted_lines.append(f"**{names[0]}** vs **{names[1]}**: {parts[1]}")
+    formatted_lines = [
+        f"**{red_name}** vs **{blue_name}**: {amount} tix"
+        for red_name, blue_name, amount in stake_pairs
+    ]
 
     if formatted_lines:
         add_links_to_embed_safely(embed, formatted_lines, f"Bets (Total: {total_stakes} tix)")

--- a/tests/test_create_and_display_teams.py
+++ b/tests/test_create_and_display_teams.py
@@ -14,25 +14,25 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-def _premade_session(sign_ups):
+def _premade_session(sign_ups, team_a=None, team_b=None):
     session = MagicMock()
     session.session_type = "premade"
     session.session_id = "fake-session-123"
     session.sign_ups = dict(sign_ups)
     ids = list(sign_ups.keys())
-    session.team_a = ids[:3]
-    session.team_b = ids[3:]
+    session.team_a = team_a if team_a is not None else ids[:len(ids) // 2]
+    session.team_b = team_b if team_b is not None else ids[len(ids) // 2:]
     session.tracked_draft = False
     session.premade_match_id = None
     return session
 
 
-async def _run_premade(sign_ups, seating_return):
+async def _run_premade(sign_ups, seating_return, team_a=None, team_b=None):
     """Run create_and_display_teams for a premade draft with generate_seating_order
     mocked to return `seating_return`. Returns (result, mock_logger, session)."""
     from services import team_creator
 
-    session = _premade_session(sign_ups)
+    session = _premade_session(sign_ups, team_a=team_a, team_b=team_b)
     select_result = MagicMock()
     select_result.scalars.return_value.first.return_value = session
 
@@ -118,3 +118,24 @@ async def test_premade_seating_maps_by_id_not_decorated_name():
     assert set(session.sign_ups.keys()) == set(sign_ups)
     assert all(session.sign_ups[uid] == sign_ups[uid] for uid in sign_ups)
     assert list(session.sign_ups.keys()) == [uid for uid, _ in seating]
+
+
+@pytest.mark.asyncio
+async def test_premade_rejects_unbalanced_teams():
+    """A premade with an even total but a lopsided split (2-vs-0) must be rejected,
+    not seated into a broken draft with only one team (Codex finding)."""
+    sign_ups = {"111": "A", "222": "B"}                 # even total = 2
+    result, _mock_logger, _session = await _run_premade(
+        sign_ups, [("111", "A"), ("222", "B")], team_a=["111", "222"], team_b=[])
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_premade_balance_counts_only_signed_up_members():
+    """Balance is measured on team members still in sign_ups — a stale id left in a
+    team (from the leave flow) must not tip an otherwise-balanced draft into rejection."""
+    sign_ups = {"111": "A", "222": "B", "333": "C", "444": "D"}
+    result, _mock_logger, _session = await _run_premade(
+        sign_ups, [("111", "A"), ("333", "C"), ("222", "B"), ("444", "D")],
+        team_a=["111", "222", "999"], team_b=["333", "444"])   # 999 not signed up
+    assert result is True                                # effective 2-vs-2 → allowed

--- a/tests/test_premade_test_users.py
+++ b/tests/test_premade_test_users.py
@@ -91,3 +91,33 @@ async def test_seating_order_uses_sign_up_names_for_non_members():
     assert "Member111" in names and "Member222" in names
     # test users keep their id even though they're not guild members
     assert "900000000000000001" in ids and "900000000000000002" in ids
+
+
+# ---- generate_seating_order excludes stale team members (Codex #1) ---------------
+
+@pytest.mark.asyncio
+async def test_seating_order_excludes_team_ids_removed_from_sign_ups():
+    """A player removed from sign_ups but still left in team_a/team_b (the leave
+    flow doesn't clean the team lists) must not be seated — otherwise the caller's
+    reorder_sign_ups does sign_ups[stale_id] and KeyErrors at premade fire."""
+    import utils
+
+    draft_session = MagicMock()
+    draft_session.guild_id = "1"
+    draft_session.team_a = ["111", "999"]   # 999 left the draft but stayed in team_a
+    draft_session.team_b = ["222"]
+    draft_session.sign_ups = {"111": "A", "222": "B"}   # 999 is gone
+
+    member = MagicMock()
+    member.display_name = "Ghost"
+    guild = MagicMock()
+    guild.get_member.return_value = member
+    bot = MagicMock()
+    bot.get_guild.return_value = guild
+
+    with patch.object(utils, "get_display_name", lambda m, g: m.display_name):
+        order = await utils.generate_seating_order(bot, draft_session)
+
+    ids = [uid for uid, _ in order]
+    assert "999" not in ids                              # stale id not seated
+    assert set(ids) <= set(draft_session.sign_ups)       # every seated id is in sign_ups

--- a/tests/test_reorder_sign_ups.py
+++ b/tests/test_reorder_sign_ups.py
@@ -1,0 +1,27 @@
+"""Unit tests for reorder_sign_ups — the shared 'reorder sign_ups by an ordered
+id list' helper used by the premade and swiss seating paths. It reorders by user
+id (never by display name), which is what keeps decorated/escaped names from
+breaking the mapping (see PR #349)."""
+
+from utils import reorder_sign_ups
+
+
+def test_reorder_sign_ups_orders_by_id_and_preserves_names():
+    sign_ups = {"1": "Alice", "2": "Bob", "3": "Carol"}
+    out = reorder_sign_ups(sign_ups, ["3", "1", "2"])
+    assert list(out.keys()) == ["3", "1", "2"]      # reordered to the id list
+    assert out == {"3": "Carol", "1": "Alice", "2": "Bob"}   # names unchanged
+
+
+def test_reorder_sign_ups_returns_a_new_dict():
+    sign_ups = {"1": "Alice"}
+    out = reorder_sign_ups(sign_ups, ["1"])
+    assert out is not sign_ups
+
+
+def test_reorder_sign_ups_keys_by_id_even_when_names_collide():
+    # two players with the same display name must not collapse — keyed by id
+    sign_ups = {"1": "Sam", "2": "Sam"}
+    out = reorder_sign_ups(sign_ups, ["2", "1"])
+    assert list(out.keys()) == ["2", "1"]
+    assert len(out) == 2

--- a/tests/test_resolve_seating_ids.py
+++ b/tests/test_resolve_seating_ids.py
@@ -1,0 +1,40 @@
+"""Unit tests for resolve_seating_ids — mapping a desired username order to
+Draftmancer userIDs. The old name->id dict collapsed duplicate display names
+(one userID seated twice, the other player omitted); this maps each occurrence
+of a name to a DISTINCT userID (Codex review finding #2)."""
+
+from helpers.seating import resolve_seating_ids
+
+
+def _u(uid, name):
+    return {"userID": uid, "userName": name}
+
+
+def test_resolve_seating_ids_basic_order():
+    users = [_u("a", "Alice"), _u("b", "Bob"), _u("bot", "DraftBot")]
+    order, missing = resolve_seating_ids(users, ["Bob", "Alice"], "bot")
+    assert order == ["b", "a"]
+    assert missing == []
+
+
+def test_resolve_seating_ids_duplicate_names_get_distinct_ids():
+    # two players both named "Sam" must resolve to two DIFFERENT userIDs, both seated
+    users = [_u("1", "Sam"), _u("2", "Sam"), _u("bot", "DraftBot")]
+    order, missing = resolve_seating_ids(users, ["Sam", "Sam"], "bot")
+    assert order == ["1", "2"]
+    assert missing == []
+
+
+def test_resolve_seating_ids_excludes_bot_and_reports_missing():
+    users = [_u("bot", "DraftBot"), _u("a", "Alice")]
+    order, missing = resolve_seating_ids(users, ["Alice", "Ghost"], "bot")
+    assert order == ["a"]
+    assert missing == ["Ghost"]
+
+
+def test_resolve_seating_ids_more_names_than_users_of_that_name():
+    # three "Sam" seats but only two Sam users → the third is missing, not a reused id
+    users = [_u("1", "Sam"), _u("2", "Sam")]
+    order, missing = resolve_seating_ids(users, ["Sam", "Sam", "Sam"], None)
+    assert order == ["1", "2"]
+    assert missing == ["Sam"]

--- a/tests/test_stake_display.py
+++ b/tests/test_stake_display.py
@@ -1,0 +1,50 @@
+"""Tests for stake display in team_creator._add_stake_info_to_embed.
+
+Regression (Codex review finding): the bet field was built by RE-PARSING the
+already-formatted stake strings ("{a} vs {b}: {amount} tix") with
+line.split(': ') and parts[0].split(' vs '). A player whose display name
+contains ': ' or ' vs ' mis-splits — wrong bold placement or IndexError.
+The fix consumes the STRUCTURED (red, blue, amount) pairs directly.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+async def _run_add_stake_info(stake_pairs, total):
+    """Call _add_stake_info_to_embed with get_stake_pairs mocked to return
+    (stake_pairs, total). Returns the (lines, title) captured from
+    add_links_to_embed_safely."""
+    from services import team_creator
+
+    embed = MagicMock()
+    session = MagicMock()
+    session.session_id = "s1"
+    session.sign_ups = {"1": "x", "2": "y"}
+
+    captured = {}
+
+    def _capture(embed_arg, lines, title):
+        captured["lines"] = lines
+        captured["title"] = title
+
+    with patch.object(team_creator, "get_stake_pairs",
+                      AsyncMock(return_value=(stake_pairs, total))), \
+         patch.object(team_creator, "add_links_to_embed_safely", _capture):
+        # stake_info_by_player just needs to be truthy to pass the early return
+        await team_creator._add_stake_info_to_embed(embed, session, {"1": 50})
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_add_stake_info_bolds_simple_names():
+    captured = await _run_add_stake_info([("Alice", "Bob", 50)], 50)
+    assert captured["lines"] == ["**Alice** vs **Bob**: 50 tix"]
+    assert "Total: 50 tix" in captured["title"]
+
+
+@pytest.mark.asyncio
+async def test_add_stake_info_preserves_names_with_delimiters():
+    # names containing ': ' and ' vs ' must NOT be mangled by delimiter splitting
+    captured = await _run_add_stake_info([("Alice: the Great", "Bob vs Evil", 30)], 30)
+    assert captured["lines"] == ["**Alice: the Great** vs **Bob vs Evil**: 30 tix"]

--- a/utils.py
+++ b/utils.py
@@ -231,10 +231,15 @@ def reorder_sign_ups(sign_ups, ordered_ids):
 async def generate_seating_order(bot, draft_session, command_type=None):
     guild = bot.get_guild(int(draft_session.guild_id))
 
+    # Only seat team members who are still signed up. A player who leaves is
+    # removed from sign_ups but may remain in team_a/team_b; seating a stale id
+    # would then KeyError in the caller's reorder_sign_ups (sign_ups[stale_id]).
+    sign_ups = draft_session.sign_ups or {}
+
     # Pair each user id with its member object; test users resolve to None and
     # fall back to their sign_ups display name instead of being dropped.
-    team_a_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_a]
-    team_b_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_b]
+    team_a_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_a if user_id in sign_ups]
+    team_b_pairs = [(user_id, guild.get_member(int(user_id))) for user_id in draft_session.team_b if user_id in sign_ups]
 
     random.shuffle(team_a_pairs)
     random.shuffle(team_b_pairs)

--- a/utils.py
+++ b/utils.py
@@ -2574,16 +2574,20 @@ async def get_missing_stake_players(session_id):
             
             return missing_players
         
-async def get_formatted_stake_pairs(session_id, sign_ups):
+async def get_stake_pairs(session_id, sign_ups):
     """
-    Get all stake pairs for a draft session, formatted for display.
-    
+    Get all stake pairs for a draft session as structured data.
+
+    Returns the pairs as (red_name, blue_name, amount) tuples so callers can
+    render them however they like — no delimiter-based reparsing needed.
+
     Args:
         session_id: The draft session ID
         sign_ups: Dict mapping player IDs to display names
-        
+
     Returns:
-        tuple: (formatted_stake_lines, total_stakes)
+        tuple: (stake_pairs, total_stakes) where stake_pairs is a list of
+        (red_name, blue_name, amount), sorted by amount (highest first).
     """
     # Fetch all stake information
     async with AsyncSessionLocal() as db_session:
@@ -2592,13 +2596,12 @@ async def get_formatted_stake_pairs(session_id, sign_ups):
             draft_stmt = select(DraftSession).where(DraftSession.session_id == session_id)
             draft_result = await db_session.execute(draft_stmt)
             draft_session = draft_result.scalars().first()
-            
+
             if not draft_session:
                 return [], 0
-                
+
             # Create sets of team members for quick lookup
             team_red_members = set(draft_session.team_a)
-            team_blue_members = set(draft_session.team_b)
 
             # Get all stake pairings for this session
             pairing_stmt = select(StakePairing).where(StakePairing.session_id == session_id)
@@ -2639,14 +2642,30 @@ async def get_formatted_stake_pairs(session_id, sign_ups):
 
                 # Add to total stake
                 total_stake += pairing.amount
-            
+
             # Sort by amount (highest first)
             unique_pairs.sort(key=lambda x: x[2], reverse=True)
-            
-            # Format for display - Team Red player vs Team Blue player
-            formatted_lines = [f"{a} vs {b}: {amount} tix" for a, b, amount in unique_pairs]
-            
-            return formatted_lines, total_stake
+
+            return unique_pairs, total_stake
+
+
+async def get_formatted_stake_pairs(session_id, sign_ups):
+    """
+    Get all stake pairs for a draft session, formatted for display.
+
+    Args:
+        session_id: The draft session ID
+        sign_ups: Dict mapping player IDs to display names
+
+    Returns:
+        tuple: (formatted_stake_lines, total_stakes)
+    """
+    stake_pairs, total_stake = await get_stake_pairs(session_id, sign_ups)
+
+    # Format for display - Team Red player vs Team Blue player
+    formatted_lines = [f"{a} vs {b}: {amount} tix" for a, b, amount in stake_pairs]
+
+    return formatted_lines, total_stake
 
 async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
     """

--- a/utils.py
+++ b/utils.py
@@ -217,6 +217,17 @@ async def split_into_teams(bot, draft_session_id):
                 else:
                     print(f"No sign-ups found for session {draft_session_id}")
 
+def reorder_sign_ups(sign_ups, ordered_ids):
+    """Return a new sign_ups dict reordered to `ordered_ids`, keyed by user id
+    with the stored names unchanged.
+
+    Reordering by user id (never by display name) is what keeps decorated or
+    markdown-escaped display names from breaking the mapping — see PR #349. Used
+    by both the premade and swiss seating paths.
+    """
+    return {user_id: sign_ups[user_id] for user_id in ordered_ids}
+
+
 async def generate_seating_order(bot, draft_session, command_type=None):
     guild = bot.get_guild(int(draft_session.guild_id))
 


### PR DESCRIPTION
## Problem
`_add_stake_info_to_embed` rebuilt the bet field by re-splitting the already-formatted stake strings (`"{a} vs {b}: {amount} tix"`) on `': '` and `' vs '`. Any display name containing those delimiters (`"Alice: the Great"`, `"Bob vs Evil"`) mis-split → wrong bold placement or `IndexError`.

## Fix
Extract the structured core `get_stake_pairs` returning `(red_name, blue_name, amount)` tuples. The bet field now formats bold names directly from that structure — no delimiter reparse. `get_formatted_stake_pairs` formats on top of the same core (DRY) and keeps its 2-tuple return, so the three string-only callers (`views`, `utils`, `livedrafts`) are untouched.

## Tests
`tests/test_stake_display.py` (2) — simple names bold correctly; names containing `': '` / `' vs '` are preserved, not mangled.

Part of a 4-PR stack (Codex review). Top of the stack.
