### PR TITLE
fix(cleanup): stale means fired-but-abandoned, and never delete history

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -811,19 +811,22 @@ class AdminCommands(commands.Cog):
         result = await db_session.execute(stmt)
         return result.scalar()
 
-    @discord.slash_command(name='cleanup_stale_drafts', description='Complete old stale drafts as draws and clean up channels')
+    @discord.slash_command(name='cleanup_stale_drafts', description='Complete abandoned drafts as draws and clean up their channels')
     @has_bot_manager_role()
     async def cleanup_stale_drafts(
         self,
         ctx,
-        hours_old: discord.Option(int, "Complete drafts older than this many hours (minimum 12)", default=24),
+        hours_old: discord.Option(int, "Complete stale drafts older than this many hours (minimum 12)", default=24),
         dry_run: discord.Option(bool, "Preview without actually completing/deleting", default=True)
     ):
-        """Complete old stale drafts as draws, clean up channels, and remove database records."""
+        """Complete stale (fired-but-abandoned) drafts as draws and delete their
+        channels. Never touches finished drafts and never deletes session rows
+        or match history — "stale" means started but abandoned, not merely old."""
         from config import is_cleanup_exempt
-        from datetime import datetime, timedelta
+        from datetime import datetime
         from session import AsyncSessionLocal
         from models.draft_session import DraftSession
+        from helpers.stale_drafts import LOOKBACK_DAYS, cleanup_window, is_stale_draft
 
         await ctx.defer(ephemeral=True)
 
@@ -847,23 +850,33 @@ class AdminCommands(commands.Cog):
             )
             return
 
-        # Calculate cutoff time
-        cutoff_time = datetime.now() - timedelta(hours=hours_old)
+        # Bounded candidate window: older than hours_old, but within
+        # LOOKBACK_DAYS. Anything older is history, not cleanup — an unbounded
+        # query here once selected a guild's entire draft archive.
+        lookback_floor, cutoff_time = cleanup_window(hours_old)
 
-        # Query for old draft sessions
         async with AsyncSessionLocal() as db_session:
             from sqlalchemy import select
             stmt = select(DraftSession).filter(
                 DraftSession.guild_id == str(ctx.guild.id),
-                DraftSession.draft_start_time < cutoff_time
+                DraftSession.draft_start_time < cutoff_time,
+                DraftSession.draft_start_time >= lookback_floor,
             )
 
             result = await db_session.execute(stmt)
-            old_sessions = result.scalars().all()
+            candidates = result.scalars().all()
+
+            # Single source of truth for staleness (helpers/stale_drafts.py):
+            # teams were created, but no completion marker exists. Finished
+            # drafts commonly sit at session_stage='pairings' forever, so the
+            # victory message is checked too — filtering on stage alone would
+            # sweep up the guild's played history.
+            old_sessions = [s for s in candidates if is_stale_draft(s)]
 
             if not old_sessions:
                 await ctx.followup.send(
-                    f"✅ No drafts found older than {hours_old} hours in this guild.",
+                    f"✅ No stale drafts found (started {hours_old}h–{LOOKBACK_DAYS}d ago, "
+                    "fired but never finished) in this guild.",
                     ephemeral=True
                 )
                 return
@@ -915,12 +928,13 @@ class AdminCommands(commands.Cog):
             # Show preview
             preview_msg = (
                 f"**{'DRY RUN - ' if dry_run else ''}Cleanup Preview**\n\n"
-                f"**Target:** Drafts older than {hours_old} hours\n"
-                f"**Guild:** {ctx.guild.name}\n"
-                f"**Cutoff time:** {cutoff_time.strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                f"**Target:** Stale drafts (fired but never finished), started between "
+                f"{lookback_floor.strftime('%Y-%m-%d')} and {cutoff_time.strftime('%Y-%m-%d %H:%M')}\n"
+                f"**Guild:** {ctx.guild.name}\n\n"
                 f"**Will process:**\n"
-                f"• {total_sessions} draft session(s)\n"
+                f"• {total_sessions} stale draft session(s)\n"
                 f"• {total_channels} channel(s) will be deleted\n"
+                f"• Session rows and match history are preserved (never deleted)\n"
             )
 
             incomplete_count = sum(1 for s in sessions_to_complete if not s['is_completed'])
@@ -969,13 +983,12 @@ class AdminCommands(commands.Cog):
 
             # Actual completion and deletion (not dry run)
             await ctx.followup.send(
-                f"⚠️ **Starting completion of {total_sessions} drafts and deletion of {total_channels} channels...**",
+                f"⚠️ **Completing {total_sessions} stale draft(s) and deleting {total_channels} channel(s)...**",
                 ephemeral=True
             )
 
             # Perform completion and cleanup
             deleted_channels = 0
-            deleted_sessions = 0
             completed_drafts = 0
             created_matches = 0
             preserved_matches = 0
@@ -1026,18 +1039,9 @@ class AdminCommands(commands.Cog):
                         except (discord.NotFound, discord.HTTPException):
                             pass  # Message already gone
 
-                    # Step 6: Detach MatchResult records before deleting session
-                    # Set session_id to NULL to preserve match records
-                    from sqlalchemy import update
-                    stmt = update(MatchResult).where(
-                        MatchResult.session_id == session.session_id
-                    ).values(session_id=None)
-                    await db_session.execute(stmt)
-                    await db_session.flush()
-
-                    # Step 7: Delete from database
-                    await db_session.delete(session)
-                    deleted_sessions += 1
+                    # The session row and its MatchResults are deliberately kept:
+                    # they feed leaderboards, trophy history, quizzes, and log
+                    # reconciliation. Cleanup means "close it out", not "erase it".
 
                 except Exception as e:
                     errors.append(f"Error cleaning session {session.session_id}: {e}")
@@ -1050,7 +1054,6 @@ class AdminCommands(commands.Cog):
             summary = (
                 f"✅ **Cleanup Complete**\n\n"
                 f"• Completed {completed_drafts} draft(s) (marked as completed)\n"
-                f"• Deleted {deleted_sessions} draft session(s)\n"
                 f"• Deleted {deleted_channels} channel(s)\n"
             )
 
@@ -1070,7 +1073,7 @@ class AdminCommands(commands.Cog):
             await ctx.followup.send(summary, ephemeral=True)
             logger.info(
                 f"Cleanup complete: {completed_drafts} drafts completed, "
-                f"{deleted_sessions} sessions deleted, {deleted_channels} channels deleted, "
+                f"{deleted_channels} channels deleted, "
                 f"{created_matches} matches created, {preserved_matches} matches preserved as draws"
             )
 

--- a/helpers/stale_drafts.py
+++ b/helpers/stale_drafts.py
@@ -1,0 +1,39 @@
+"""Selection policy for /cleanup_stale_drafts: which sessions are stale.
+
+"Stale" means fired-but-abandoned, never merely old. Finished drafts routinely
+keep session_stage='pairings' forever (only ~2 in 10 historical rows ever see
+'completed'), so the posted victory/draw message is the load-bearing finish
+marker alongside the stage.
+
+The command fetches candidates by guild + time window in SQL, then applies
+is_stale_draft in Python so this module is the single source of truth for
+what "stale" means (and is unit-testable without a DB).
+"""
+from datetime import datetime, timedelta
+
+# Only chase recently-stuck drafts; anything older is history, not cleanup.
+LOOKBACK_DAYS = 30
+
+
+def cleanup_window(hours_old: int, now: datetime | None = None) -> tuple[datetime, datetime]:
+    """(floor, cutoff): candidates started before `cutoff` (older than
+    `hours_old`) but on/after `floor` (within LOOKBACK_DAYS)."""
+    now = now or datetime.now()
+    return now - timedelta(days=LOOKBACK_DAYS), now - timedelta(hours=hours_old)
+
+
+def is_finished_draft(session) -> bool:
+    """A draft with any completion marker: explicit completed stage or a
+    posted victory/draw message (the common case — the stage rarely
+    advances past 'pairings' even for fully played drafts)."""
+    return (
+        session.session_stage == "completed"
+        or session.victory_message_id_draft_chat is not None
+        or session.victory_message_id_results_channel is not None
+    )
+
+
+def is_stale_draft(session) -> bool:
+    """Fired (teams were created) but never finished. Sessions that never
+    fired are the queue-inactivity cleanup's job, not this command's."""
+    return session.teams_start_time is not None and not is_finished_draft(session)

--- a/tests/test_stale_drafts.py
+++ b/tests/test_stale_drafts.py
@@ -1,0 +1,72 @@
+"""Tests for the /cleanup_stale_drafts selection policy (helpers/stale_drafts).
+
+Regression context: the command once selected every session older than
+`hours_old` — on a real guild that meant ~800 finished drafts (sitting at
+session_stage='pairings' with a victory message posted) queued for
+completion-as-draws and DB deletion. "Stale" must mean fired-but-abandoned.
+"""
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from helpers.stale_drafts import LOOKBACK_DAYS, cleanup_window, is_finished_draft, is_stale_draft
+
+
+def _session(stage="pairings", victory_chat=None, victory_results=None, teams_started=True):
+    return SimpleNamespace(
+        session_stage=stage,
+        victory_message_id_draft_chat=victory_chat,
+        victory_message_id_results_channel=victory_results,
+        teams_start_time=datetime(2026, 7, 29, 15, 18) if teams_started else None,
+    )
+
+
+# ---- is_finished_draft ---------------------------------------------------------------
+
+def test_completed_stage_is_finished():
+    assert is_finished_draft(_session(stage="completed"))
+
+
+def test_victory_message_is_finished_even_at_pairings_stage():
+    # The common real-world shape: fully played draft, stage never advanced.
+    assert is_finished_draft(_session(stage="pairings", victory_chat="123"))
+    assert is_finished_draft(_session(stage="pairings", victory_results="456"))
+
+
+def test_no_completion_marker_is_not_finished():
+    assert not is_finished_draft(_session(stage="pairings"))
+
+
+# ---- is_stale_draft ------------------------------------------------------------------
+
+def test_fired_and_unfinished_is_stale():
+    assert is_stale_draft(_session(stage="pairings"))
+
+
+def test_finished_draft_is_never_stale():
+    # The ~800-draft regression: played drafts at 'pairings' with a victory
+    # message must not be selected.
+    assert not is_stale_draft(_session(stage="pairings", victory_chat="123"))
+    assert not is_stale_draft(_session(stage="completed"))
+
+
+def test_never_fired_lobby_is_not_stale():
+    # Queue-inactivity cleanup owns unfired lobbies, not this command.
+    assert not is_stale_draft(_session(stage=None, teams_started=False))
+
+
+# ---- cleanup_window ------------------------------------------------------------------
+
+def test_cleanup_window_bounds():
+    now = datetime(2026, 7, 30, 12, 0)
+    floor, cutoff = cleanup_window(24, now=now)
+    assert cutoff == now - timedelta(hours=24)
+    assert floor == now - timedelta(days=LOOKBACK_DAYS)
+    assert floor < cutoff
+
+
+def test_cleanup_window_larger_than_lookback_selects_nothing():
+    # hours_old beyond the lookback window inverts the range -> empty selection,
+    # by design: anything that old is history, not cleanup.
+    now = datetime(2026, 7, 30, 12, 0)
+    floor, cutoff = cleanup_window(24 * (LOOKBACK_DAYS + 5), now=now)
+    assert cutoff < floor


### PR DESCRIPTION
## Problem

`/cleanup_stale_drafts` implemented "stale" as merely *old*: it selected **every** DraftSession in the guild with `draft_start_time < now - hours_old` (default 24h), with no state filter. A non-dry run would then, for each — including fully played, healthy drafts:

- create "missing" matches as 0-0 draws and mark the session completed,
- **detach all its MatchResults** (`session_id -> NULL`), and
- **delete the DraftSession row**.

A dry run on a real guild queued **1,054 sessions** (its entire history; ~800 of them finished drafts that simply sit at `session_stage='pairings'` with a victory message posted — the stage rarely advances). Running it for real would have erased the data behind leaderboards, trophy history, quizzes, and log reconciliation in one command.

## Fix

**Selection** now lives in `helpers/stale_drafts.py` (single source of truth, unit-testable):
- *stale* = teams were created (`teams_start_time` set) **and** no completion marker (`session_stage='completed'` **or** a posted victory/draw message — validated against prod data: 802/1054 finished drafts carry only the victory marker);
- bounded to a **30-day lookback** — anything older is history, not cleanup;
- never-fired lobbies excluded (queue-inactivity cleanup owns those).

**Destruction** is defanged: close out the draft (missing matches as draws, mark completed) and delete its Discord channels/message. **Session rows and match results are never deleted or detached.**

Validated against the prod DB copy: on the same guild, the new selection finds **exactly 1** session — a genuinely stuck 7/29 draft — instead of 1,054.

## Testing

- New `tests/test_stale_drafts.py` (8 tests): the finished-at-pairings regression case, victory-marker semantics, never-fired exclusion, window bounds (including hours_old > lookback → empty by design).
- Full suite: 801 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv