### PR TITLE
Add /server_draft_stats admin command for drafts-per-cube and timing stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,19 +205,31 @@ model attributes type as `Any` — strictness covers the checked file's local
 logic, not its model contracts (e.g. a nullable JSON column passed where a
 `dict` is expected won't be caught).
 
-Conventions for the awkward py-cord cases:
+Conventions for the awkward py-cord cases, in preference order — the goal is
+that narrowing is declared ONCE at a boundary (or backed by a runtime check),
+never re-asserted per use site:
 
 - `not_none(x)` (in `helpers/utils.py`) asserts a value isn't `None`, raising at
   runtime if the assumption is wrong. Use it for things like
   `not_none(interaction.user).id`, where pycord's types allow `None` but the
   handler can only run when it's present. Use it sparingly — prefer a real
   `is not None` check when the value genuinely can be absent.
-- `cast(...)` for narrowing a union the checker can't infer, e.g.
-  `cast(discord.TextChannel, channel).fetch_message(...)` where `bot.get_channel`
-  returns the full `GuildChannel` union.
+- `@ui_button(...)` (in `helpers/utils.py`) instead of `@discord.ui.button(...)`:
+  py-cord swaps every decorated method attribute for its Button item at View
+  init, so `ui_button` declares the attribute as the `Button` it actually is —
+  `self.my_button.style = ...` then typechecks everywhere with no casts. The
+  one static lie (the class attribute is the raw function until init, which
+  nothing observes) lives inside the wrapper, documented.
+- `as_messageable(x)` (in `helpers/utils.py`) narrows a `bot.get_channel`
+  result to `Messageable` with a real isinstance check — a clear boundary
+  error instead of an AttributeError deep in py-cord, and it tolerates
+  threads/DMs where a `TextChannel` cast would not.
 - `discord.ui.Button[Any]` — `Button` is generic over its parent view, which
   button callbacks don't depend on.
-- `# pyrefly: ignore [error-kind]` as a last resort, on the line above the error.
+- `cast(...)` as a last resort, only for unions no isinstance can express, with
+  a comment justifying each use. (The checked files currently contain none.)
+- `# pyrefly: ignore [error-kind]` as a very last resort, on the line above the
+  error.
 
 ### Security Considerations
 - Never commit secrets or tokens

--- a/cogs/server_draft_stats.py
+++ b/cogs/server_draft_stats.py
@@ -1,0 +1,419 @@
+import operator
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import Any, NamedTuple, Optional, cast
+from zoneinfo import ZoneInfo
+
+import discord
+from discord.ext import commands
+from loguru import logger
+from sqlalchemy import and_, func, select
+from typing_extensions import override
+
+from database.db_session import db_session
+from helpers.permissions import has_bot_manager_role
+from helpers.utils import not_none
+from models.draft_session import DraftSession
+from models.match import MatchResult
+
+MAX_CUBES_SHOWN = 25
+
+DEFAULT_PERIOD = "90d"
+
+# Fixed rather than per-viewer, so every admin reads the same numbers off a
+# server-wide stat. Pacific because it's already how this bot buckets draft
+# activity by time - weekly_summary's league week and PlayerLimit's weekly limits
+# both cut at midnight Monday Pacific (spelled "US/Pacific" at those sites).
+DISPLAY_TZ = ZoneInfo("America/Los_Angeles")
+
+# Character width of the longest histogram bar.
+HISTOGRAM_BAR_WIDTH = 18
+
+
+class PeriodConfig(NamedTuple):
+    label: str
+    lookback: Optional[timedelta]
+    min_drafts: int
+
+
+# Minimum completed drafts a cube needs in the period to be displayed, scaled to
+# the period length so a one-off draft doesn't clutter the shorter views.
+PERIOD_CONFIGS: dict[str, PeriodConfig] = {
+    "14d": PeriodConfig("Last 14 Days", timedelta(days=14), 4),
+    "30d": PeriodConfig("Last 30 Days", timedelta(days=30), 6),
+    "90d": PeriodConfig("Last 90 Days", timedelta(days=90), 8),
+    "lifetime": PeriodConfig("Lifetime", None, 10),
+}
+
+
+async def get_cube_draft_counts(guild_id: str, start_date: Optional[datetime]) -> tuple[Counter[str], int]:
+    """Count completed drafts per cube for a guild, optionally since start_date.
+
+    The GROUP BY runs in SQL so the app only ever receives one row per distinct
+    cube, not one row per draft session.
+    """
+    conditions = [
+        DraftSession.guild_id == guild_id,
+        DraftSession.victory_message_id_draft_chat.isnot(None),
+        DraftSession.cube.isnot(None),
+    ]
+    if start_date is not None:
+        conditions.append(DraftSession.teams_start_time >= start_date)
+
+    async with db_session() as session:
+        stmt = (
+            select(DraftSession.cube, func.count())
+            .where(and_(*conditions))
+            .group_by(DraftSession.cube)
+        )
+        result = await session.execute(stmt)
+        rows = result.all()
+
+    counts = Counter({cube: count for cube, count in rows})
+    return counts, sum(counts.values())
+
+
+def rank_cubes(counts: Counter[str], min_drafts: int) -> list[tuple[str, int]]:
+    """Sort cubes by draft count descending, dropping any below min_drafts."""
+    return sorted(
+        ((cube, count) for cube, count in counts.items() if count >= min_drafts),
+        key=operator.itemgetter(1),
+        reverse=True,
+    )
+
+
+class DurationStats(NamedTuple):
+    min_seconds: float
+    avg_seconds: float
+    max_seconds: float
+    count: int
+
+
+async def _get_duration_stats(
+    guild_id: str,
+    start_date: Optional[datetime],
+    start_column: Any,
+    end_column: Any,
+) -> Optional[DurationStats]:
+    """Min/avg/max seconds between two DraftSession datetime columns, for
+    completed drafts in a guild. A single SQL aggregate query does all the
+    work - only the final numbers (never the underlying rows) reach Python.
+    """
+    conditions: list[object] = [
+        DraftSession.guild_id == guild_id,
+        DraftSession.victory_message_id_draft_chat.isnot(None),
+        start_column.isnot(None),
+        end_column.isnot(None),
+        end_column >= start_column,
+    ]
+    if start_date is not None:
+        conditions.append(DraftSession.teams_start_time >= start_date)
+
+    # SQLite has no interval type; julianday() converts a datetime to a
+    # fractional day count, so the difference * seconds-per-day is the gap
+    # in seconds between the two timestamps.
+    duration_expr = (func.julianday(end_column) - func.julianday(start_column)) * 86400.0
+
+    async with db_session() as session:
+        agg_stmt = select(
+            func.min(duration_expr), func.avg(duration_expr), func.max(duration_expr), func.count()
+        ).where(and_(*conditions))
+        min_seconds, avg_seconds, max_seconds, count = (await session.execute(agg_stmt)).one()
+
+    if not count:
+        return None
+    return DurationStats(float(min_seconds), float(avg_seconds), float(max_seconds), count)
+
+
+async def get_draft_fire_duration_stats(guild_id: str, start_date: Optional[datetime]) -> Optional[DurationStats]:
+    """Min/avg/max seconds from draft_start_time (sign-up posted) to
+    teams_start_time (ready check passed and teams created)."""
+    return await _get_duration_stats(guild_id, start_date, DraftSession.draft_start_time, DraftSession.teams_start_time)
+
+
+async def get_draft_completion_duration_stats(guild_id: str, start_date: Optional[datetime]) -> Optional[DurationStats]:
+    """Min/avg/max seconds from teams_start_time (draft started) to the
+    last match result submitted for that draft - i.e. total time from teams
+    being created to the whole event (drafting + every match) finishing.
+
+    Unlike get_draft_fire_duration_stats, the end point isn't a plain
+    DraftSession column: it's the max(result_submitted_at) per session, so
+    this needs its own query joining against a per-session aggregate over
+    match_results instead of reusing _get_duration_stats.
+    """
+    last_match = (
+        select(
+            MatchResult.session_id.label("session_id"),
+            func.max(MatchResult.result_submitted_at).label("last_result_at"),
+        )
+        .where(MatchResult.result_submitted_at.isnot(None))
+        .group_by(MatchResult.session_id)
+        .subquery()
+    )
+
+    conditions: list[object] = [
+        DraftSession.guild_id == guild_id,
+        DraftSession.victory_message_id_draft_chat.isnot(None),
+        DraftSession.teams_start_time.isnot(None),
+        last_match.c.last_result_at >= DraftSession.teams_start_time,
+    ]
+    if start_date is not None:
+        conditions.append(DraftSession.teams_start_time >= start_date)
+
+    duration_expr = (
+        func.julianday(last_match.c.last_result_at) - func.julianday(DraftSession.teams_start_time)
+    ) * 86400.0
+
+    async with db_session() as session:
+        agg_stmt = (
+            select(func.min(duration_expr), func.avg(duration_expr), func.max(duration_expr), func.count())
+            .select_from(DraftSession)
+            .join(last_match, last_match.c.session_id == DraftSession.session_id)
+            .where(and_(*conditions))
+        )
+        min_seconds, avg_seconds, max_seconds, count = (await session.execute(agg_stmt)).one()
+
+    if not count:
+        return None
+    return DurationStats(float(min_seconds), float(avg_seconds), float(max_seconds), count)
+
+
+def to_display_hour(stored: datetime) -> int:
+    """Hour of day (0-23) in DISPLAY_TZ for a naive timestamp read from the DB.
+
+    These columns are written by datetime.now() on the bot host, so they hold
+    host-local wall clock, not UTC. astimezone() reads a naive datetime as
+    host-local, so it round-trips them without hardcoding the deployment's zone.
+    Caveat: running against a fetched copy of the prod DB reads prod's timestamps
+    in the dev box's zone, shifting the histogram.
+    """
+    return stored.astimezone(DISPLAY_TZ).hour
+
+
+async def get_draft_start_hour_counts(guild_id: str, start_date: Optional[datetime]) -> Counter[int]:
+    """Count completed drafts by the DISPLAY_TZ hour their teams were created.
+
+    Buckets on teams_start_time, the moment the draft actually fired, so these
+    counts sum to the same total as "Total Completed Drafts".
+
+    Bucketing happens in Python rather than SQL because SQLite can't convert
+    DST-aware between named zones, and grouping on a fixed hour offset would skew
+    rows on the far side of a DST change. Only one column is selected, so the
+    row-per-draft cost stays negligible.
+    """
+    conditions = [
+        DraftSession.guild_id == guild_id,
+        DraftSession.victory_message_id_draft_chat.isnot(None),
+        DraftSession.teams_start_time.isnot(None),
+    ]
+    if start_date is not None:
+        conditions.append(DraftSession.teams_start_time >= start_date)
+
+    async with db_session() as session:
+        stmt = select(DraftSession.teams_start_time).where(and_(*conditions))
+        rows = (await session.execute(stmt)).all()
+
+    return Counter(to_display_hour(started_at) for (started_at,) in rows)
+
+
+def format_duration(seconds: float) -> str:
+    """Render a duration in seconds as a compact human-readable string."""
+    total_seconds = round(seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def format_duration_field(stats: Optional[DurationStats]) -> str:
+    """Build the embed field text for the time-to-fire section."""
+    if stats is None:
+        return "No timing data available for this period."
+
+    return (
+        f"Min: {format_duration(stats.min_seconds)}\n"
+        f"Avg: {format_duration(stats.avg_seconds)}\n"
+        f"Max: {format_duration(stats.max_seconds)}"
+    )
+
+
+def format_hour_histogram(counts: Counter[int]) -> str:
+    """Render 24 hourly buckets as a fixed-width bar chart for an embed field.
+
+    Empty hours are listed too, so the shape of the day reads at a glance. Bars
+    scale to the busiest hour, flooring at one block so an hour with drafts in it
+    never renders empty.
+    """
+    if not counts:
+        return "No draft start times available for this period."
+
+    peak = max(counts.values())
+    count_width = len(str(peak))
+    # "HH" labels the hour column, "#" the count column; the bar column between
+    # them is left unlabelled since the bars speak for themselves.
+    label_width = 2 + 1 + HISTOGRAM_BAR_WIDTH
+
+    lines = [
+        f"{'HH':<{label_width}} {'#':>{count_width}}",
+        "─" * (label_width + 1 + count_width),
+    ]
+    for hour in range(24):
+        count = counts[hour]
+        blocks = max(1, round(count / peak * HISTOGRAM_BAR_WIDTH)) if count else 0
+        bar = "█" * blocks
+        lines.append(f"{hour:02d} {bar:<{HISTOGRAM_BAR_WIDTH}} {count:>{count_width}}")
+
+    # Fenced so Discord renders it monospaced and the columns line up.
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def display_tz_label() -> str:
+    """Current abbreviation for DISPLAY_TZ ("PDT" in summer, "PST" in winter)."""
+    return datetime.now(DISPLAY_TZ).strftime("%Z")
+
+
+async def build_stats_embed(guild_id: str, period: str) -> discord.Embed:
+    """Build the guild-draft-stats embed for a single timeframe."""
+    config = PERIOD_CONFIGS[period]
+    start_date = datetime.now() - config.lookback if config.lookback is not None else None
+    counts, total_drafts = await get_cube_draft_counts(guild_id, start_date)
+    fire_stats = await get_draft_fire_duration_stats(guild_id, start_date)
+    drafting_stats = await get_draft_completion_duration_stats(guild_id, start_date)
+    hour_counts = await get_draft_start_hour_counts(guild_id, start_date)
+
+    embed = discord.Embed(
+        title="Server Draft Stats",
+        description=f"Timeframe: **{config.label}** (min {config.min_drafts} completed drafts to appear)",
+        color=discord.Color.blue(),
+    )
+    embed.add_field(name="Total Completed Drafts", value=str(total_drafts), inline=False)
+
+    if total_drafts == 0:
+        embed.add_field(name="Drafts per Cube", value="No completed drafts found for this period.", inline=False)
+    else:
+        ranked = rank_cubes(counts, config.min_drafts)
+        if not ranked:
+            embed.add_field(
+                name="Drafts per Cube",
+                value=f"No cube reached the minimum of {config.min_drafts} drafts for this period.",
+                inline=False,
+            )
+        else:
+            lines = [f"{i + 1}. **{cube}**: {count} drafts" for i, (cube, count) in enumerate(ranked[:MAX_CUBES_SHOWN])]
+            if len(ranked) > MAX_CUBES_SHOWN:
+                lines.append(f"...and {len(ranked) - MAX_CUBES_SHOWN} more")
+            embed.add_field(name="Drafts per Cube", value="\n".join(lines), inline=False)
+
+    embed.add_field(
+        name="Time to Fire (sign-up → teams created)",
+        value=format_duration_field(fire_stats),
+        inline=False,
+    )
+    embed.add_field(
+        name="Time to Finish (teams created → last match reported)",
+        value=format_duration_field(drafting_stats),
+        inline=False,
+    )
+    embed.add_field(
+        name=f"Draft Starts by Hour ({display_tz_label()})",
+        value=format_hour_histogram(hour_counts),
+        inline=False,
+    )
+
+    return embed
+
+
+class DraftStatsView(discord.ui.View):
+    """Timeframe-switching buttons for an already-sent server_draft_stats embed."""
+
+    def __init__(self, guild_id: str, current_period: str) -> None:
+        super().__init__(timeout=180)
+        self.guild_id = guild_id
+        self.current_period = current_period
+        self.message: Optional[discord.Message] = None
+
+        # py-cord's View.__init__ replaces each decorated method attribute
+        # with its Button item, so these assignments hit the ITEM at runtime;
+        # the static type is the function, hence the casts (see CLAUDE.md).
+        cast(discord.ui.Button[Any], self.fourteen_day_button).style = self._style_for("14d")
+        cast(discord.ui.Button[Any], self.thirty_day_button).style = self._style_for("30d")
+        cast(discord.ui.Button[Any], self.ninety_day_button).style = self._style_for("90d")
+        cast(discord.ui.Button[Any], self.lifetime_button).style = self._style_for("lifetime")
+
+    def _style_for(self, period: str) -> discord.ButtonStyle:
+        return discord.ButtonStyle.primary if period == self.current_period else discord.ButtonStyle.secondary
+
+    async def _switch(self, interaction: discord.Interaction, period: str) -> None:
+        try:
+            embed = await build_stats_embed(self.guild_id, period)
+        except Exception as e:
+            logger.error(f"Error refreshing server draft stats: {e}")
+            await interaction.response.send_message(f"An error occurred: {e}", ephemeral=True)
+            return
+
+        new_view = DraftStatsView(self.guild_id, period)
+        new_view.message = self.message
+        await interaction.response.edit_message(embed=embed, view=new_view)
+
+    @discord.ui.button(label=PERIOD_CONFIGS["14d"].label, custom_id="server_draft_stats_14d")
+    async def fourteen_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
+        await self._switch(interaction, "14d")
+
+    @discord.ui.button(label=PERIOD_CONFIGS["30d"].label, custom_id="server_draft_stats_30d")
+    async def thirty_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
+        await self._switch(interaction, "30d")
+
+    @discord.ui.button(label=PERIOD_CONFIGS["90d"].label, custom_id="server_draft_stats_90d")
+    async def ninety_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
+        await self._switch(interaction, "90d")
+
+    @discord.ui.button(label=PERIOD_CONFIGS["lifetime"].label, custom_id="server_draft_stats_lifetime")
+    async def lifetime_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
+        await self._switch(interaction, "lifetime")
+
+    @override
+    async def on_timeout(self) -> None:
+        if self.message is None:
+            return
+        self.disable_all_items()
+        try:
+            await self.message.edit(view=self)
+        except Exception:
+            pass
+
+
+class ServerDraftStatsCog(commands.Cog):
+    """Cog exposing server-wide draft activity stats (completed drafts per cube)."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        logger.info("Server draft stats cog loaded")
+
+    @discord.slash_command(
+        name="server_draft_stats",
+        description="[Admin] View completed drafts per cube for this server",
+    )
+    @has_bot_manager_role()
+    async def server_draft_stats(self, ctx: discord.ApplicationContext) -> None:
+        """Show how many completed drafts each cube has had, with buttons to switch timeframe."""
+        await ctx.defer(ephemeral=True)
+
+        guild_id = str(not_none(ctx.guild).id)
+
+        try:
+            embed = await build_stats_embed(guild_id, DEFAULT_PERIOD)
+        except Exception as e:
+            logger.error(f"Error fetching server draft stats: {e}")
+            await ctx.followup.send(f"An error occurred: {e}", ephemeral=True)
+            return
+
+        view = DraftStatsView(guild_id, DEFAULT_PERIOD)
+        message = await ctx.followup.send(embed=embed, view=view, ephemeral=True)
+        view.message = message
+
+
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(ServerDraftStatsCog(bot))

--- a/cogs/server_draft_stats.py
+++ b/cogs/server_draft_stats.py
@@ -1,7 +1,7 @@
 import operator
 from collections import Counter
 from datetime import datetime, timedelta
-from typing import Any, NamedTuple, Optional, cast
+from typing import Any, NamedTuple, Optional
 from zoneinfo import ZoneInfo
 
 import discord
@@ -12,7 +12,7 @@ from typing_extensions import override
 
 from database.db_session import db_session
 from helpers.permissions import has_bot_manager_role
-from helpers.utils import not_none
+from helpers.utils import ui_button, not_none
 from models.draft_session import DraftSession
 from models.match import MatchResult
 
@@ -335,13 +335,10 @@ class DraftStatsView(discord.ui.View):
         self.current_period = current_period
         self.message: Optional[discord.Message] = None
 
-        # py-cord's View.__init__ replaces each decorated method attribute
-        # with its Button item, so these assignments hit the ITEM at runtime;
-        # the static type is the function, hence the casts (see CLAUDE.md).
-        cast(discord.ui.Button[Any], self.fourteen_day_button).style = self._style_for("14d")
-        cast(discord.ui.Button[Any], self.thirty_day_button).style = self._style_for("30d")
-        cast(discord.ui.Button[Any], self.ninety_day_button).style = self._style_for("90d")
-        cast(discord.ui.Button[Any], self.lifetime_button).style = self._style_for("lifetime")
+        self.fourteen_day_button.style = self._style_for("14d")
+        self.thirty_day_button.style = self._style_for("30d")
+        self.ninety_day_button.style = self._style_for("90d")
+        self.lifetime_button.style = self._style_for("lifetime")
 
     def _style_for(self, period: str) -> discord.ButtonStyle:
         return discord.ButtonStyle.primary if period == self.current_period else discord.ButtonStyle.secondary
@@ -358,19 +355,19 @@ class DraftStatsView(discord.ui.View):
         new_view.message = self.message
         await interaction.response.edit_message(embed=embed, view=new_view)
 
-    @discord.ui.button(label=PERIOD_CONFIGS["14d"].label, custom_id="server_draft_stats_14d")
+    @ui_button(label=PERIOD_CONFIGS["14d"].label, custom_id="server_draft_stats_14d")
     async def fourteen_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "14d")
 
-    @discord.ui.button(label=PERIOD_CONFIGS["30d"].label, custom_id="server_draft_stats_30d")
+    @ui_button(label=PERIOD_CONFIGS["30d"].label, custom_id="server_draft_stats_30d")
     async def thirty_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "30d")
 
-    @discord.ui.button(label=PERIOD_CONFIGS["90d"].label, custom_id="server_draft_stats_90d")
+    @ui_button(label=PERIOD_CONFIGS["90d"].label, custom_id="server_draft_stats_90d")
     async def ninety_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "90d")
 
-    @discord.ui.button(label=PERIOD_CONFIGS["lifetime"].label, custom_id="server_draft_stats_lifetime")
+    @ui_button(label=PERIOD_CONFIGS["lifetime"].label, custom_id="server_draft_stats_lifetime")
     async def lifetime_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "lifetime")
 

--- a/cogs/server_draft_stats.py
+++ b/cogs/server_draft_stats.py
@@ -1,7 +1,7 @@
 import operator
 from collections import Counter
-from datetime import datetime, timedelta
-from typing import Any, NamedTuple, Optional
+from datetime import datetime
+from typing import NamedTuple, Optional
 from zoneinfo import ZoneInfo
 
 import discord
@@ -13,6 +13,8 @@ from typing_extensions import override
 from database.db_session import db_session
 from helpers.permissions import has_bot_manager_role
 from helpers.utils import ui_button, not_none
+from services.leaderboard_formatter import TIMEFRAME_DISPLAY
+from services.leaderboard_service import get_timeframe_date
 from models.draft_session import DraftSession
 from models.match import MatchResult
 
@@ -30,35 +32,46 @@ DISPLAY_TZ = ZoneInfo("America/Los_Angeles")
 HISTOGRAM_BAR_WIDTH = 18
 
 
-class PeriodConfig(NamedTuple):
-    label: str
-    lookback: Optional[timedelta]
-    min_drafts: int
-
-
 # Minimum completed drafts a cube needs in the period to be displayed, scaled to
 # the period length so a one-off draft doesn't clutter the shorter views.
-PERIOD_CONFIGS: dict[str, PeriodConfig] = {
-    "14d": PeriodConfig("Last 14 Days", timedelta(days=14), 4),
-    "30d": PeriodConfig("Last 30 Days", timedelta(days=30), 6),
-    "90d": PeriodConfig("Last 90 Days", timedelta(days=90), 8),
-    "lifetime": PeriodConfig("Lifetime", None, 10),
+# Keys are the leaderboard timeframe vocabulary — start dates come from
+# services.leaderboard_service.get_timeframe_date and labels from
+# services.leaderboard_formatter.TIMEFRAME_DISPLAY, so this cog adds no new
+# token->date implementation (the existing duplication is tracked in #391).
+PERIOD_MIN_DRAFTS: dict[str, int] = {
+    "14d": 4,
+    "30d": 6,
+    "90d": 8,
+    "lifetime": 10,
 }
 
 
-async def get_cube_draft_counts(guild_id: str, start_date: Optional[datetime]) -> tuple[Counter[str], int]:
+def _completed_draft_conditions(guild_id: str, start_date: Optional[datetime]) -> list[object]:
+    """The one definition of "completed draft in this guild/period".
+
+    victory_message_id_draft_chat is the repo's standard completed-draft
+    filter (bet_analysis, history_cog, stale_drafts, ...). It is
+    intentionally NOT services.ledger_stats._is_completed: that predicate's
+    legacy-import arm would add ~1200 pre-bot rows that lack cube and
+    teams_start_time, which no section of this embed could display.
+    """
+    conditions: list[object] = [
+        DraftSession.guild_id == guild_id,
+        DraftSession.victory_message_id_draft_chat.isnot(None),
+    ]
+    if start_date is not None:
+        conditions.append(DraftSession.teams_start_time >= start_date)
+    return conditions
+
+
+async def get_cube_draft_counts(guild_id: str, start_date: Optional[datetime]) -> Counter[str]:
     """Count completed drafts per cube for a guild, optionally since start_date.
 
     The GROUP BY runs in SQL so the app only ever receives one row per distinct
     cube, not one row per draft session.
     """
-    conditions = [
-        DraftSession.guild_id == guild_id,
-        DraftSession.victory_message_id_draft_chat.isnot(None),
-        DraftSession.cube.isnot(None),
-    ]
-    if start_date is not None:
-        conditions.append(DraftSession.teams_start_time >= start_date)
+    conditions = _completed_draft_conditions(guild_id, start_date)
+    conditions.append(DraftSession.cube.isnot(None))
 
     async with db_session() as session:
         stmt = (
@@ -69,8 +82,7 @@ async def get_cube_draft_counts(guild_id: str, start_date: Optional[datetime]) -
         result = await session.execute(stmt)
         rows = result.all()
 
-    counts = Counter({cube: count for cube, count in rows})
-    return counts, sum(counts.values())
+    return Counter({cube: count for cube, count in rows})
 
 
 def rank_cubes(counts: Counter[str], min_drafts: int) -> list[tuple[str, int]]:
@@ -89,25 +101,20 @@ class DurationStats(NamedTuple):
     count: int
 
 
-async def _get_duration_stats(
-    guild_id: str,
-    start_date: Optional[datetime],
-    start_column: Any,
-    end_column: Any,
-) -> Optional[DurationStats]:
-    """Min/avg/max seconds between two DraftSession datetime columns, for
-    completed drafts in a guild. A single SQL aggregate query does all the
-    work - only the final numbers (never the underlying rows) reach Python.
+async def get_draft_fire_duration_stats(guild_id: str, start_date: Optional[datetime]) -> Optional[DurationStats]:
+    """Min/avg/max seconds from draft_start_time (sign-up posted) to
+    teams_start_time (ready check passed and teams created). A single SQL
+    aggregate query does all the work - only the final numbers (never the
+    underlying rows) reach Python.
     """
-    conditions: list[object] = [
-        DraftSession.guild_id == guild_id,
-        DraftSession.victory_message_id_draft_chat.isnot(None),
+    start_column = DraftSession.draft_start_time
+    end_column = DraftSession.teams_start_time
+    conditions = _completed_draft_conditions(guild_id, start_date)
+    conditions += [
         start_column.isnot(None),
         end_column.isnot(None),
         end_column >= start_column,
     ]
-    if start_date is not None:
-        conditions.append(DraftSession.teams_start_time >= start_date)
 
     # SQLite has no interval type; julianday() converts a datetime to a
     # fractional day count, so the difference * seconds-per-day is the gap
@@ -123,12 +130,6 @@ async def _get_duration_stats(
     if not count:
         return None
     return DurationStats(float(min_seconds), float(avg_seconds), float(max_seconds), count)
-
-
-async def get_draft_fire_duration_stats(guild_id: str, start_date: Optional[datetime]) -> Optional[DurationStats]:
-    """Min/avg/max seconds from draft_start_time (sign-up posted) to
-    teams_start_time (ready check passed and teams created)."""
-    return await _get_duration_stats(guild_id, start_date, DraftSession.draft_start_time, DraftSession.teams_start_time)
 
 
 async def get_draft_completion_duration_stats(guild_id: str, start_date: Optional[datetime]) -> Optional[DurationStats]:
@@ -151,14 +152,11 @@ async def get_draft_completion_duration_stats(guild_id: str, start_date: Optiona
         .subquery()
     )
 
-    conditions: list[object] = [
-        DraftSession.guild_id == guild_id,
-        DraftSession.victory_message_id_draft_chat.isnot(None),
+    conditions = _completed_draft_conditions(guild_id, start_date)
+    conditions += [
         DraftSession.teams_start_time.isnot(None),
         last_match.c.last_result_at >= DraftSession.teams_start_time,
     ]
-    if start_date is not None:
-        conditions.append(DraftSession.teams_start_time >= start_date)
 
     duration_expr = (
         func.julianday(last_match.c.last_result_at) - func.julianday(DraftSession.teams_start_time)
@@ -201,13 +199,8 @@ async def get_draft_start_hour_counts(guild_id: str, start_date: Optional[dateti
     rows on the far side of a DST change. Only one column is selected, so the
     row-per-draft cost stays negligible.
     """
-    conditions = [
-        DraftSession.guild_id == guild_id,
-        DraftSession.victory_message_id_draft_chat.isnot(None),
-        DraftSession.teams_start_time.isnot(None),
-    ]
-    if start_date is not None:
-        conditions.append(DraftSession.teams_start_time >= start_date)
+    conditions = _completed_draft_conditions(guild_id, start_date)
+    conditions.append(DraftSession.teams_start_time.isnot(None))
 
     async with db_session() as session:
         stmt = select(DraftSession.teams_start_time).where(and_(*conditions))
@@ -277,16 +270,17 @@ def display_tz_label() -> str:
 
 async def build_stats_embed(guild_id: str, period: str) -> discord.Embed:
     """Build the guild-draft-stats embed for a single timeframe."""
-    config = PERIOD_CONFIGS[period]
-    start_date = datetime.now() - config.lookback if config.lookback is not None else None
-    counts, total_drafts = await get_cube_draft_counts(guild_id, start_date)
+    start_date = get_timeframe_date(period)
+    min_drafts = PERIOD_MIN_DRAFTS[period]
+    counts = await get_cube_draft_counts(guild_id, start_date)
+    total_drafts = counts.total()
     fire_stats = await get_draft_fire_duration_stats(guild_id, start_date)
     drafting_stats = await get_draft_completion_duration_stats(guild_id, start_date)
     hour_counts = await get_draft_start_hour_counts(guild_id, start_date)
 
     embed = discord.Embed(
         title="Server Draft Stats",
-        description=f"Timeframe: **{config.label}** (min {config.min_drafts} completed drafts to appear)",
+        description=f"Timeframe: **{TIMEFRAME_DISPLAY[period]}** (min {min_drafts} completed drafts to appear)",
         color=discord.Color.blue(),
     )
     embed.add_field(name="Total Completed Drafts", value=str(total_drafts), inline=False)
@@ -294,11 +288,11 @@ async def build_stats_embed(guild_id: str, period: str) -> discord.Embed:
     if total_drafts == 0:
         embed.add_field(name="Drafts per Cube", value="No completed drafts found for this period.", inline=False)
     else:
-        ranked = rank_cubes(counts, config.min_drafts)
+        ranked = rank_cubes(counts, min_drafts)
         if not ranked:
             embed.add_field(
                 name="Drafts per Cube",
-                value=f"No cube reached the minimum of {config.min_drafts} drafts for this period.",
+                value=f"No cube reached the minimum of {min_drafts} drafts for this period.",
                 inline=False,
             )
         else:
@@ -335,10 +329,11 @@ class DraftStatsView(discord.ui.View):
         self.current_period = current_period
         self.message: Optional[discord.Message] = None
 
-        self.fourteen_day_button.style = self._style_for("14d")
-        self.thirty_day_button.style = self._style_for("30d")
-        self.ninety_day_button.style = self._style_for("90d")
-        self.lifetime_button.style = self._style_for("lifetime")
+        # Each button's custom_id carries its period, so one loop styles all
+        # of them — a new period button never needs a matching style line.
+        for child in self.children:
+            if isinstance(child, discord.ui.Button) and child.custom_id:
+                child.style = self._style_for(child.custom_id.removeprefix("server_draft_stats_"))
 
     def _style_for(self, period: str) -> discord.ButtonStyle:
         return discord.ButtonStyle.primary if period == self.current_period else discord.ButtonStyle.secondary
@@ -355,19 +350,19 @@ class DraftStatsView(discord.ui.View):
         new_view.message = self.message
         await interaction.response.edit_message(embed=embed, view=new_view)
 
-    @ui_button(label=PERIOD_CONFIGS["14d"].label, custom_id="server_draft_stats_14d")
+    @ui_button(label=TIMEFRAME_DISPLAY["14d"], custom_id="server_draft_stats_14d")
     async def fourteen_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "14d")
 
-    @ui_button(label=PERIOD_CONFIGS["30d"].label, custom_id="server_draft_stats_30d")
+    @ui_button(label=TIMEFRAME_DISPLAY["30d"], custom_id="server_draft_stats_30d")
     async def thirty_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "30d")
 
-    @ui_button(label=PERIOD_CONFIGS["90d"].label, custom_id="server_draft_stats_90d")
+    @ui_button(label=TIMEFRAME_DISPLAY["90d"], custom_id="server_draft_stats_90d")
     async def ninety_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "90d")
 
-    @ui_button(label=PERIOD_CONFIGS["lifetime"].label, custom_id="server_draft_stats_lifetime")
+    @ui_button(label=TIMEFRAME_DISPLAY["lifetime"], custom_id="server_draft_stats_lifetime")
     async def lifetime_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
         await self._switch(interaction, "lifetime")
 

--- a/cogs/server_draft_stats.py
+++ b/cogs/server_draft_stats.py
@@ -8,11 +8,10 @@ import discord
 from discord.ext import commands
 from loguru import logger
 from sqlalchemy import and_, func, select
-from typing_extensions import override
 
 from database.db_session import db_session
 from helpers.permissions import has_bot_manager_role
-from helpers.utils import ui_button, not_none
+from helpers.utils import not_none
 from services.leaderboard_formatter import TIMEFRAME_DISPLAY
 from services.leaderboard_service import get_timeframe_date
 from models.draft_session import DraftSession
@@ -320,63 +319,6 @@ async def build_stats_embed(guild_id: str, period: str) -> discord.Embed:
     return embed
 
 
-class DraftStatsView(discord.ui.View):
-    """Timeframe-switching buttons for an already-sent server_draft_stats embed."""
-
-    def __init__(self, guild_id: str, current_period: str) -> None:
-        super().__init__(timeout=180)
-        self.guild_id = guild_id
-        self.current_period = current_period
-        self.message: Optional[discord.Message] = None
-
-        # Each button's custom_id carries its period, so one loop styles all
-        # of them — a new period button never needs a matching style line.
-        for child in self.children:
-            if isinstance(child, discord.ui.Button) and child.custom_id:
-                child.style = self._style_for(child.custom_id.removeprefix("server_draft_stats_"))
-
-    def _style_for(self, period: str) -> discord.ButtonStyle:
-        return discord.ButtonStyle.primary if period == self.current_period else discord.ButtonStyle.secondary
-
-    async def _switch(self, interaction: discord.Interaction, period: str) -> None:
-        try:
-            embed = await build_stats_embed(self.guild_id, period)
-        except Exception as e:
-            logger.error(f"Error refreshing server draft stats: {e}")
-            await interaction.response.send_message(f"An error occurred: {e}", ephemeral=True)
-            return
-
-        new_view = DraftStatsView(self.guild_id, period)
-        new_view.message = self.message
-        await interaction.response.edit_message(embed=embed, view=new_view)
-
-    @ui_button(label=TIMEFRAME_DISPLAY["14d"], custom_id="server_draft_stats_14d")
-    async def fourteen_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
-        await self._switch(interaction, "14d")
-
-    @ui_button(label=TIMEFRAME_DISPLAY["30d"], custom_id="server_draft_stats_30d")
-    async def thirty_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
-        await self._switch(interaction, "30d")
-
-    @ui_button(label=TIMEFRAME_DISPLAY["90d"], custom_id="server_draft_stats_90d")
-    async def ninety_day_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
-        await self._switch(interaction, "90d")
-
-    @ui_button(label=TIMEFRAME_DISPLAY["lifetime"], custom_id="server_draft_stats_lifetime")
-    async def lifetime_button(self, button: "discord.ui.Button[DraftStatsView]", interaction: discord.Interaction) -> None:
-        await self._switch(interaction, "lifetime")
-
-    @override
-    async def on_timeout(self) -> None:
-        if self.message is None:
-            return
-        self.disable_all_items()
-        try:
-            await self.message.edit(view=self)
-        except Exception:
-            pass
-
-
 class ServerDraftStatsCog(commands.Cog):
     """Cog exposing server-wide draft activity stats (completed drafts per cube)."""
 
@@ -389,22 +331,34 @@ class ServerDraftStatsCog(commands.Cog):
         description="[Admin] View completed drafts per cube for this server",
     )
     @has_bot_manager_role()
-    async def server_draft_stats(self, ctx: discord.ApplicationContext) -> None:
-        """Show how many completed drafts each cube has had, with buttons to switch timeframe."""
+    @discord.option(
+        "timeframe",
+        str,
+        description="Stats window",
+        choices=[discord.OptionChoice(name=TIMEFRAME_DISPLAY[p], value=p) for p in PERIOD_MIN_DRAFTS],
+        default=DEFAULT_PERIOD,
+        required=False,
+    )
+    async def server_draft_stats(self, ctx: discord.ApplicationContext, timeframe: str) -> None:
+        """Show how many completed drafts each cube has had in the chosen timeframe.
+
+        Timeframe is a command option rather than buttons on the reply: the
+        reply is ephemeral, and a view's buttons outlive both its timeout and
+        py-cord's ability to edit the message (the webhook handle is clobbered
+        on first dispatch), leaving clickable buttons that silently fail.
+        """
         await ctx.defer(ephemeral=True)
 
         guild_id = str(not_none(ctx.guild).id)
 
         try:
-            embed = await build_stats_embed(guild_id, DEFAULT_PERIOD)
+            embed = await build_stats_embed(guild_id, timeframe)
         except Exception as e:
             logger.error(f"Error fetching server draft stats: {e}")
             await ctx.followup.send(f"An error occurred: {e}", ephemeral=True)
             return
 
-        view = DraftStatsView(guild_id, DEFAULT_PERIOD)
-        message = await ctx.followup.send(embed=embed, view=view, ephemeral=True)
-        view.message = message
+        await ctx.followup.send(embed=embed, ephemeral=True)
 
 
 def setup(bot: commands.Bot) -> None:

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,4 +1,8 @@
-from typing import TypeVar
+from typing import Any, Callable, TypeVar
+
+import discord
+
+_BUTTON_SECONDARY = discord.ButtonStyle.secondary
 
 _T = TypeVar("_T")
 
@@ -12,6 +16,20 @@ def not_none(x: _T | None) -> _T:
     if x is None:
         raise ValueError("Expected non-None value, got None")
     return x
+
+
+def as_messageable(channel: object) -> "discord.abc.Messageable":
+    """Narrow a ``bot.get_channel`` result to something you can send/fetch on.
+
+    ``get_channel`` returns the full channel union; most callers only need
+    Messageable (``send``/``fetch_message`` — satisfied by text channels,
+    threads, and DMs alike). isinstance narrows for the checker AND raises a
+    clear boundary error if the ID points at e.g. a voice channel, instead of
+    an AttributeError deep inside py-cord.
+    """
+    if not isinstance(channel, discord.abc.Messageable):
+        raise TypeError(f"channel is not messageable: {type(channel).__name__}")
+    return channel
 
 
 # Define a mapping of cube names to thumbnail URLs
@@ -31,3 +49,28 @@ DEFAULT_THUMBNAIL = "https://cdn.discordapp.com/attachments/1186757246936424558/
 def get_cube_thumbnail_url(cube_name: str | None) -> str:
     """Get the thumbnail URL for a given cube name."""
     return CUBE_THUMBNAILS.get(cube_name or "", DEFAULT_THUMBNAIL)
+
+def ui_button(
+    *,
+    label: "str | None" = None,
+    custom_id: "str | None" = None,
+    disabled: bool = False,
+    style: "discord.ButtonStyle" = _BUTTON_SECONDARY,
+    emoji: "str | discord.Emoji | discord.PartialEmoji | None" = None,
+    row: "int | None" = None,
+) -> "Callable[[Any], discord.ui.Button[Any]]":
+    """discord.ui.button, typed as what the attribute actually IS.
+
+    py-cord's View.__init__ replaces every decorated method attribute with
+    its Button item, so for the whole life of every instance the attribute's
+    real type is Button — the checker-visible "function" type is true only
+    inside the class body, which nothing observes. Declaring the swap HERE,
+    once, lets `self.my_button.style` / `.disabled` / `.custom_id` typecheck
+    at every use site with no casts. The single static lie (the class-level
+    attribute is the raw function until init) is confined to this wrapper.
+    """
+    # pyrefly: ignore  # bad-return — the deliberate, documented lie above
+    return discord.ui.button(
+        label=label, custom_id=custom_id, disabled=disabled,
+        style=style, emoji=emoji, row=row,
+    )

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -2,8 +2,6 @@ from typing import Any, Callable, TypeVar
 
 import discord
 
-_BUTTON_SECONDARY = discord.ButtonStyle.secondary
-
 _T = TypeVar("_T")
 
 
@@ -55,7 +53,7 @@ def ui_button(
     label: "str | None" = None,
     custom_id: "str | None" = None,
     disabled: bool = False,
-    style: "discord.ButtonStyle" = _BUTTON_SECONDARY,
+    style: "discord.ButtonStyle" = discord.ButtonStyle.secondary,
     emoji: "str | discord.Emoji | discord.PartialEmoji | None" = None,
     row: "int | None" = None,
 ) -> "Callable[[Any], discord.ui.Button[Any]]":

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -9,6 +9,7 @@
 preset = "strict"
 
 project-includes = [
+    "cogs/server_draft_stats.py",
     "helpers/utils.py",
     "ready_check.py",
 ]

--- a/ready_check.py
+++ b/ready_check.py
@@ -2,11 +2,11 @@ import asyncio
 
 import discord
 from loguru import logger
-from typing import Any, Dict, Iterable, List, Literal, Optional, cast
+from typing import Any, Dict, Iterable, List, Literal, Optional
 
 from helpers.display_names import get_display_name_by_id
 from helpers.draft_footer import apply_draft_footer_from_session
-from helpers.utils import not_none
+from helpers.utils import as_messageable, not_none, ui_button
 from models import SignUpHistory
 from services.state_manager import state_manager
 from services.team_creator import create_and_display_teams
@@ -284,7 +284,7 @@ class ReadyCheckSession:
             if not channel:
                 return
 
-            message = await cast(discord.TextChannel, channel).fetch_message(int(draft_session.message_id))
+            message = await as_messageable(channel).fetch_message(int(draft_session.message_id))
 
             # Deferred to avoid circular import: views -> ready_check -> views
             from views import PersistentView
@@ -328,23 +328,19 @@ class ReadyCheckView(discord.ui.View):
     def __init__(self, draft_session_id: str):
         super().__init__(timeout=None)
         self.draft_session_id = draft_session_id
-        # py-cord's View.__init__ replaces each @discord.ui.button-decorated
-        # method attribute with its Button item, so these assignments hit the
-        # ITEM at runtime; the static type is still the decorated function,
-        # hence the casts (same py-cord typing gap as elsewhere in this file).
-        cast(discord.ui.Button[Any], self.ready_button).custom_id = f"ready_check_ready_{self.draft_session_id}"
-        cast(discord.ui.Button[Any], self.not_ready_button).custom_id = f"ready_check_not_ready_{self.draft_session_id}"
-        cast(discord.ui.Button[Any], self.cancel_button).custom_id = f"ready_check_cancel_{self.draft_session_id}"
+        self.ready_button.custom_id = f"ready_check_ready_{self.draft_session_id}"
+        self.not_ready_button.custom_id = f"ready_check_not_ready_{self.draft_session_id}"
+        self.cancel_button.custom_id = f"ready_check_cancel_{self.draft_session_id}"
 
-    @discord.ui.button(label="Ready", style=discord.ButtonStyle.green, custom_id="placeholder_ready")
+    @ui_button(label="Ready", style=discord.ButtonStyle.green, custom_id="placeholder_ready")
     async def ready_button(self, button: discord.ui.Button[Any], interaction: discord.Interaction):
         await self._handle_status(interaction, "ready")
 
-    @discord.ui.button(label="Not Ready", style=discord.ButtonStyle.red, custom_id="placeholder_not_ready")
+    @ui_button(label="Not Ready", style=discord.ButtonStyle.red, custom_id="placeholder_not_ready")
     async def not_ready_button(self, button: discord.ui.Button[Any], interaction: discord.Interaction):
         await self._handle_status(interaction, "not_ready")
 
-    @discord.ui.button(label="Cancel Check", style=discord.ButtonStyle.grey, custom_id="placeholder_cancel_rc")
+    @ui_button(label="Cancel Check", style=discord.ButtonStyle.grey, custom_id="placeholder_cancel_rc")
     async def cancel_button(self, button: discord.ui.Button[Any], interaction: discord.Interaction):
         await interaction.response.send_message(
             "Are you sure you want to cancel the ready check?",

--- a/tests/test_helpers_utils.py
+++ b/tests/test_helpers_utils.py
@@ -26,3 +26,41 @@ def test_cube_thumbnail_falls_back_to_default():
     assert get_cube_thumbnail_url("NoSuchCube") == DEFAULT_THUMBNAIL
     assert get_cube_thumbnail_url(None) == DEFAULT_THUMBNAIL
     assert get_cube_thumbnail_url("LSVCube") != DEFAULT_THUMBNAIL
+
+
+def test_as_messageable_narrows_and_rejects():
+    import discord
+    from unittest.mock import MagicMock
+
+    from helpers.utils import as_messageable
+
+    messageable = MagicMock(spec=discord.TextChannel)
+    assert as_messageable(messageable) is messageable
+
+    with pytest.raises(TypeError):
+        as_messageable(MagicMock(spec=discord.CategoryChannel))
+    with pytest.raises(TypeError):
+        as_messageable(None)
+
+
+def test_ui_button_attribute_is_the_button_item():
+    """The whole point of ui_button: after View init, the decorated attribute
+    IS the Button item, so attribute access needs no casts."""
+    import discord
+
+    from helpers.utils import ui_button
+
+    class _V(discord.ui.View):
+        @ui_button(label="Go", custom_id="x")
+        async def go_button(self, button, interaction):
+            pass
+
+    import asyncio
+
+    async def check():
+        v = _V(timeout=1)
+        assert isinstance(v.go_button, discord.ui.Button)
+        v.go_button.disabled = True          # typed attribute access, no cast
+        assert v.go_button.custom_id == "x"
+
+    asyncio.run(check())

--- a/tests/test_server_draft_stats.py
+++ b/tests/test_server_draft_stats.py
@@ -17,6 +17,9 @@ from database.db_session import AsyncSessionLocal
 from database.models_base import Base
 from models.draft_session import DraftSession
 from models.match import MatchResult
+from services.leaderboard_formatter import TIMEFRAME_DISPLAY
+from services.leaderboard_service import get_timeframe_date
+
 from cogs.server_draft_stats import (
     get_cube_draft_counts,
     rank_cubes,
@@ -31,7 +34,7 @@ from cogs.server_draft_stats import (
     DurationStats,
     DEFAULT_PERIOD,
     HISTOGRAM_BAR_WIDTH,
-    PERIOD_CONFIGS,
+    PERIOD_MIN_DRAFTS,
 )
 
 GUILD = "guild_1"
@@ -132,10 +135,10 @@ class TestGetCubeDraftCounts:
         await _seed("s2", cube="ArenaMax")
         await _seed("s3", cube="Vintage Cube")
 
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
 
         assert counts == Counter({"ArenaMax": 2, "Vintage Cube": 1})
-        assert total == 3
+        assert counts.total() == 3
 
     @pytest.mark.asyncio
     async def test_excludes_in_progress_sessions(self, test_db):
@@ -143,10 +146,10 @@ class TestGetCubeDraftCounts:
         await _seed("s1", cube="ArenaMax", completed=True)
         await _seed("s2", cube="ArenaMax", completed=False, session_stage="pairings")
 
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
 
         assert counts == Counter({"ArenaMax": 1})
-        assert total == 1
+        assert counts.total() == 1
 
     @pytest.mark.asyncio
     async def test_excludes_abandoned_sessions(self, test_db):
@@ -155,30 +158,30 @@ class TestGetCubeDraftCounts:
         await _seed("s1", cube="ArenaMax", completed=True)
         await _seed("s2", cube="ArenaMax", completed=False, session_stage="abandoned")
 
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
 
         assert counts == Counter({"ArenaMax": 1})
-        assert total == 1
+        assert counts.total() == 1
 
     @pytest.mark.asyncio
     async def test_excludes_sessions_without_a_cube(self, test_db):
         await _seed("s1", cube="ArenaMax")
         await _seed("s2", cube=None)
 
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
 
         assert counts == Counter({"ArenaMax": 1})
-        assert total == 1
+        assert counts.total() == 1
 
     @pytest.mark.asyncio
     async def test_excludes_other_guilds(self, test_db):
         await _seed("s1", cube="ArenaMax", guild_id=GUILD)
         await _seed("s2", cube="ArenaMax", guild_id="some_other_guild")
 
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
 
         assert counts == Counter({"ArenaMax": 1})
-        assert total == 1
+        assert counts.total() == 1
 
     @pytest.mark.asyncio
     async def test_start_date_filters_out_older_drafts(self, test_db):
@@ -186,14 +189,14 @@ class TestGetCubeDraftCounts:
         await _seed("recent", cube="ArenaMax", teams_start_time=now)
         await _seed("old", cube="ArenaMax", teams_start_time=now - timedelta(days=30))
 
-        counts, total = await get_cube_draft_counts(GUILD, now - timedelta(days=7))
+        counts = await get_cube_draft_counts(GUILD, now - timedelta(days=7))
         assert counts == Counter({"ArenaMax": 1})
-        assert total == 1
+        assert counts.total() == 1
 
         # With no start_date (lifetime), both are included.
-        counts, total = await get_cube_draft_counts(GUILD, None)
+        counts = await get_cube_draft_counts(GUILD, None)
         assert counts == Counter({"ArenaMax": 2})
-        assert total == 2
+        assert counts.total() == 2
 
 
 class TestRankCubes:
@@ -573,35 +576,43 @@ class TestFormatHourHistogram:
 
 
 class TestPeriodsAndView:
-    """The view wires one hardcoded button per period, with the style set in
-    __init__ and the disable in on_timeout, so each new period touches three
-    places. These cover the two that fail silently if missed."""
+    """The view wires one hardcoded button per period; styling is derived from
+    each button's custom_id in one __init__ loop and disabling uses
+    disable_all_items, so a new period touches two places (the min-drafts map
+    and its button stub). These cover what would fail silently if missed."""
 
     def test_default_period_is_a_configured_period(self):
         """A typo here would KeyError on the command's primary path."""
-        assert DEFAULT_PERIOD in PERIOD_CONFIGS
+        assert DEFAULT_PERIOD in PERIOD_MIN_DRAFTS
+
+    def test_every_period_resolves_through_the_shared_timeframe_helpers(self):
+        """Dates and labels are reused from the leaderboard machinery (#391);
+        a period key outside that vocabulary would KeyError at display time."""
+        for period in PERIOD_MIN_DRAFTS:
+            assert period in TIMEFRAME_DISPLAY
+            start = get_timeframe_date(period)
+            assert (start is None) == (period == "lifetime")
 
     def test_cutoff_rises_with_period_length(self):
-        lookbacks = [
-            (c.min_drafts, c.lookback.days if c.lookback else float("inf"))
-            for c in PERIOD_CONFIGS.values()
-        ]
-        assert lookbacks == sorted(lookbacks)
+        ordered = ["14d", "30d", "90d", "lifetime"]
+        assert list(PERIOD_MIN_DRAFTS) == ordered
+        mins = [PERIOD_MIN_DRAFTS[p] for p in ordered]
+        assert mins == sorted(mins)
 
     @pytest.mark.asyncio
     async def test_one_button_per_period(self):
         view = DraftStatsView(GUILD, DEFAULT_PERIOD)
 
         labels = {getattr(child, "label", None) for child in view.children}
-        assert labels == {config.label for config in PERIOD_CONFIGS.values()}
+        assert labels == {TIMEFRAME_DISPLAY[p] for p in PERIOD_MIN_DRAFTS}
 
     @pytest.mark.asyncio
     async def test_only_the_current_period_is_highlighted(self):
-        """Catches a new period missing its style line in __init__."""
+        """Catches a button whose custom_id doesn't carry its period."""
         view = DraftStatsView(GUILD, "90d")
 
         highlighted = [c for c in view.children if getattr(c, "style", None) == discord.ButtonStyle.primary]
-        assert [c.label for c in highlighted] == [PERIOD_CONFIGS["90d"].label]
+        assert [c.label for c in highlighted] == [TIMEFRAME_DISPLAY["90d"]]
 
     @pytest.mark.asyncio
     async def test_timeout_disables_every_button(self):
@@ -624,4 +635,3 @@ class TestFormatDurationField:
         assert "Min: 1m 0s" in text
         assert "Avg: 5m 0s" in text
         assert "Max: 1h 0m" in text
-        assert "based on" not in text

--- a/tests/test_server_draft_stats.py
+++ b/tests/test_server_draft_stats.py
@@ -1,0 +1,627 @@
+"""
+Unit tests for cogs.server_draft_stats
+"""
+import os
+import tempfile
+import time
+from collections import Counter
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from database.db_session import AsyncSessionLocal
+from database.models_base import Base
+from models.draft_session import DraftSession
+from models.match import MatchResult
+from cogs.server_draft_stats import (
+    get_cube_draft_counts,
+    rank_cubes,
+    get_draft_fire_duration_stats,
+    get_draft_completion_duration_stats,
+    get_draft_start_hour_counts,
+    format_duration,
+    format_duration_field,
+    format_hour_histogram,
+    to_display_hour,
+    DraftStatsView,
+    DurationStats,
+    DEFAULT_PERIOD,
+    HISTOGRAM_BAR_WIDTH,
+    PERIOD_CONFIGS,
+)
+
+GUILD = "guild_1"
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    """Bind the shared session factory to a temporary on-disk SQLite database."""
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    temp_db.close()
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    AsyncSessionLocal.configure(bind=engine)
+
+    yield
+
+    await engine.dispose()
+    os.unlink(temp_db.name)
+
+
+async def _seed(
+    session_id: str,
+    *,
+    guild_id: str = GUILD,
+    cube: str | None = "ArenaMax",
+    completed: bool = True,
+    session_stage: str = "completed",
+    teams_start_time: datetime | None = None,
+    draft_start_time: datetime | None = None,
+) -> None:
+    """Insert a DraftSession row with sensible defaults for these tests.
+
+    draft_start_time is left unset unless explicitly given, since most tests
+    don't care about it.
+    """
+    kwargs = dict(
+        session_id=session_id,
+        guild_id=guild_id,
+        cube=cube,
+        session_stage=session_stage,
+        teams_start_time=teams_start_time or datetime.now(),
+        sign_ups={},
+        victory_message_id_draft_chat="999" if completed else None,
+    )
+    if draft_start_time is not None:
+        kwargs["draft_start_time"] = draft_start_time
+
+    async with AsyncSessionLocal() as db:
+        async with db.begin():
+            db.add(DraftSession(**kwargs))
+
+
+@pytest.fixture
+def eastern_host():
+    """Pin the process's local zone, since to_display_hour reads naive DB
+    timestamps as host-local - otherwise expected hours would vary by machine."""
+    previous = os.environ.get("TZ")
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous
+        time.tzset()
+
+
+_match_counter = 0
+
+
+async def _seed_match_result(session_id: str, result_submitted_at: datetime | None, guild_id: str = GUILD) -> None:
+    """Insert a MatchResult row for a session. result_submitted_at=None models
+    an unreported match still in progress."""
+    global _match_counter
+    _match_counter += 1
+    async with AsyncSessionLocal() as db:
+        async with db.begin():
+            db.add(MatchResult(
+                session_id=session_id,
+                match_number=_match_counter,
+                player1_id="p1",
+                player2_id="p2",
+                winner_id="p1" if result_submitted_at else None,
+                result_submitted_at=result_submitted_at,
+                guild_id=guild_id,
+            ))
+
+
+class TestGetCubeDraftCounts:
+    @pytest.mark.asyncio
+    async def test_aggregates_completed_drafts_by_cube(self, test_db):
+        await _seed("s1", cube="ArenaMax")
+        await _seed("s2", cube="ArenaMax")
+        await _seed("s3", cube="Vintage Cube")
+
+        counts, total = await get_cube_draft_counts(GUILD, None)
+
+        assert counts == Counter({"ArenaMax": 2, "Vintage Cube": 1})
+        assert total == 3
+
+    @pytest.mark.asyncio
+    async def test_excludes_in_progress_sessions(self, test_db):
+        """A draft that hasn't posted a victory message yet isn't 'completed'."""
+        await _seed("s1", cube="ArenaMax", completed=True)
+        await _seed("s2", cube="ArenaMax", completed=False, session_stage="pairings")
+
+        counts, total = await get_cube_draft_counts(GUILD, None)
+
+        assert counts == Counter({"ArenaMax": 1})
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_abandoned_sessions(self, test_db):
+        """Abandoned drafts never get a victory message (see check_and_post_victory_or_draw),
+        so they're excluded the same way an in-progress draft is."""
+        await _seed("s1", cube="ArenaMax", completed=True)
+        await _seed("s2", cube="ArenaMax", completed=False, session_stage="abandoned")
+
+        counts, total = await get_cube_draft_counts(GUILD, None)
+
+        assert counts == Counter({"ArenaMax": 1})
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_sessions_without_a_cube(self, test_db):
+        await _seed("s1", cube="ArenaMax")
+        await _seed("s2", cube=None)
+
+        counts, total = await get_cube_draft_counts(GUILD, None)
+
+        assert counts == Counter({"ArenaMax": 1})
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_other_guilds(self, test_db):
+        await _seed("s1", cube="ArenaMax", guild_id=GUILD)
+        await _seed("s2", cube="ArenaMax", guild_id="some_other_guild")
+
+        counts, total = await get_cube_draft_counts(GUILD, None)
+
+        assert counts == Counter({"ArenaMax": 1})
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_start_date_filters_out_older_drafts(self, test_db):
+        now = datetime.now()
+        await _seed("recent", cube="ArenaMax", teams_start_time=now)
+        await _seed("old", cube="ArenaMax", teams_start_time=now - timedelta(days=30))
+
+        counts, total = await get_cube_draft_counts(GUILD, now - timedelta(days=7))
+        assert counts == Counter({"ArenaMax": 1})
+        assert total == 1
+
+        # With no start_date (lifetime), both are included.
+        counts, total = await get_cube_draft_counts(GUILD, None)
+        assert counts == Counter({"ArenaMax": 2})
+        assert total == 2
+
+
+class TestRankCubes:
+    def test_sorts_descending_by_count(self):
+        counts = Counter({"A": 2, "B": 5, "C": 3})
+        assert rank_cubes(counts, min_drafts=0) == [("B", 5), ("C", 3), ("A", 2)]
+
+    def test_drops_cubes_below_minimum(self):
+        counts = Counter({"A": 5, "B": 2, "C": 1})
+        assert rank_cubes(counts, min_drafts=2) == [("A", 5), ("B", 2)]
+
+    def test_empty_when_nothing_meets_minimum(self):
+        counts = Counter({"A": 1, "B": 1})
+        assert rank_cubes(counts, min_drafts=2) == []
+
+
+class TestGetDraftFireDurationStats:
+    """min/avg/max/count are all computed via a single SQL aggregate query,
+    never by pulling every row into Python - see the docstring on
+    get_draft_fire_duration_stats. julianday() arithmetic in SQLite isn't
+    bit-exact, so seconds are compared with pytest.approx."""
+
+    @pytest.mark.asyncio
+    async def test_none_when_no_data(self, test_db):
+        assert await get_draft_fire_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_single_draft(self, test_db):
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", draft_start_time=start, teams_start_time=start + timedelta(minutes=5))
+
+        stats = await get_draft_fire_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.min_seconds == pytest.approx(300.0, abs=0.01)
+        assert stats.avg_seconds == pytest.approx(300.0, abs=0.01)
+        assert stats.max_seconds == pytest.approx(300.0, abs=0.01)
+        assert stats.count == 1
+
+    @pytest.mark.asyncio
+    async def test_computes_arithmetic_mean(self, test_db):
+        # Deliberately asymmetric (10, 20, 60) so avg (30) and median (20)
+        # would disagree - this proves it's a true mean, not a median.
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        for i, minutes in enumerate([10, 20, 60]):
+            await _seed(f"s{i}", draft_start_time=start, teams_start_time=start + timedelta(minutes=minutes))
+
+        stats = await get_draft_fire_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.min_seconds == pytest.approx(600.0, abs=0.01)
+        assert stats.avg_seconds == pytest.approx(1800.0, abs=0.01)
+        assert stats.max_seconds == pytest.approx(3600.0, abs=0.01)
+        assert stats.count == 3
+
+    @pytest.mark.asyncio
+    async def test_excludes_incomplete_sessions(self, test_db):
+        """Timing is only meaningful for drafts that actually finished."""
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", draft_start_time=start, teams_start_time=start + timedelta(minutes=5), completed=True)
+        await _seed(
+            "s2", draft_start_time=start, teams_start_time=start + timedelta(minutes=50),
+            completed=False, session_stage="pairings",
+        )
+
+        stats = await get_draft_fire_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.count == 1
+        assert stats.avg_seconds == pytest.approx(300.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_excludes_sessions_missing_teams_start_time(self, test_db):
+        """Malformed/legacy row with no teams_start_time can't yield a duration."""
+        async with AsyncSessionLocal() as db:
+            async with db.begin():
+                db.add(DraftSession(
+                    session_id="no_teams_start",
+                    guild_id=GUILD,
+                    cube="ArenaMax",
+                    session_stage="completed",
+                    sign_ups={},
+                    draft_start_time=datetime(2026, 1, 1, 12, 0, 0),
+                    teams_start_time=None,
+                    victory_message_id_draft_chat="999",
+                ))
+
+        assert await get_draft_fire_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_excludes_negative_durations(self, test_db):
+        """Defensive: teams_start_time before draft_start_time is bad data, not a valid sample."""
+        start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("bad", draft_start_time=start, teams_start_time=start - timedelta(minutes=5))
+
+        assert await get_draft_fire_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_start_date_filters_by_teams_start_time(self, test_db):
+        now = datetime.now()
+        await _seed("recent", draft_start_time=now - timedelta(minutes=10), teams_start_time=now)
+        await _seed(
+            "old", draft_start_time=now - timedelta(days=30, minutes=10),
+            teams_start_time=now - timedelta(days=30),
+        )
+
+        stats = await get_draft_fire_duration_stats(GUILD, now - timedelta(days=7))
+        assert stats is not None
+        assert stats.count == 1
+        assert stats.avg_seconds == pytest.approx(600.0, abs=0.01)
+
+        stats = await get_draft_fire_duration_stats(GUILD, None)
+        assert stats is not None
+        assert stats.count == 2
+
+
+class TestGetDraftCompletionDurationStats:
+    """teams_start_time -> the LAST reported match result for that session
+    (max result_submitted_at), via a join against match_results. This is a
+    separate query shape from get_draft_fire_duration_stats (join vs a plain
+    two-column diff), so these tests re-cover the aggregate math as well as
+    the join-specific filters."""
+
+    @pytest.mark.asyncio
+    async def test_none_when_no_data(self, test_db):
+        assert await get_draft_completion_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_uses_the_last_reported_match_not_the_first(self, test_db):
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", teams_start_time=teams_start)
+        await _seed_match_result("s1", teams_start + timedelta(minutes=30))
+        await _seed_match_result("s1", teams_start + timedelta(minutes=50))  # last -> this one counts
+
+        stats = await get_draft_completion_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.avg_seconds == pytest.approx(3000.0, abs=0.01)
+        assert stats.count == 1
+
+    @pytest.mark.asyncio
+    async def test_ignores_unreported_matches(self, test_db):
+        """A match with no result yet shouldn't count as 'the last one', and
+        shouldn't block the session from having a valid (partial) reading."""
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", teams_start_time=teams_start)
+        await _seed_match_result("s1", teams_start + timedelta(minutes=30))
+        await _seed_match_result("s1", None)  # still in progress
+
+        stats = await get_draft_completion_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.avg_seconds == pytest.approx(1800.0, abs=0.01)
+        assert stats.count == 1
+
+    @pytest.mark.asyncio
+    async def test_excludes_sessions_with_no_reported_matches(self, test_db):
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", teams_start_time=teams_start)
+        await _seed_match_result("s1", None)
+
+        assert await get_draft_completion_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_excludes_incomplete_sessions(self, test_db):
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("s1", teams_start_time=teams_start, completed=True)
+        await _seed_match_result("s1", teams_start + timedelta(minutes=45))
+        await _seed("s2", teams_start_time=teams_start, completed=False, session_stage="pairings")
+        await _seed_match_result("s2", teams_start + timedelta(minutes=90))
+
+        stats = await get_draft_completion_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.count == 1
+        assert stats.avg_seconds == pytest.approx(2700.0, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_excludes_negative_durations(self, test_db):
+        """Defensive: a match reported before teams_start_time is bad data, not a valid sample."""
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        await _seed("bad", teams_start_time=teams_start)
+        await _seed_match_result("bad", teams_start - timedelta(minutes=5))
+
+        assert await get_draft_completion_duration_stats(GUILD, None) is None
+
+    @pytest.mark.asyncio
+    async def test_computes_arithmetic_mean_across_sessions(self, test_db):
+        # Deliberately asymmetric (10, 20, 60) so avg (30) and median (20)
+        # would disagree - this proves it's a true mean, not a median.
+        teams_start = datetime(2026, 1, 1, 12, 0, 0)
+        for i, minutes in enumerate([10, 20, 60]):
+            session_id = f"s{i}"
+            await _seed(session_id, teams_start_time=teams_start)
+            await _seed_match_result(session_id, teams_start + timedelta(minutes=minutes))
+
+        stats = await get_draft_completion_duration_stats(GUILD, None)
+
+        assert stats is not None
+        assert stats.avg_seconds == pytest.approx(1800.0, abs=0.01)
+        assert stats.count == 3
+
+    @pytest.mark.asyncio
+    async def test_start_date_filters_by_teams_start_time(self, test_db):
+        now = datetime.now()
+        await _seed("recent", teams_start_time=now - timedelta(minutes=45))
+        await _seed_match_result("recent", now)
+        await _seed("old", teams_start_time=now - timedelta(days=30, minutes=45))
+        await _seed_match_result("old", now - timedelta(days=30))
+
+        stats = await get_draft_completion_duration_stats(GUILD, now - timedelta(days=7))
+        assert stats is not None
+        assert stats.count == 1
+
+        stats = await get_draft_completion_duration_stats(GUILD, None)
+        assert stats is not None
+        assert stats.count == 2
+
+
+class TestFormatDuration:
+    def test_seconds_only(self):
+        assert format_duration(45) == "45s"
+
+    def test_minutes_and_seconds(self):
+        assert format_duration(125) == "2m 5s"
+
+    def test_hours_and_minutes(self):
+        assert format_duration(3900) == "1h 5m"
+
+    def test_rounds_to_nearest_second(self):
+        assert format_duration(59.6) == "1m 0s"
+
+
+@pytest.mark.usefixtures("eastern_host")
+class TestToDisplayHour:
+    """Host pinned to Eastern, so stored timestamps are Eastern and DISPLAY_TZ
+    (Pacific) is a 3-hour shift back."""
+
+    def test_shifts_eastern_to_pacific(self):
+        # 20:30 ET -> 17:30 PT
+        assert to_display_hour(datetime(2026, 7, 25, 20, 30)) == 17
+
+    def test_shift_holds_outside_daylight_saving(self):
+        """Both zones change DST together, so the gap is still 3h in January."""
+        assert to_display_hour(datetime(2026, 1, 15, 20, 30)) == 17
+
+    def test_wraps_backwards_across_midnight(self):
+        """01:00 ET is the previous day in Pacific, so it wraps to 22, not 0."""
+        assert to_display_hour(datetime(2026, 7, 25, 1, 0)) == 22
+
+    def test_midnight_eastern(self):
+        assert to_display_hour(datetime(2026, 7, 25, 0, 0)) == 21
+
+
+@pytest.mark.usefixtures("eastern_host")
+class TestGetDraftStartHourCounts:
+    @pytest.mark.asyncio
+    async def test_empty_when_no_data(self, test_db):
+        assert await get_draft_start_hour_counts(GUILD, None) == Counter()
+
+    @pytest.mark.asyncio
+    async def test_buckets_by_display_hour(self, test_db):
+        # 20:xx ET all land in the 17:00 PT bucket; 22:00 ET lands in 19:00 PT.
+        await _seed("s1", teams_start_time=datetime(2026, 7, 25, 20, 5))
+        await _seed("s2", teams_start_time=datetime(2026, 7, 25, 20, 55))
+        await _seed("s3", teams_start_time=datetime(2026, 7, 26, 22, 0))
+
+        assert await get_draft_start_hour_counts(GUILD, None) == Counter({17: 2, 19: 1})
+
+    @pytest.mark.asyncio
+    async def test_excludes_incomplete_sessions(self, test_db):
+        """Matches the cube counts and timing stats: only completed drafts."""
+        await _seed("s1", teams_start_time=datetime(2026, 7, 25, 20, 0), completed=True)
+        await _seed(
+            "s2", teams_start_time=datetime(2026, 7, 25, 20, 0),
+            completed=False, session_stage="pairings",
+        )
+
+        assert await get_draft_start_hour_counts(GUILD, None) == Counter({17: 1})
+
+    @pytest.mark.asyncio
+    async def test_excludes_other_guilds(self, test_db):
+        await _seed("s1", teams_start_time=datetime(2026, 7, 25, 20, 0), guild_id=GUILD)
+        await _seed("s2", teams_start_time=datetime(2026, 7, 25, 20, 0), guild_id="some_other_guild")
+
+        assert await get_draft_start_hour_counts(GUILD, None) == Counter({17: 1})
+
+    @pytest.mark.asyncio
+    async def test_excludes_sessions_missing_teams_start_time(self, test_db):
+        """A legacy row with no teams_start_time must not reach the conversion."""
+        async with AsyncSessionLocal() as db:
+            async with db.begin():
+                db.add(DraftSession(
+                    session_id="no_teams_start",
+                    guild_id=GUILD,
+                    cube="ArenaMax",
+                    session_stage="completed",
+                    sign_ups={},
+                    teams_start_time=None,
+                    victory_message_id_draft_chat="999",
+                ))
+
+        assert await get_draft_start_hour_counts(GUILD, None) == Counter()
+
+    @pytest.mark.asyncio
+    async def test_start_date_filters_out_older_drafts(self, test_db):
+        now = datetime.now()
+        await _seed("recent", teams_start_time=now)
+        await _seed("old", teams_start_time=now - timedelta(days=30))
+
+        recent_only = await get_draft_start_hour_counts(GUILD, now - timedelta(days=7))
+        assert sum(recent_only.values()) == 1
+
+        lifetime = await get_draft_start_hour_counts(GUILD, None)
+        assert sum(lifetime.values()) == 2
+
+
+class TestFormatHourHistogram:
+    def test_no_data_message_when_empty(self):
+        assert format_hour_histogram(Counter()) == "No draft start times available for this period."
+
+    def test_lists_all_twenty_four_hours(self):
+        """Quiet hours are empty rows, not omitted, so the day's shape is intact."""
+        text = format_hour_histogram(Counter({17: 5}))
+        hour_rows = [line for line in text.splitlines() if line[:2].isdigit()]
+
+        assert len(hour_rows) == 24
+        assert hour_rows[0].startswith("00")
+        assert hour_rows[-1].startswith("23")
+
+    def test_has_a_column_header_above_a_rule(self):
+        text = format_hour_histogram(Counter({17: 5}))
+        header, rule = text.splitlines()[1:3]
+
+        assert header.startswith("HH")
+        assert header.rstrip().endswith("#")
+        assert set(rule) == {"─"}
+        assert len(rule) == len(header)
+
+    def test_busiest_hour_gets_a_full_width_bar(self):
+        text = format_hour_histogram(Counter({17: 10, 18: 5}))
+        peak_line = next(line for line in text.splitlines() if line.startswith("17"))
+
+        assert peak_line.count("█") == HISTOGRAM_BAR_WIDTH
+
+    def test_scales_other_hours_against_the_peak(self):
+        text = format_hour_histogram(Counter({17: 12, 18: 6}))
+        half_line = next(line for line in text.splitlines() if line.startswith("18"))
+
+        assert half_line.count("█") == HISTOGRAM_BAR_WIDTH // 2
+
+    def test_low_but_nonzero_hour_still_draws_a_block(self):
+        """1 of 100 rounds to zero blocks, so it has to floor at one."""
+        text = format_hour_histogram(Counter({10: 100, 3: 1}))
+        thin_line = next(line for line in text.splitlines() if line.startswith("03"))
+
+        assert thin_line.count("█") == 1
+
+    def test_empty_hour_draws_no_blocks(self):
+        text = format_hour_histogram(Counter({10: 100}))
+        empty_line = next(line for line in text.splitlines() if line.startswith("04"))
+
+        assert "█" not in empty_line
+        assert empty_line.endswith("0")
+
+    def test_counts_are_rendered(self):
+        text = format_hour_histogram(Counter({17: 23}))
+        peak_line = next(line for line in text.splitlines() if line.startswith("17"))
+
+        assert peak_line.endswith("23")
+
+    def test_fits_within_discord_embed_field_limit(self):
+        """Discord rejects an embed field over 1024 chars, failing the command."""
+        text = format_hour_histogram(Counter({hour: 9999 for hour in range(24)}))
+
+        assert len(text) <= 1024
+
+
+class TestPeriodsAndView:
+    """The view wires one hardcoded button per period, with the style set in
+    __init__ and the disable in on_timeout, so each new period touches three
+    places. These cover the two that fail silently if missed."""
+
+    def test_default_period_is_a_configured_period(self):
+        """A typo here would KeyError on the command's primary path."""
+        assert DEFAULT_PERIOD in PERIOD_CONFIGS
+
+    def test_cutoff_rises_with_period_length(self):
+        lookbacks = [
+            (c.min_drafts, c.lookback.days if c.lookback else float("inf"))
+            for c in PERIOD_CONFIGS.values()
+        ]
+        assert lookbacks == sorted(lookbacks)
+
+    @pytest.mark.asyncio
+    async def test_one_button_per_period(self):
+        view = DraftStatsView(GUILD, DEFAULT_PERIOD)
+
+        labels = {getattr(child, "label", None) for child in view.children}
+        assert labels == {config.label for config in PERIOD_CONFIGS.values()}
+
+    @pytest.mark.asyncio
+    async def test_only_the_current_period_is_highlighted(self):
+        """Catches a new period missing its style line in __init__."""
+        view = DraftStatsView(GUILD, "90d")
+
+        highlighted = [c for c in view.children if getattr(c, "style", None) == discord.ButtonStyle.primary]
+        assert [c.label for c in highlighted] == [PERIOD_CONFIGS["90d"].label]
+
+    @pytest.mark.asyncio
+    async def test_timeout_disables_every_button(self):
+        """Catches a new period missing its disable line in on_timeout."""
+        view = DraftStatsView(GUILD, DEFAULT_PERIOD)
+        view.message = AsyncMock()
+
+        await view.on_timeout()
+
+        assert all(child.disabled for child in view.children)
+
+
+class TestFormatDurationField:
+    def test_no_data_message_when_none(self):
+        assert format_duration_field(None) == "No timing data available for this period."
+
+    def test_renders_min_avg_max(self):
+        stats = DurationStats(min_seconds=60, avg_seconds=300, max_seconds=3600, count=5)
+        text = format_duration_field(stats)
+        assert "Min: 1m 0s" in text
+        assert "Avg: 5m 0s" in text
+        assert "Max: 1h 0m" in text
+        assert "based on" not in text

--- a/tests/test_server_draft_stats.py
+++ b/tests/test_server_draft_stats.py
@@ -6,9 +6,7 @@ import tempfile
 import time
 from collections import Counter
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock
 
-import discord
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -30,7 +28,7 @@ from cogs.server_draft_stats import (
     format_duration_field,
     format_hour_histogram,
     to_display_hour,
-    DraftStatsView,
+    ServerDraftStatsCog,
     DurationStats,
     DEFAULT_PERIOD,
     HISTOGRAM_BAR_WIDTH,
@@ -575,11 +573,12 @@ class TestFormatHourHistogram:
         assert len(text) <= 1024
 
 
-class TestPeriodsAndView:
-    """The view wires one hardcoded button per period; styling is derived from
-    each button's custom_id in one __init__ loop and disabling uses
-    disable_all_items, so a new period touches two places (the min-drafts map
-    and its button stub). These cover what would fail silently if missed."""
+class TestPeriodsAndCommand:
+    """Timeframe selection lives on the slash command as a choices option (an
+    earlier button-based view was dropped: its 180s timeout left dead-looking
+    buttons on the ephemeral message once py-cord clobbered the webhook message
+    handle). The option's choices are derived from PERIOD_MIN_DRAFTS, so these
+    pin the wiring that would fail silently if a period were added halfway."""
 
     def test_default_period_is_a_configured_period(self):
         """A typo here would KeyError on the command's primary path."""
@@ -599,30 +598,20 @@ class TestPeriodsAndView:
         mins = [PERIOD_MIN_DRAFTS[p] for p in ordered]
         assert mins == sorted(mins)
 
-    @pytest.mark.asyncio
-    async def test_one_button_per_period(self):
-        view = DraftStatsView(GUILD, DEFAULT_PERIOD)
+    def _timeframe_option(self):
+        options = ServerDraftStatsCog.server_draft_stats.options
+        return next(o for o in options if o.name == "timeframe")
 
-        labels = {getattr(child, "label", None) for child in view.children}
-        assert labels == {TIMEFRAME_DISPLAY[p] for p in PERIOD_MIN_DRAFTS}
+    def test_timeframe_option_offers_every_period(self):
+        """One choice per configured period, labelled with its display name."""
+        choices = self._timeframe_option().choices
+        assert {c.value for c in choices} == set(PERIOD_MIN_DRAFTS)
+        assert {c.name for c in choices} == {TIMEFRAME_DISPLAY[p] for p in PERIOD_MIN_DRAFTS}
 
-    @pytest.mark.asyncio
-    async def test_only_the_current_period_is_highlighted(self):
-        """Catches a button whose custom_id doesn't carry its period."""
-        view = DraftStatsView(GUILD, "90d")
-
-        highlighted = [c for c in view.children if getattr(c, "style", None) == discord.ButtonStyle.primary]
-        assert [c.label for c in highlighted] == [TIMEFRAME_DISPLAY["90d"]]
-
-    @pytest.mark.asyncio
-    async def test_timeout_disables_every_button(self):
-        """Catches a new period missing its disable line in on_timeout."""
-        view = DraftStatsView(GUILD, DEFAULT_PERIOD)
-        view.message = AsyncMock()
-
-        await view.on_timeout()
-
-        assert all(child.disabled for child in view.children)
+    def test_timeframe_option_defaults_to_the_default_period(self):
+        option = self._timeframe_option()
+        assert option.default == DEFAULT_PERIOD
+        assert option.required is False
 
 
 class TestFormatDurationField:


### PR DESCRIPTION
## Summary
Provide a `/server_draft_stats` command for admins to help answer q's about how long drafts typically take, when the server is actually active, and which cubes are being drafted.

Reports four things per timeframe — 14d / 30d / 90d / Lifetime, opening on 90d:
- **Drafts per cube**, with a min-drafts cutoff scaled to the period so one-off cubes don't clutter the shorter views
- **Time to Fire** — sign-up posted → teams created
- **Time to Finish** — teams created → last match reported
- **Draft starts by hour** — all 24 hours as a bar chart, so you can see when the server fires drafts

<img width="600" height="1086" alt="Screenshot 2026-07-29 at 22 46 49" src="https://github.com/user-attachments/assets/9b029406-e6f3-4a4c-ac49-3612b42b2504" />
