### PR TITLE
fix(card-images): read Draftmancer language-keyed image_uris as rung 1

### DIFF
--- a/helpers/card_image_fetcher.py
+++ b/helpers/card_image_fetcher.py
@@ -23,20 +23,34 @@ SCRYFALL_HEADERS = {
 _TRANSIENT_STATUSES = {429, 500, 502, 503, 504}
 
 
+def _direct_image_url(image_uris: dict) -> Optional[str]:
+    """Direct CDN URL from an image_uris dict in either known shape: Scryfall's
+    size-keyed ({"normal": url, ...}) or Draftmancer's language-keyed
+    ({"en": url, "fr": url, ...}, as in captured draft logs). Preferring these
+    over the api.scryfall.com rungs matters: CDN fetches are not rate-limited,
+    while a whole pod's worth of API fetches gets 429-stormed."""
+    if not image_uris:
+        return None
+    for key in ("normal", "en"):
+        if image_uris.get(key):
+            return image_uris[key]
+    return next((url for url in image_uris.values() if url), None)
+
+
 def build_image_url_ladder(card_id: str, carddata: dict) -> List[str]:
     """Ordered, de-duplicated candidate image URLs for one card."""
     urls: List[str] = []
     info = carddata.get(card_id) or {}
 
-    image_uris = info.get("image_uris") or {}
-    if image_uris.get("normal"):
-        urls.append(image_uris["normal"])
+    captured = _direct_image_url(info.get("image_uris") or {})
+    if captured:
+        urls.append(captured)
 
     faces = info.get("card_faces") or []
     if faces:
-        face_uris = (faces[0] or {}).get("image_uris") or {}
-        if face_uris.get("normal"):
-            urls.append(face_uris["normal"])
+        face = _direct_image_url((faces[0] or {}).get("image_uris") or {})
+        if face:
+            urls.append(face)
 
     urls.append(f"https://api.scryfall.com/cards/{card_id}?format=image&version=normal")
 

--- a/helpers/card_image_fetcher.py
+++ b/helpers/card_image_fetcher.py
@@ -22,6 +22,24 @@ SCRYFALL_HEADERS = {
 }
 _TRANSIENT_STATUSES = {429, 500, 502, 503, 504}
 
+# Global pacing for api.scryfall.com (Scryfall asks for <=10 req/s; direct
+# cards.scryfall.io CDN fetches are exempt). Shared across every concurrent
+# build in the process — per-build pacing would still stampede in aggregate.
+_SCRYFALL_MIN_INTERVAL = 0.11
+_scryfall_next_slot = 0.0  # time.monotonic() when the next API call may go
+
+
+async def _throttle_scryfall() -> None:
+    """Reserve the next api.scryfall.com slot and sleep until it arrives.
+    The read-reserve of `_scryfall_next_slot` has no await between them, so
+    concurrent tasks can't grab the same slot (single-threaded event loop)."""
+    global _scryfall_next_slot
+    now = time.monotonic()
+    wait = _scryfall_next_slot - now
+    _scryfall_next_slot = max(now, _scryfall_next_slot) + _SCRYFALL_MIN_INTERVAL
+    if wait > 0:
+        await asyncio.sleep(wait)
+
 
 def _direct_image_url(image_uris: dict) -> Optional[str]:
     """Direct CDN URL from an image_uris dict in either known shape: Scryfall's
@@ -78,11 +96,14 @@ async def fetch_card_image(
     backoff and falling through the URL ladder. `deadline` is an absolute
     time.monotonic() timestamp; once passed the fetch gives up immediately."""
     for url in build_image_url_ladder(card_id, carddata):
-        headers = SCRYFALL_HEADERS if "api.scryfall.com" in url else None
+        is_api = "api.scryfall.com" in url
+        headers = SCRYFALL_HEADERS if is_api else None
         for attempt in range(max_retries):
             if deadline is not None and time.monotonic() >= deadline:
                 logger.warning(f"[card-image] deadline exceeded fetching {card_id}")
                 return None
+            if is_api:
+                await _throttle_scryfall()
             try:
                 async with session.get(
                     url,

--- a/tests/test_card_image_fetcher.py
+++ b/tests/test_card_image_fetcher.py
@@ -209,3 +209,45 @@ def test_dfc_face_language_keyed_uris_used():
     ladder = build_image_url_ladder("cid6", carddata)
     assert ladder[0] == "http://cdn/face-en.jpg"   # front face only
     assert "http://cdn/back-en.jpg" not in ladder
+
+
+# ---- Scryfall API throttle -----------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_scryfall_throttle():
+    import helpers.card_image_fetcher as cif
+    cif._scryfall_next_slot = 0.0
+    yield
+    cif._scryfall_next_slot = 0.0
+
+
+@pytest.mark.asyncio
+async def test_api_calls_are_paced_by_global_throttle():
+    import helpers.card_image_fetcher as cif
+    with patch("helpers.card_image_fetcher.asyncio.sleep", new=AsyncMock()) as slept:
+        await cif._throttle_scryfall()          # first call: slot free, no sleep
+        await cif._throttle_scryfall()          # second call: must wait ~one interval
+    assert slept.await_count == 1
+    waited = slept.await_args.args[0]
+    assert 0 < waited <= cif._SCRYFALL_MIN_INTERVAL
+
+
+@pytest.mark.asyncio
+async def test_cdn_fetch_is_not_throttled():
+    session = _FakeSession({CAPTURED: [_FakeResp(200, _png_bytes())]})
+    with patch("helpers.card_image_fetcher._throttle_scryfall", new=AsyncMock()) as thr:
+        img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is not None
+    thr.assert_not_awaited()                    # captured CDN rung: no throttle
+
+
+@pytest.mark.asyncio
+async def test_api_rung_goes_through_throttle():
+    session = _FakeSession({
+        CAPTURED: [_FakeResp(404)],
+        BY_NAME: [_FakeResp(200, _png_bytes())],
+    })
+    with patch("helpers.card_image_fetcher._throttle_scryfall", new=AsyncMock()) as thr:
+        img = await fetch_card_image(session, "cid1", CARDDATA)
+    assert img is not None
+    assert thr.await_count == 2                 # by-id attempt + by-name attempt

--- a/tests/test_card_image_fetcher.py
+++ b/tests/test_card_image_fetcher.py
@@ -161,3 +161,51 @@ async def test_200_with_non_image_body_advances_to_next_rung():
     assert img is not None
     assert session.requested.count(CAPTURED) == 1               # no retry on same rung
     assert session.requested[-1] == BY_ID                       # advanced to next rung
+
+
+# Draftmancer draft logs store image_uris keyed by LANGUAGE, not by size
+# (the shape that made every team-log card fall through to the rate-limited
+# api.scryfall.com rungs on 7/29).
+LANG_CARDDATA = {
+    "cid3": {
+        "name": "Black Lotus",
+        "image_uris": {"en": "https://cards.scryfall.io/border_crop/lotus.jpg"},
+    },
+    "cid4": {
+        "name": "Phantasmal Image",
+        "image_uris": {
+            "fr": "https://cards.scryfall.io/border_crop/image-fr.jpg",
+            "ja": "https://cards.scryfall.io/border_crop/image-ja.jpg",
+        },
+    },
+}
+
+
+def test_ladder_uses_language_keyed_image_uris_as_first_rung():
+    ladder = build_image_url_ladder("cid3", LANG_CARDDATA)
+    assert ladder[0] == "https://cards.scryfall.io/border_crop/lotus.jpg"
+    assert "api.scryfall.com" in ladder[1]        # API rungs demoted, not gone
+
+
+def test_ladder_falls_back_to_any_language_when_en_missing():
+    ladder = build_image_url_ladder("cid4", LANG_CARDDATA)
+    assert ladder[0] in (
+        "https://cards.scryfall.io/border_crop/image-fr.jpg",
+        "https://cards.scryfall.io/border_crop/image-ja.jpg",
+    )
+
+
+def test_ladder_prefers_normal_over_language_keys():
+    carddata = {"cid5": {"name": "X", "image_uris": {
+        "en": "http://cdn/en.jpg", "normal": "http://cdn/normal.jpg"}}}
+    assert build_image_url_ladder("cid5", carddata)[0] == "http://cdn/normal.jpg"
+
+
+def test_dfc_face_language_keyed_uris_used():
+    carddata = {"cid6": {"name": "Some DFC", "card_faces": [
+        {"image_uris": {"en": "http://cdn/face-en.jpg"}},
+        {"image_uris": {"en": "http://cdn/back-en.jpg"}},
+    ]}}
+    ladder = build_image_url_ladder("cid6", carddata)
+    assert ladder[0] == "http://cdn/face-en.jpg"   # front face only
+    assert "http://cdn/back-en.jpg" not in ladder


### PR DESCRIPTION
## Problem

`build_image_url_ladder`'s first rung looks for `image_uris["normal"]` — Scryfall's API shape. But Draftmancer draft logs (the carddata used for team-log deck images) store `image_uris` keyed by **language**: `{"en": "https://cards.scryfall.io/border_crop/…"}`. So the captured-printing rung silently never fired, and every card of every pool fell through to the rate-limited `api.scryfall.com` rungs.

Observed on 7/29 (session `DBKMC4Y230`): ~360 API fetches in a burst → Scryfall 429 storm → the fetcher's 3 quick retries exhausted → per-member all-or-nothing pile builds aborted → **7 of 8 members got no deck image**, and each member's post was delayed ~15s by doomed retries. The "unfetchable" cards (Black Lotus, Gitaxian Probe, …) all fetch fine individually — they were rate-limit victims.

## Fix

Two layers:

1. **CDN-first ladder**: new `_direct_image_url()` accepts both shapes — preference `normal` → `en` → any language — applied to both the top-level `image_uris` and the front face's. The API rungs remain as fallbacks. CDN fetches (`cards.scryfall.io`) aren't rate-limited, and the image now shows the **actual printing drafted**.
2. **Global API throttle**: every `api.scryfall.com` request (including retries) reserves a slot in a process-global pacer (~9 req/s; Scryfall asks for ≤10). Concurrent pile builds share the same pacer, so aggregate load can't stampede even for cards that lack captured URIs. CDN fetches are exempt.

## Verification

- 4 new ladder tests (language-keyed en, non-en fallback, normal-precedence, language-keyed DFC face) + 3 throttle tests (pacing interval, CDN exemption, API rungs paced).
- Replayed against the real captured log from 7/29: **all 360 cards** in that cube now resolve a CDN first rung (was 0).
- Full suite: 778 passed, 9 skipped.

Companion to #364 (which stops the overlapping double-builds the slow runs caused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv