### PR TITLE
Auto-grant utility bot roles access to draft channels

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,10 +11,10 @@ SPECIAL_GUILD_ID = "336345350535118849"
 # Change this to switch between environments (prod, beta, dev)
 DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
-# Assistant bots granted read+send in every draft channel (incl. private team
+# Bots granted read+send in every draft channel (incl. private team
 # channels). Matched against bot-managed integration roles only — the role a
 # bot auto-creates when invited — so "Scryfall" works with zero guild setup.
-DEFAULT_DRAFT_ASSISTANT_ROLES = ["Scryfall"]
+DEFAULT_BOTS_WITH_DRAFT_ACCESS = ["Scryfall"]
 
 def is_test_mode() -> bool:
     """Returns True if TEST_MODE env var is set to a truthy value."""
@@ -39,7 +39,7 @@ class Config:
                     "winston": "Winston Gamer",
                 },
                 "timeout": "the pit",
-                "draft_assistants": list(DEFAULT_DRAFT_ASSISTANT_ROLES)  # Assistant-bot roles granted read+send in every draft channel
+                "bots_with_draft_access": list(DEFAULT_BOTS_WITH_DRAFT_ACCESS)  # Bot roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -150,7 +150,7 @@ class Config:
                     "winston": "Winston Gamer",
                 },
                 "suspected_bot": "suspected bot",
-                "draft_assistants": list(DEFAULT_DRAFT_ASSISTANT_ROLES)  # Assistant-bot roles granted read+send in every draft channel
+                "bots_with_draft_access": list(DEFAULT_BOTS_WITH_DRAFT_ACCESS)  # Bot roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -385,12 +385,12 @@ def get_dm_notifications_default(guild_id):
     config = get_config(guild_id)
     return config.get("notifications", {}).get("dm_notifications_default", True)
 
-def get_draft_assistant_roles(guild_id):
-    """Get the list of assistant-bot role names auto-granted read+send access to every
-    draft channel (e.g. the Scryfall card-lookup bot's role). Only bot-managed
+def get_bots_with_draft_access(guild_id):
+    """Get the list of bot role names auto-granted read+send access to every draft
+    channel (e.g. the Scryfall card-lookup bot's role). Only bot-managed
     integration roles are honored at grant time."""
     config = get_config(guild_id)
-    return config.get("roles", {}).get("draft_assistants", list(DEFAULT_DRAFT_ASSISTANT_ROLES))
+    return config.get("roles", {}).get("bots_with_draft_access", list(DEFAULT_BOTS_WITH_DRAFT_ACCESS))
 
 def get_league_challenge_hours(guild_id):
     """Get league challenge timeout in hours"""
@@ -412,10 +412,10 @@ def migrate_configs():
             config["roles"]["timeout"] = "the pit"
             updated = True
 
-        # Add draft_assistants roles if missing (assistant-bot roles auto-granted
+        # Add bots_with_draft_access if missing (bot roles auto-granted
         # access to every draft channel, e.g. the Scryfall card-lookup bot)
-        if "roles" in config and "draft_assistants" not in config["roles"]:
-            config["roles"]["draft_assistants"] = list(DEFAULT_DRAFT_ASSISTANT_ROLES)
+        if "roles" in config and "bots_with_draft_access" not in config["roles"]:
+            config["roles"]["bots_with_draft_access"] = list(DEFAULT_BOTS_WITH_DRAFT_ACCESS)
             updated = True
 
         # Add timeout configuration if missing

--- a/config.py
+++ b/config.py
@@ -11,6 +11,11 @@ SPECIAL_GUILD_ID = "336345350535118849"
 # Change this to switch between environments (prod, beta, dev)
 DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 
+# Assistant bots granted read+send in every draft channel (incl. private team
+# channels). Matched against bot-managed integration roles only — the role a
+# bot auto-creates when invited — so "Scryfall" works with zero guild setup.
+DEFAULT_DRAFT_ASSISTANT_ROLES = ["Scryfall"]
+
 def is_test_mode() -> bool:
     """Returns True if TEST_MODE env var is set to a truthy value."""
     return os.environ.get("TEST_MODE", "false").lower() in ("true", "1", "yes")
@@ -34,7 +39,7 @@ class Config:
                     "winston": "Winston Gamer",
                 },
                 "timeout": "the pit",
-                "extra_draft_channel_access": ["Scryfall"]  # Bot/utility roles granted read+send in every draft channel
+                "draft_assistants": list(DEFAULT_DRAFT_ASSISTANT_ROLES)  # Assistant-bot roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -145,7 +150,7 @@ class Config:
                     "winston": "Winston Gamer",
                 },
                 "suspected_bot": "suspected bot",
-                "extra_draft_channel_access": ["Scryfall"]  # Bot/utility roles granted read+send in every draft channel
+                "draft_assistants": list(DEFAULT_DRAFT_ASSISTANT_ROLES)  # Assistant-bot roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -380,11 +385,12 @@ def get_dm_notifications_default(guild_id):
     config = get_config(guild_id)
     return config.get("notifications", {}).get("dm_notifications_default", True)
 
-def get_extra_draft_channel_access_roles(guild_id):
-    """Get the list of role names auto-granted read+send access to every draft channel
-    (e.g. the Scryfall card-lookup bot's role)"""
+def get_draft_assistant_roles(guild_id):
+    """Get the list of assistant-bot role names auto-granted read+send access to every
+    draft channel (e.g. the Scryfall card-lookup bot's role). Only bot-managed
+    integration roles are honored at grant time."""
     config = get_config(guild_id)
-    return config.get("roles", {}).get("extra_draft_channel_access", ["Scryfall"])
+    return config.get("roles", {}).get("draft_assistants", list(DEFAULT_DRAFT_ASSISTANT_ROLES))
 
 def get_league_challenge_hours(guild_id):
     """Get league challenge timeout in hours"""
@@ -406,10 +412,10 @@ def migrate_configs():
             config["roles"]["timeout"] = "the pit"
             updated = True
 
-        # Add extra_draft_channel_access roles if missing (bot/utility roles auto-granted
+        # Add draft_assistants roles if missing (assistant-bot roles auto-granted
         # access to every draft channel, e.g. the Scryfall card-lookup bot)
-        if "roles" in config and "extra_draft_channel_access" not in config["roles"]:
-            config["roles"]["extra_draft_channel_access"] = ["Scryfall"]
+        if "roles" in config and "draft_assistants" not in config["roles"]:
+            config["roles"]["draft_assistants"] = list(DEFAULT_DRAFT_ASSISTANT_ROLES)
             updated = True
 
         # Add timeout configuration if missing

--- a/config.py
+++ b/config.py
@@ -33,7 +33,8 @@ class Config:
                 "session_roles": {
                     "winston": "Winston Gamer",
                 },
-                "timeout": "the pit"
+                "timeout": "the pit",
+                "extra_draft_channel_access": ["Scryfall"]  # Bot/utility roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -143,7 +144,8 @@ class Config:
                 "session_roles": {
                     "winston": "Winston Gamer",
                 },
-                "suspected_bot": "suspected bot"
+                "suspected_bot": "suspected bot",
+                "extra_draft_channel_access": ["Scryfall"]  # Bot/utility roles granted read+send in every draft channel
             },
             "timezone": "US/Eastern",
             "external": {
@@ -378,6 +380,12 @@ def get_dm_notifications_default(guild_id):
     config = get_config(guild_id)
     return config.get("notifications", {}).get("dm_notifications_default", True)
 
+def get_extra_draft_channel_access_roles(guild_id):
+    """Get the list of role names auto-granted read+send access to every draft channel
+    (e.g. the Scryfall card-lookup bot's role)"""
+    config = get_config(guild_id)
+    return config.get("roles", {}).get("extra_draft_channel_access", ["Scryfall"])
+
 def get_league_challenge_hours(guild_id):
     """Get league challenge timeout in hours"""
     timeout_config = get_timeout_config(guild_id)
@@ -397,7 +405,13 @@ def migrate_configs():
         if "roles" in config and "timeout" not in config["roles"]:
             config["roles"]["timeout"] = "the pit"
             updated = True
-            
+
+        # Add extra_draft_channel_access roles if missing (bot/utility roles auto-granted
+        # access to every draft channel, e.g. the Scryfall card-lookup bot)
+        if "roles" in config and "extra_draft_channel_access" not in config["roles"]:
+            config["roles"]["extra_draft_channel_access"] = ["Scryfall"]
+            updated = True
+
         # Add timeout configuration if missing
         if "timeouts" not in config:
             # Special handling for test guild - give it longer timeouts and cleanup exemption

--- a/tests/test_bots_with_draft_access.py
+++ b/tests/test_bots_with_draft_access.py
@@ -1,31 +1,31 @@
-"""Tests for draft-assistant role config: default, opt-out, and migration."""
+"""Tests for bots_with_draft_access role config: default, opt-out, and migration."""
 from unittest.mock import patch
 
 import config as config_module
-from config import DEFAULT_DRAFT_ASSISTANT_ROLES, get_draft_assistant_roles
+from config import DEFAULT_BOTS_WITH_DRAFT_ACCESS, get_bots_with_draft_access
 
 
 # ---- getter semantics ----------------------------------------------------------------
 
 def test_defaults_to_scryfall_when_key_missing():
     with patch("config.get_config", return_value={"roles": {}}):
-        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+        assert get_bots_with_draft_access(123) == DEFAULT_BOTS_WITH_DRAFT_ACCESS
 
 
 def test_defaults_apply_without_roles_block():
     with patch("config.get_config", return_value={}):
-        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+        assert get_bots_with_draft_access(123) == DEFAULT_BOTS_WITH_DRAFT_ACCESS
 
 
 def test_explicit_empty_list_opts_out():
-    with patch("config.get_config", return_value={"roles": {"draft_assistants": []}}):
-        assert get_draft_assistant_roles(123) == []
+    with patch("config.get_config", return_value={"roles": {"bots_with_draft_access": []}}):
+        assert get_bots_with_draft_access(123) == []
 
 
 def test_default_is_not_aliased_to_caller():
     with patch("config.get_config", return_value={"roles": {}}):
-        get_draft_assistant_roles(123).append("Mutated")
-        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+        get_bots_with_draft_access(123).append("Mutated")
+        assert get_bots_with_draft_access(123) == DEFAULT_BOTS_WITH_DRAFT_ACCESS
 
 
 # ---- migrate_configs injects the key ---------------------------------------------------
@@ -41,12 +41,12 @@ def _migrate_fake_guild(roles):
         del config_module.bot_config.configs[guild_id]
 
 
-def test_migrate_configs_adds_draft_assistants_when_missing():
+def test_migrate_configs_adds_bots_with_draft_access_when_missing():
     roles = _migrate_fake_guild({"admin": "Cube Overseer"})
-    assert roles["draft_assistants"] == DEFAULT_DRAFT_ASSISTANT_ROLES
-    assert roles["draft_assistants"] is not DEFAULT_DRAFT_ASSISTANT_ROLES
+    assert roles["bots_with_draft_access"] == DEFAULT_BOTS_WITH_DRAFT_ACCESS
+    assert roles["bots_with_draft_access"] is not DEFAULT_BOTS_WITH_DRAFT_ACCESS
 
 
 def test_migrate_configs_keeps_explicit_opt_out():
-    roles = _migrate_fake_guild({"draft_assistants": []})
-    assert roles["draft_assistants"] == []
+    roles = _migrate_fake_guild({"bots_with_draft_access": []})
+    assert roles["bots_with_draft_access"] == []

--- a/tests/test_draft_assistant_roles.py
+++ b/tests/test_draft_assistant_roles.py
@@ -1,0 +1,52 @@
+"""Tests for draft-assistant role config: default, opt-out, and migration."""
+from unittest.mock import patch
+
+import config as config_module
+from config import DEFAULT_DRAFT_ASSISTANT_ROLES, get_draft_assistant_roles
+
+
+# ---- getter semantics ----------------------------------------------------------------
+
+def test_defaults_to_scryfall_when_key_missing():
+    with patch("config.get_config", return_value={"roles": {}}):
+        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+
+
+def test_defaults_apply_without_roles_block():
+    with patch("config.get_config", return_value={}):
+        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+
+
+def test_explicit_empty_list_opts_out():
+    with patch("config.get_config", return_value={"roles": {"draft_assistants": []}}):
+        assert get_draft_assistant_roles(123) == []
+
+
+def test_default_is_not_aliased_to_caller():
+    with patch("config.get_config", return_value={"roles": {}}):
+        get_draft_assistant_roles(123).append("Mutated")
+        assert get_draft_assistant_roles(123) == DEFAULT_DRAFT_ASSISTANT_ROLES
+
+
+# ---- migrate_configs injects the key ---------------------------------------------------
+
+def _migrate_fake_guild(roles):
+    guild_id = "999000999000999000"
+    config_module.bot_config.configs[guild_id] = {"roles": dict(roles)}
+    try:
+        with patch.object(config_module.bot_config, "save_config"):
+            config_module.migrate_configs()
+        return config_module.bot_config.configs[guild_id]["roles"]
+    finally:
+        del config_module.bot_config.configs[guild_id]
+
+
+def test_migrate_configs_adds_draft_assistants_when_missing():
+    roles = _migrate_fake_guild({"admin": "Cube Overseer"})
+    assert roles["draft_assistants"] == DEFAULT_DRAFT_ASSISTANT_ROLES
+    assert roles["draft_assistants"] is not DEFAULT_DRAFT_ASSISTANT_ROLES
+
+
+def test_migrate_configs_keeps_explicit_opt_out():
+    roles = _migrate_fake_guild({"draft_assistants": []})
+    assert roles["draft_assistants"] == []

--- a/views.py
+++ b/views.py
@@ -1320,13 +1320,11 @@ class PersistentView(discord.ui.View):
         # creates when a bot is invited) are honored: they cannot be assigned to
         # humans, so a same-named vanity role can't be used to read private team
         # channels.
-        for role_name in get_bots_with_draft_access(guild.id):
-            role = discord.utils.get(guild.roles, name=role_name)
-            bot_managed = role is not None and role.tags is not None and role.tags.bot_id is not None
-            if bot_managed:
-                overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
-            status = "granted" if bot_managed else "skipped (not bot-managed)" if role else "skipped (role not found)"
-            logger.info(f"Draft-access bot role '{role_name}' on '{channel_name}': {status}")
+        wanted_bots = set(get_bots_with_draft_access(guild.id))
+        bot_roles = [r for r in guild.roles if r.name in wanted_bots and r.tags and r.tags.bot_id]
+        for role in bot_roles:
+            overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+        logger.info(f"Draft-access bot roles on '{channel_name}': {[r.name for r in bot_roles] or 'none'}")
 
         # Only add admin roles to the Draft chat, not to team-specific channels
         if team_name == "Draft":

--- a/views.py
+++ b/views.py
@@ -1288,7 +1288,7 @@ class PersistentView(discord.ui.View):
     
 
     async def create_team_channel(self, guild, team_name, team_members, team_a=None, team_b=None):
-        from config import get_config, is_special_guild
+        from config import get_config, get_extra_draft_channel_access_roles, is_special_guild
 
         config = get_config(guild.id)
         draft_category = discord.utils.get(guild.categories, name=config["categories"]["draft"])
@@ -1313,6 +1313,17 @@ class PersistentView(discord.ui.View):
             guild.default_role: discord.PermissionOverwrite(read_messages=False),
             guild.me: discord.PermissionOverwrite(read_messages=True, manage_messages=True)
         }
+
+        # Bot/utility roles (e.g. the Scryfall card-lookup bot) get read+send in every
+        # draft channel, including team-specific ones. Missing roles are skipped
+        # silently since not every guild has invited every configured bot.
+        for role_name in get_extra_draft_channel_access_roles(guild.id):
+            role = discord.utils.get(guild.roles, name=role_name)
+            if role:
+                overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+                logger.info(f"Granting '{role_name}' role access to channel '{channel_name}'")
+            else:
+                logger.debug(f"Extra-channel-access role '{role_name}' not found in guild {guild.name}")
 
         # Only add admin roles to the Draft chat, not to team-specific channels
         if team_name == "Draft":

--- a/views.py
+++ b/views.py
@@ -1325,14 +1325,15 @@ class PersistentView(discord.ui.View):
             role = discord.utils.get(guild.roles, name=role_name)
             if role is None:
                 logger.debug(f"Draft-access bot role '{role_name}' not found in guild {guild.name}")
-            elif role.tags is None or role.tags.bot_id is None:
+                continue
+            if role.tags is None or role.tags.bot_id is None:
                 logger.warning(
                     f"Draft-access bot role '{role_name}' in guild {guild.name} is not a "
                     f"bot-managed role; skipping channel access grant"
                 )
-            else:
-                overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
-                logger.info(f"Granting '{role_name}' role access to channel '{channel_name}'")
+                continue
+            overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+            logger.info(f"Granting '{role_name}' role access to channel '{channel_name}'")
 
         # Only add admin roles to the Draft chat, not to team-specific channels
         if team_name == "Draft":

--- a/views.py
+++ b/views.py
@@ -1316,24 +1316,17 @@ class PersistentView(discord.ui.View):
 
         # Bots with draft access (e.g. the Scryfall card-lookup bot) get read+send in
         # every draft channel, including team-specific ones and the premade voice
-        # channels created below. Missing roles are skipped silently since not every
-        # guild has invited every configured bot. Only bot-managed integration roles
-        # (the role Discord creates when a bot is invited) are honored: they cannot be
-        # assigned to humans, so a same-named vanity role can't be used to read
-        # private team channels.
+        # channels created below. Only bot-managed integration roles (the role Discord
+        # creates when a bot is invited) are honored: they cannot be assigned to
+        # humans, so a same-named vanity role can't be used to read private team
+        # channels.
         for role_name in get_bots_with_draft_access(guild.id):
             role = discord.utils.get(guild.roles, name=role_name)
-            if role is None:
-                logger.debug(f"Draft-access bot role '{role_name}' not found in guild {guild.name}")
-                continue
-            if role.tags is None or role.tags.bot_id is None:
-                logger.warning(
-                    f"Draft-access bot role '{role_name}' in guild {guild.name} is not a "
-                    f"bot-managed role; skipping channel access grant"
-                )
-                continue
-            overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
-            logger.info(f"Granting '{role_name}' role access to channel '{channel_name}'")
+            bot_managed = role is not None and role.tags is not None and role.tags.bot_id is not None
+            if bot_managed:
+                overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
+            status = "granted" if bot_managed else "skipped (not bot-managed)" if role else "skipped (role not found)"
+            logger.info(f"Draft-access bot role '{role_name}' on '{channel_name}': {status}")
 
         # Only add admin roles to the Draft chat, not to team-specific channels
         if team_name == "Draft":

--- a/views.py
+++ b/views.py
@@ -1288,7 +1288,7 @@ class PersistentView(discord.ui.View):
     
 
     async def create_team_channel(self, guild, team_name, team_members, team_a=None, team_b=None):
-        from config import get_config, get_draft_assistant_roles, is_special_guild
+        from config import get_config, get_bots_with_draft_access, is_special_guild
 
         config = get_config(guild.id)
         draft_category = discord.utils.get(guild.categories, name=config["categories"]["draft"])
@@ -1314,20 +1314,20 @@ class PersistentView(discord.ui.View):
             guild.me: discord.PermissionOverwrite(read_messages=True, manage_messages=True)
         }
 
-        # Draft-assistant bots (e.g. the Scryfall card-lookup bot) get read+send in
+        # Bots with draft access (e.g. the Scryfall card-lookup bot) get read+send in
         # every draft channel, including team-specific ones and the premade voice
         # channels created below. Missing roles are skipped silently since not every
         # guild has invited every configured bot. Only bot-managed integration roles
         # (the role Discord creates when a bot is invited) are honored: they cannot be
         # assigned to humans, so a same-named vanity role can't be used to read
         # private team channels.
-        for role_name in get_draft_assistant_roles(guild.id):
+        for role_name in get_bots_with_draft_access(guild.id):
             role = discord.utils.get(guild.roles, name=role_name)
             if role is None:
-                logger.debug(f"Draft-assistant role '{role_name}' not found in guild {guild.name}")
+                logger.debug(f"Draft-access bot role '{role_name}' not found in guild {guild.name}")
             elif role.tags is None or role.tags.bot_id is None:
                 logger.warning(
-                    f"Draft-assistant role '{role_name}' in guild {guild.name} is not a "
+                    f"Draft-access bot role '{role_name}' in guild {guild.name} is not a "
                     f"bot-managed role; skipping channel access grant"
                 )
             else:

--- a/views.py
+++ b/views.py
@@ -1288,7 +1288,7 @@ class PersistentView(discord.ui.View):
     
 
     async def create_team_channel(self, guild, team_name, team_members, team_a=None, team_b=None):
-        from config import get_config, get_extra_draft_channel_access_roles, is_special_guild
+        from config import get_config, get_draft_assistant_roles, is_special_guild
 
         config = get_config(guild.id)
         draft_category = discord.utils.get(guild.categories, name=config["categories"]["draft"])
@@ -1314,16 +1314,25 @@ class PersistentView(discord.ui.View):
             guild.me: discord.PermissionOverwrite(read_messages=True, manage_messages=True)
         }
 
-        # Bot/utility roles (e.g. the Scryfall card-lookup bot) get read+send in every
-        # draft channel, including team-specific ones. Missing roles are skipped
-        # silently since not every guild has invited every configured bot.
-        for role_name in get_extra_draft_channel_access_roles(guild.id):
+        # Draft-assistant bots (e.g. the Scryfall card-lookup bot) get read+send in
+        # every draft channel, including team-specific ones and the premade voice
+        # channels created below. Missing roles are skipped silently since not every
+        # guild has invited every configured bot. Only bot-managed integration roles
+        # (the role Discord creates when a bot is invited) are honored: they cannot be
+        # assigned to humans, so a same-named vanity role can't be used to read
+        # private team channels.
+        for role_name in get_draft_assistant_roles(guild.id):
             role = discord.utils.get(guild.roles, name=role_name)
-            if role:
+            if role is None:
+                logger.debug(f"Draft-assistant role '{role_name}' not found in guild {guild.name}")
+            elif role.tags is None or role.tags.bot_id is None:
+                logger.warning(
+                    f"Draft-assistant role '{role_name}' in guild {guild.name} is not a "
+                    f"bot-managed role; skipping channel access grant"
+                )
+            else:
                 overwrites[role] = discord.PermissionOverwrite(read_messages=True, send_messages=True)
                 logger.info(f"Granting '{role_name}' role access to channel '{channel_name}'")
-            else:
-                logger.debug(f"Extra-channel-access role '{role_name}' not found in guild {guild.name}")
 
         # Only add admin roles to the Draft chat, not to team-specific channels
         if team_name == "Draft":


### PR DESCRIPTION
## Summary
- Adds a per-guild config list, `roles.extra_draft_channel_access` (defaults to `["Scryfall"]`) so that we can have scryfall in the draft/team draft channels. Scryfall seems to create this role itself, and if it doesn't exist we just no-op

<img width="1272" height="1277" alt="Screenshot 2026-07-27 at 11 41 53" src="https://github.com/user-attachments/assets/fcd802b1-7aa0-4008-8ed2-47d7ef476af1" />
<img width="1262" height="1214" alt="Screenshot 2026-07-27 at 11 41 29" src="https://github.com/user-attachments/assets/0f895c7e-c26f-4a76-8921-1e76268baea2" />
