### PR TITLE
fix(test-mode): auto-ready the bot-id test signup in ready checks

### DIFF
--- a/tests/test_synthetic_test_user.py
+++ b/tests/test_synthetic_test_user.py
@@ -26,3 +26,32 @@ def test_synthetic_id_in_test_mode_is_auto_readied(monkeypatch):
     # The button mints TEST_USER_ID_START + i for small i; all must qualify.
     for i in range(1, 9):
         assert is_synthetic_test_user(str(TEST_USER_ID_START + i))
+
+
+BOT_USER_ID = "1000000000000000001"   # the bot's own snowflake (arbitrary)
+
+
+def test_bot_id_signup_is_test_signup_in_test_mode(monkeypatch):
+    """The first 'Add Test Users' slot reuses the bot's own id; it must
+    auto-ready like the synthetic users or a test ready check never completes."""
+    monkeypatch.setenv("TEST_MODE", "true")
+    from views import is_test_signup
+    assert is_test_signup(BOT_USER_ID, BOT_USER_ID)
+
+
+def test_bot_id_signup_not_test_signup_outside_test_mode(monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    from views import is_test_signup
+    assert not is_test_signup(BOT_USER_ID, BOT_USER_ID)
+
+
+def test_real_player_still_not_test_signup_in_test_mode(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    from views import is_test_signup
+    assert not is_test_signup(REAL_NEW_ACCOUNT_ID, BOT_USER_ID)
+
+
+def test_synthetic_users_still_covered_by_is_test_signup(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    from views import is_test_signup
+    assert is_test_signup(str(TEST_USER_ID_START + 1), BOT_USER_ID)

--- a/views.py
+++ b/views.py
@@ -60,6 +60,14 @@ def is_synthetic_test_user(user_id: str) -> bool:
     return is_test_mode() and TEST_USER_ID_START <= int(user_id) < TEST_USER_ID_END
 
 
+def is_test_signup(user_id: str, bot_user_id: str) -> bool:
+    """True for any sign-up minted by the TEST_MODE "Add Test Users" button:
+    the synthetic high-ID users, plus the first slot which reuses the bot's own
+    id (so guild.get_member() resolves) and therefore sits below
+    TEST_USER_ID_START."""
+    return is_synthetic_test_user(user_id) or (is_test_mode() and user_id == bot_user_id)
+
+
 class PersistentView(discord.ui.View):
 
     # AUTO_PAIRINGS_TASKS = {}  # session_id -> task
@@ -792,8 +800,9 @@ class PersistentView(discord.ui.View):
         # All players start as no_response; initiator and test users are marked ready immediately.
         rc = ReadyCheckSession(player_ids=session.sign_ups.keys())
         rc.set_status(user_id, 'ready')
+        bot_user_id = str(interaction.client.user.id)
         for uid in session.sign_ups.keys():
-            if uid != user_id and is_synthetic_test_user(uid):
+            if uid != user_id and is_test_signup(uid, bot_user_id):
                 rc.set_status(uid, 'ready')
                 logger.debug(f"Auto-marked test user {uid} as ready")
 


### PR DESCRIPTION
## Problem

Follow-up to #363. The TEST_MODE "Add Test Users" button mints the first test user with the **bot's own user id** (deliberately, so `guild.get_member()` resolves for features like debt settlement). That id sits below `TEST_USER_ID_START`, so the ready-check auto-ready loop skips it — and since a bot can't click buttons, a TEST_MODE ready check with that signup present can never reach all-ready on its own.

## Fix

New `is_test_signup(user_id, bot_user_id)` predicate covering both kinds of test signup — the synthetic high-ID range **or** the bot's own id — both gated on `is_test_mode()`. The ready-check loop uses it instead of the bare synthetic check.

Prod is unaffected: the bot's id never appears in `sign_ups` outside the TEST_MODE-only button, and the predicate is test-mode-gated regardless.

## Testing

- 4 new tests: bot-id signup auto-readies in test mode, does not outside test mode, real players still excluded, synthetic users still covered.
- `tests/test_synthetic_test_user.py`: 7 passed. Full suite: 779 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv