### PR TITLE
fix(premade): validate teams are non-empty + balanced before firing

### DIFF
--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -59,6 +59,26 @@ async def create_and_display_teams(bot, draft_session_id, interaction, persisten
                     await interaction.followup.send("There must be an even number of players to fire.")
                     return False
 
+                if session.session_type == 'premade':
+                    # Drop team members who left (removed from sign_ups but still in
+                    # team_a/team_b) so a stale id can't KeyError downstream, then
+                    # require the teams to be non-empty and equal — an even total
+                    # alone allows a lopsided split (e.g. 2-vs-0).
+                    team_a = [uid for uid in (session.team_a or []) if uid in session.sign_ups]
+                    team_b = [uid for uid in (session.team_b or []) if uid in session.sign_ups]
+                    if not team_a or not team_b or len(team_a) != len(team_b):
+                        await interaction.followup.send(
+                            "Premade teams must be non-empty and equal size "
+                            f"(currently {len(team_a)} vs {len(team_b)})."
+                        )
+                        return False
+                    if team_a != list(session.team_a or []) or team_b != list(session.team_b or []):
+                        session.team_a = team_a
+                        session.team_b = team_b
+                        await db_session.execute(update(DraftSession)
+                                            .where(DraftSession.session_id == session.session_id)
+                                            .values(team_a=team_a, team_b=team_b))
+
                 # Update session timing and stage
                 session.teams_start_time = datetime.now()
                 if session.session_type == 'premade':

--- a/tests/test_create_and_display_teams.py
+++ b/tests/test_create_and_display_teams.py
@@ -14,25 +14,25 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-def _premade_session(sign_ups):
+def _premade_session(sign_ups, team_a=None, team_b=None):
     session = MagicMock()
     session.session_type = "premade"
     session.session_id = "fake-session-123"
     session.sign_ups = dict(sign_ups)
     ids = list(sign_ups.keys())
-    session.team_a = ids[:3]
-    session.team_b = ids[3:]
+    session.team_a = team_a if team_a is not None else ids[:len(ids) // 2]
+    session.team_b = team_b if team_b is not None else ids[len(ids) // 2:]
     session.tracked_draft = False
     session.premade_match_id = None
     return session
 
 
-async def _run_premade(sign_ups, seating_return):
+async def _run_premade(sign_ups, seating_return, team_a=None, team_b=None):
     """Run create_and_display_teams for a premade draft with generate_seating_order
     mocked to return `seating_return`. Returns (result, mock_logger, session)."""
     from services import team_creator
 
-    session = _premade_session(sign_ups)
+    session = _premade_session(sign_ups, team_a=team_a, team_b=team_b)
     select_result = MagicMock()
     select_result.scalars.return_value.first.return_value = session
 
@@ -118,3 +118,24 @@ async def test_premade_seating_maps_by_id_not_decorated_name():
     assert set(session.sign_ups.keys()) == set(sign_ups)
     assert all(session.sign_ups[uid] == sign_ups[uid] for uid in sign_ups)
     assert list(session.sign_ups.keys()) == [uid for uid, _ in seating]
+
+
+@pytest.mark.asyncio
+async def test_premade_rejects_unbalanced_teams():
+    """A premade with an even total but a lopsided split (2-vs-0) must be rejected,
+    not seated into a broken draft with only one team (Codex finding)."""
+    sign_ups = {"111": "A", "222": "B"}                 # even total = 2
+    result, _mock_logger, _session = await _run_premade(
+        sign_ups, [("111", "A"), ("222", "B")], team_a=["111", "222"], team_b=[])
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_premade_balance_counts_only_signed_up_members():
+    """Balance is measured on team members still in sign_ups — a stale id left in a
+    team (from the leave flow) must not tip an otherwise-balanced draft into rejection."""
+    sign_ups = {"111": "A", "222": "B", "333": "C", "444": "D"}
+    result, _mock_logger, _session = await _run_premade(
+        sign_ups, [("111", "A"), ("333", "C"), ("222", "B"), ("444", "D")],
+        team_a=["111", "222", "999"], team_b=["333", "444"])   # 999 not signed up
+    assert result is True                                # effective 2-vs-2 → allowed


### PR DESCRIPTION
## Problem
A premade with an even total but a lopsided split (e.g. 2-vs-0, or teams left unbalanced after leaves) would seat into a broken one-team draft instead of being rejected.

## Fix
Early validation in `create_and_display_teams` for premade sessions: normalize `team_a`/`team_b` to members still in `sign_ups` (persisting the cleanup), then require both teams non-empty and equal size — otherwise reply with the counts and abort before firing the draft. Balance is measured only on signed-up members, so a stale id can't tip an otherwise-balanced draft into rejection.

## Tests
`tests/test_create_and_display_teams.py`:
- `test_premade_rejects_unbalanced_teams` (2-vs-0 → rejected)
- `test_premade_balance_counts_only_signed_up_members` (stale id → effective 2-vs-2 → allowed)

Part of a 4-PR stack (Codex review). Stacked on the stale-team-members fix.

