### PR TITLE
fix(ready-check): stop auto-readying real users with post-2021 accounts

### DIFF
--- a/tests/test_synthetic_test_user.py
+++ b/tests/test_synthetic_test_user.py
@@ -1,0 +1,28 @@
+"""Regression tests for ready-check auto-ready of synthetic test users.
+
+Real Discord snowflakes exceeded TEST_USER_ID_START (9e17) for accounts
+created after ~Oct 2021, so a bare `>=` check auto-readied real players in
+production (e.g. user 1306388347043971156). Auto-ready must only apply to
+the fake IDs minted by the TEST_MODE "Add Test Users" button.
+"""
+from views import TEST_USER_ID_START, is_synthetic_test_user
+
+# A real player's snowflake (account created ~2024) that sits above 9e17.
+REAL_NEW_ACCOUNT_ID = "1306388347043971156"
+
+
+def test_real_new_account_is_not_synthetic_even_in_test_mode(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    assert not is_synthetic_test_user(REAL_NEW_ACCOUNT_ID)
+
+
+def test_synthetic_id_outside_test_mode_is_not_auto_readied(monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    assert not is_synthetic_test_user(str(TEST_USER_ID_START + 1))
+
+
+def test_synthetic_id_in_test_mode_is_auto_readied(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    # The button mints TEST_USER_ID_START + i for small i; all must qualify.
+    for i in range(1, 9):
+        assert is_synthetic_test_user(str(TEST_USER_ID_START + i))

--- a/views.py
+++ b/views.py
@@ -47,6 +47,18 @@ from preference_service import get_players_bet_capping_preferences
 # between them is asserted in one place; re-exported here for the cooldown logic.
 from ready_check import READY_CHECK_DEBOUNCE_SECONDS
 
+# Synthetic sign-ups minted by the TEST_MODE "Add Test Users" button use
+# TEST_USER_ID_START + i as fake Discord IDs. Real snowflakes passed 9e17
+# around Oct 2021, so a bare `>= TEST_USER_ID_START` check matches real
+# newer accounts — membership must be a tight range gated on test mode.
+TEST_USER_ID_START = 900000000000000000
+TEST_USER_ID_END = TEST_USER_ID_START + 100
+
+
+def is_synthetic_test_user(user_id: str) -> bool:
+    """True only for fake test-mode sign-ups, never for real Discord accounts."""
+    return is_test_mode() and TEST_USER_ID_START <= int(user_id) < TEST_USER_ID_END
+
 
 class PersistentView(discord.ui.View):
 
@@ -278,7 +290,7 @@ class PersistentView(discord.ui.View):
             if i == 0:
                 user_id = bot_user_id
             else:
-                user_id = str(900000000000000000 + i)
+                user_id = str(TEST_USER_ID_START + i)
             name = test_names[i]
             fake_users[user_id] = name
             logger.info(f"Generated test user: {name} with ID {user_id}")
@@ -778,12 +790,10 @@ class PersistentView(discord.ui.View):
 
         # Build the initial ready check state.
         # All players start as no_response; initiator and test users are marked ready immediately.
-        TEST_USER_ID_START = 900000000000000000
-
         rc = ReadyCheckSession(player_ids=session.sign_ups.keys())
         rc.set_status(user_id, 'ready')
         for uid in session.sign_ups.keys():
-            if uid != user_id and int(uid) >= TEST_USER_ID_START:
+            if uid != user_id and is_synthetic_test_user(uid):
                 rc.set_status(uid, 'ready')
                 logger.debug(f"Auto-marked test user {uid} as ready")
 


### PR DESCRIPTION
## Problem

The ready check auto-marks "test users" as ready at check creation, identified by `int(uid) >= 900000000000000000`. But real Discord snowflakes crossed 9e17 around **October 2021**, so every player whose account is newer than that gets silently marked Ready the instant a ready check fires — without clicking anything.

This is live in prod. From the last two weeks of logs alone, 5 real players were auto-readied (28 times for one of them), e.g.:

```
2026-07-29 15:14:23 | DEBUG | views:ready_check_callback:788 - Auto-marked test user 1306388347043971156 as ready
```

That ID is a real player (account created ~2024). Practical impact: ready checks can pass while those players are AFK, since the check never actually asks them.

Introduced in #225 (Dec 2025) as a TEST_MODE convenience; the threshold was already below real snowflakes when it merged.

## Fix

- New `is_synthetic_test_user()` predicate: requires `is_test_mode()` **and** an ID inside the tight range the "Add Test Users" button actually mints (`TEST_USER_ID_START` to `+100`).
- The ready-check auto-ready loop and the test-user minting code now share the same `TEST_USER_ID_START` constant, so the range invariant holds by construction.
- Regression tests cover the three cases: real post-2021 account is never synthetic (even in test mode), synthetic ID outside test mode is not auto-readied, synthetic IDs in test mode still are.

## Testing

- `pipenv run python -m pytest` — 761 passed, 9 skipped
- New: `tests/test_synthetic_test_user.py` (3 tests, includes the real prod ID as a regression case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv