### PR TITLE
fix(team-logs): drop overlapping post_team_logs runs for a session

### DIFF
--- a/services/draft_log_store.py
+++ b/services/draft_log_store.py
@@ -130,9 +130,29 @@ async def _post_pools_for_team(
         )
 
 
+# Sessions with a post_team_logs run currently in flight. The endDraft push
+# path and the 60s reconciler tick can both call within one run's duration
+# (image builds can stretch a run past several ticks), and the
+# team_logs_posted_at stamp is only written at the END of a successful run —
+# so the stamp alone cannot prevent overlapping duplicate runs.
+_POSTS_IN_FLIGHT: set[str] = set()
+
+
 async def post_team_logs(session_id: str, bot) -> bool:
     """Post each team's own members' pools to its private team channel, then
-    stamp team_logs_posted_at. Idempotent; safe to call before unlock_at."""
+    stamp team_logs_posted_at. Idempotent; safe to call before unlock_at.
+    Concurrent calls for the same session are dropped (False) while one runs."""
+    if session_id in _POSTS_IN_FLIGHT:
+        logger.info(f"post_team_logs already in flight for {session_id}; dropping duplicate call")
+        return False
+    _POSTS_IN_FLIGHT.add(session_id)
+    try:
+        return await _post_team_logs_locked(session_id, bot)
+    finally:
+        _POSTS_IN_FLIGHT.discard(session_id)
+
+
+async def _post_team_logs_locked(session_id: str, bot) -> bool:
     async with db_session() as session:
         ds = (await session.execute(
             select(DraftSession).filter(DraftSession.session_id == session_id)

--- a/tests/test_draft_log_store.py
+++ b/tests/test_draft_log_store.py
@@ -261,3 +261,35 @@ async def test_post_team_logs_idempotent_when_already_posted():
         ok = await post_team_logs("sid", bot)
     assert ok is True
     bot.get_guild.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_team_logs_concurrent_calls_post_once():
+    """The endDraft push and a reconciler tick can call while one run is still
+    in flight (slow image builds); the overlapping call must be dropped, not
+    re-post the pools."""
+    import asyncio
+    ds = _team_ds()
+    _, ctx = _db_ctx(ds)
+
+    red = _channel("Red-Team-Chat-ABC")
+    blue = _channel("Blue-Team-Chat-ABC")
+
+    async def slow_send(*a, **k):
+        await asyncio.sleep(0.05)   # keep run 1 in flight while run 2 starts
+    red.send = AsyncMock(side_effect=slow_send)
+    blue.send = AsyncMock(side_effect=slow_send)
+    bot = _bot_for({111: red, 222: blue})
+
+    with patch("services.draft_log_store.db_session", MagicMock(return_value=ctx)), \
+         patch("services.draft_log_store.discord.File", lambda fp, filename=None: ("FILE", filename)), \
+         patch("services.draft_log_store.PileImageBuilder") as PIB:
+        PIB.return_value.build = AsyncMock(return_value=None)
+        results = await asyncio.gather(
+            post_team_logs("sid", bot),
+            post_team_logs("sid", bot),
+        )
+
+    assert sorted(results) == [False, True]          # one ran, one was dropped
+    assert red.send.await_count == 1                 # Alice posted exactly once
+    assert blue.send.await_count == 1                # Bob posted exactly once


### PR DESCRIPTION
## Problem

`post_team_logs` guards against re-runs only via `team_logs_posted_at` — read at the **start** of a run, stamped at the **end**. Both the endDraft push path and the 60-second reconciler tick call it, so any run slower than one tick lets a second (and third) caller pass the stamp check and start an overlapping duplicate run.

This was latent while runs took ~1s (eight .txt sends). The deck-image feature (#341) made runs slow — on 7/29 a Scryfall 429 storm stretched one to 2+ minutes — and four members' pool posts ran twice (duplicate image builds; duplicate .txt posts for members the second pass reached).

## Fix

In-process `_POSTS_IN_FLIGHT` set: a call for a session that already has a run in flight is dropped immediately (returns False, logged at INFO). The reconciler just re-checks next tick, where the completed run's stamp answers. `try/finally` guarantees the slot is always released. Both callers live in the same process, so no cross-process coordination is needed.

## Testing

- New regression test: two concurrent `post_team_logs` calls (with slow sends to force overlap) → exactly one send per team channel, results `[True, False]`.
- `tests/test_draft_log_store.py`: 13 passed. Full suite: 772 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv