### PR TITLE
chore(gitignore): ignore analysis_data/ scratch output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ cython_debug/
 #.idea/
 card_analysis_cache/
 drafts.db.backup.*
+analysis_data/


### PR DESCRIPTION
## What

Add `analysis_data/` to `.gitignore` and restore the file's trailing newline.

## Why

`analysis_data/` holds locally-generated draft-analysis artifacts (the draft-log JSON cache and generated reports) that shouldn't be tracked — they were cluttering `git status`.

While here, restore the trailing newline on the last line. The file previously ended with `drafts.db.backup.*` and **no** trailing newline, which is a footgun: a plain append silently concatenates the new entry onto that last pattern (this actually happened locally, producing a malformed `drafts.db.backup.*analysis_data/` glob that ignored neither the backups nor `analysis_data/`).

## Notes

Nothing broken was ever committed to `main` — the malformed line existed only in a local working tree. This PR is purely housekeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)