### PR TITLE
Fix /configure crashing on the Cubes category

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -78,11 +78,7 @@ async def core_commands(bot):
     async def configure_ui(ctx):
         """Interactive configuration system with dropdowns and modals"""
         from config import get_config
-
-        if ctx.guild is None:
-            await ctx.respond("This command must be used in a server, not a DM.", ephemeral=True)
-            return
-
+        
         # Get the current config
         config = get_config(ctx.guild.id)
         

--- a/commands.py
+++ b/commands.py
@@ -651,6 +651,17 @@ async def weekly_summary(bot):
                 if channel:
                     await channel.send(embed=embed)
 
+def _is_configurable_value(value):
+    """A value the /configure UI can render as an editable setting.
+
+    Both CategoryDropdown (deciding which categories to list) and
+    SettingDropdown (deciding which settings to render) must agree on this:
+    if they diverge, a category can be listed with zero renderable settings,
+    which makes Discord reject the empty-options dropdown.
+    """
+    return isinstance(value, (str, int, bool, float)) or value is None
+
+
 class ConfigCategorySelector(discord.ui.View):
     def __init__(self, config):
         super().__init__(timeout=300)  # 5 minute timeout
@@ -667,9 +678,9 @@ class CategoryDropdown(discord.ui.Select):
         for category in config.keys():
             if isinstance(config[category], dict):
                 # Only include categories with at least one setting SettingDropdown
-                # can actually show (scalar values) - otherwise that menu ends up
-                # with zero options, which Discord's API rejects outright.
-                if not any(isinstance(v, (str, int, bool, float)) or v is None for v in config[category].values()):
+                # can actually show - otherwise that menu ends up with zero
+                # options, which Discord's API rejects outright.
+                if not any(_is_configurable_value(v) for v in config[category].values()):
                     continue
                 # Only include dictionary items (categories of settings)
                 label = category.replace("_", " ").title()  # Format as readable text
@@ -722,7 +733,7 @@ class SettingDropdown(discord.ui.Select):
         options = []
         for setting, value in config[category].items():
             # Only include simple values as configurable settings
-            if isinstance(value, (str, int, bool, float)) or value is None:
+            if _is_configurable_value(value):
                 label = setting.replace("_", " ").title()
                 current_value = str(value)
                 # Truncate long values

--- a/commands.py
+++ b/commands.py
@@ -78,7 +78,11 @@ async def core_commands(bot):
     async def configure_ui(ctx):
         """Interactive configuration system with dropdowns and modals"""
         from config import get_config
-        
+
+        if ctx.guild is None:
+            await ctx.respond("This command must be used in a server, not a DM.", ephemeral=True)
+            return
+
         # Get the current config
         config = get_config(ctx.guild.id)
         
@@ -666,6 +670,11 @@ class CategoryDropdown(discord.ui.Select):
         options = []
         for category in config.keys():
             if isinstance(config[category], dict):
+                # Only include categories with at least one setting SettingDropdown
+                # can actually show (scalar values) - otherwise that menu ends up
+                # with zero options, which Discord's API rejects outright.
+                if not any(isinstance(v, (str, int, bool, float)) or v is None for v in config[category].values()):
+                    continue
                 # Only include dictionary items (categories of settings)
                 label = category.replace("_", " ").title()  # Format as readable text
                 options.append(discord.SelectOption(


### PR DESCRIPTION
Fixes #361

`CategoryDropdown` listed "Cubes" even though every value under it is a list, not a scalar — `SettingDropdown` then built a select menu with zero options, which Discord's API rejects (`Must be between 1 and 25 in length`). It now skips any category with no scalar-valued settings, so it can't offer a dead end like that. (Cube lists are already editable via `/set_cube_list`.)

<img width="539" height="345" alt="Screenshot 2026-07-27 at 11 59 48" src="https://github.com/user-attachments/assets/090ac1c5-9bcf-4676-81dd-48bfbfd4023d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)