### PR TITLE
feat: warn staked-draft signups about players with significant outstanding debt

### DIFF
--- a/cogs/debt_admin_commands.py
+++ b/cogs/debt_admin_commands.py
@@ -130,6 +130,10 @@ class DebtAdminCommands(commands.Cog):
             # Update debt summary message if it exists
             await update_debt_summary_for_guild(self.bot, str(ctx.guild.id))
 
+            # Clear/update debt warnings on any open staked queues promptly
+            from utils import refresh_open_staked_queues
+            await refresh_open_staked_queues(self.bot, str(ctx.guild.id))
+
             # Format success message
             direction = "more" if amount > 0 else "less"
             logger.info(

--- a/config.py
+++ b/config.py
@@ -16,6 +16,10 @@ DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 # bot auto-creates when invited — so "Scryfall" works with zero guild setup.
 DEFAULT_BOTS_WITH_DRAFT_ACCESS = ["Scryfall"]
 
+# Tix total-owed at/above which a staked signup line shows a debt warning.
+# 0 disables the warning for a guild.
+DEFAULT_DEBT_WARNING_THRESHOLD = 50
+
 def is_test_mode() -> bool:
     """Returns True if TEST_MODE env var is set to a truthy value."""
     return os.environ.get("TEST_MODE", "false").lower() in ("true", "1", "yes")
@@ -81,7 +85,8 @@ class Config:
             },
             "stakes": {
                 "use_optimized_algorithm": True,
-                "stake_multiple": 10
+                "stake_multiple": 10,
+                "debt_warning_threshold": DEFAULT_DEBT_WARNING_THRESHOLD
             },
             "activity_tracking": {
                 "enabled": False,
@@ -188,11 +193,12 @@ class Config:
                 }
             },
             "matchmaking": {
-                "trueskill_chance": 60  
+                "trueskill_chance": 60
             },
             "stakes": {
                 "use_optimized_algorithm": True,
-                "stake_multiple": 10
+                "stake_multiple": 10,
+                "debt_warning_threshold": DEFAULT_DEBT_WARNING_THRESHOLD
             },
             "activity_tracking": {
                 "enabled": False,
@@ -392,6 +398,12 @@ def get_bots_with_draft_access(guild_id):
     config = get_config(guild_id)
     return config.get("roles", {}).get("bots_with_draft_access", list(DEFAULT_BOTS_WITH_DRAFT_ACCESS))
 
+def get_debt_warning_threshold(guild_id):
+    """Tix total-owed at/above which a staked signup shows a debt warning
+    to other players. 0 (or missing stakes config entirely) disables."""
+    config = get_config(guild_id)
+    return config.get("stakes", {}).get("debt_warning_threshold", DEFAULT_DEBT_WARNING_THRESHOLD)
+
 def get_league_challenge_hours(guild_id):
     """Get league challenge timeout in hours"""
     timeout_config = get_timeout_config(guild_id)
@@ -416,6 +428,11 @@ def migrate_configs():
         # access to every draft channel, e.g. the Scryfall card-lookup bot)
         if "roles" in config and "bots_with_draft_access" not in config["roles"]:
             config["roles"]["bots_with_draft_access"] = list(DEFAULT_BOTS_WITH_DRAFT_ACCESS)
+            updated = True
+
+        # Add debt_warning_threshold if missing (staked signup debt warnings)
+        if "stakes" in config and "debt_warning_threshold" not in config["stakes"]:
+            config["stakes"]["debt_warning_threshold"] = DEFAULT_DEBT_WARNING_THRESHOLD
             updated = True
 
         # Add timeout configuration if missing

--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -787,6 +787,13 @@ class TransferConfirmView(View):
             except Exception as e:
                 logger.warning(f"[TransferConfirm] Failed to trigger debt summary update: {e}")
 
+            # Clear/update debt warnings on any open staked queues promptly
+            try:
+                from utils import refresh_open_staked_queues
+                asyncio.create_task(refresh_open_staked_queues(interaction.client, self.guild_id))
+            except Exception as e:
+                logger.warning(f"[TransferConfirm] Failed to trigger staked queue refresh: {e}")
+
             # Notify debtor and creditor via DM
             try:
                 asyncio.create_task(send_debt_transfer_dms(
@@ -1079,6 +1086,13 @@ class SettlementConfirmView(View):
                 asyncio.create_task(update_debt_summary_for_guild(interaction.client, self.guild_id))
             except Exception as e:
                 logger.warning(f"[SettlementConfirm] Failed to trigger debt summary update: {e}")
+
+            # Clear/update debt warnings on any open staked queues promptly
+            try:
+                from utils import refresh_open_staked_queues
+                asyncio.create_task(refresh_open_staked_queues(interaction.client, self.guild_id))
+            except Exception as e:
+                logger.warning(f"[SettlementConfirm] Failed to trigger staked queue refresh: {e}")
 
         except Exception as e:
             logger.error(f"[SettlementConfirm] Failed to create settlement: {e}")

--- a/helpers/debt_warning.py
+++ b/helpers/debt_warning.py
@@ -1,0 +1,55 @@
+"""Debt warning marker for staked-draft sign-ups, and the (extracted, pure)
+staked Sign-Ups field formatter that applies it.
+
+The formatter is the render-time-only decoration point: stored sign_ups names
+are never modified (see PR #349 — decorating stored names broke seating)."""
+from loguru import logger
+
+
+def debt_warning_suffix(total_owed, threshold) -> str:
+    """" ⚠️ owes 75 tix" when total_owed >= threshold; "" otherwise.
+    A falsy threshold disables warnings entirely."""
+    if not threshold or not total_owed or total_owed < threshold:
+        return ""
+    return f" ⚠️ owes {total_owed} tix"
+
+
+def format_staked_sign_ups(sign_ups, stake_info_by_player, owed_map, threshold,
+                           display_name_for, session_id: str = "") -> str:
+    """The staked draft message's Sign-Ups field text: one line per player with
+    stake, cap emoji, display name, and (over-threshold players only) the debt
+    warning suffix. Identical to the historical format when owed_map is empty."""
+    sign_ups_list = []
+    for user_id, stored_name in sign_ups.items():
+        display_name = display_name_for(user_id, stored_name)
+        if user_id in stake_info_by_player:
+            stake_amount = stake_info_by_player[user_id]["amount"]
+            is_capped = stake_info_by_player[user_id]["is_capped"]
+            capped_emoji = "🧢" if is_capped else "🏎️"
+            sign_ups_list.append((user_id, display_name, stake_amount, is_capped, capped_emoji))
+        else:
+            sign_ups_list.append((user_id, display_name, "Not set", True, "❓"))
+
+    def sort_key(item):
+        stake = item[2]
+        return -1 if stake == "Not set" else stake
+
+    sign_ups_list.sort(key=sort_key, reverse=True)
+
+    formatted = []
+    for user_id, display_name, stake_amount, _is_capped, emoji in sign_ups_list:
+        suffix = debt_warning_suffix(owed_map.get(user_id), threshold)
+        if stake_amount == "Not set":
+            formatted.append(f"❌ Not set: {display_name}{suffix}")
+        else:
+            formatted.append(f"{emoji} {stake_amount} tix: {display_name}{suffix}")
+
+    result = (f"**Players ({len(sign_ups)}):**\n"
+              + ("\n".join(formatted) if formatted else "No players yet."))
+    if len(result) > 1000:
+        logger.warning(
+            f"[debt-warning] Sign-Ups field for {session_id or 'unknown session'} "
+            f"exceeds single-field limit ({len(result)} chars); continuation-chunk "
+            "splitting may drop content"
+        )
+    return result

--- a/helpers/debt_warning.py
+++ b/helpers/debt_warning.py
@@ -7,8 +7,8 @@ from loguru import logger
 
 
 def debt_warning_suffix(total_owed, threshold) -> str:
-    """" ⚠️ owes 75 tix" when total_owed >= threshold; "" otherwise.
-    A falsy threshold disables warnings entirely."""
+    """The trailing marker (e.g. " ⚠️ owes 75 tix") when total_owed reaches
+    threshold, else "". A falsy threshold disables warnings entirely."""
     if not threshold or not total_owed or total_owed < threshold:
         return ""
     return f" ⚠️ owes {total_owed} tix"
@@ -19,33 +19,32 @@ def format_staked_sign_ups(sign_ups, stake_info_by_player, owed_map, threshold,
     """The staked draft message's Sign-Ups field text: one line per player with
     stake, cap emoji, display name, and (over-threshold players only) the debt
     warning suffix. Identical to the historical format when owed_map is empty."""
-    sign_ups_list = []
+    entries = []
     for user_id, stored_name in sign_ups.items():
         display_name = display_name_for(user_id, stored_name)
         if user_id in stake_info_by_player:
-            stake_amount = stake_info_by_player[user_id]["amount"]
-            is_capped = stake_info_by_player[user_id]["is_capped"]
-            capped_emoji = "🧢" if is_capped else "🏎️"
-            sign_ups_list.append((user_id, display_name, stake_amount, is_capped, capped_emoji))
+            stake = stake_info_by_player[user_id]
+            emoji = "🧢" if stake["is_capped"] else "🏎️"
+            entries.append((user_id, display_name, stake["amount"], emoji))
         else:
-            sign_ups_list.append((user_id, display_name, "Not set", True, "❓"))
+            entries.append((user_id, display_name, "Not set", "❓"))
 
-    def sort_key(item):
-        stake = item[2]
-        return -1 if stake == "Not set" else stake
+    def sort_key(entry):
+        stake_amount = entry[2]
+        return -1 if stake_amount == "Not set" else stake_amount
 
-    sign_ups_list.sort(key=sort_key, reverse=True)
+    entries.sort(key=sort_key, reverse=True)
 
-    formatted = []
-    for user_id, display_name, stake_amount, _is_capped, emoji in sign_ups_list:
+    lines = []
+    for user_id, display_name, stake_amount, emoji in entries:
         suffix = debt_warning_suffix(owed_map.get(user_id), threshold)
         if stake_amount == "Not set":
-            formatted.append(f"❌ Not set: {display_name}{suffix}")
+            lines.append(f"❌ Not set: {display_name}{suffix}")
         else:
-            formatted.append(f"{emoji} {stake_amount} tix: {display_name}{suffix}")
+            lines.append(f"{emoji} {stake_amount} tix: {display_name}{suffix}")
 
     result = (f"**Players ({len(sign_ups)}):**\n"
-              + ("\n".join(formatted) if formatted else "No players yet."))
+              + ("\n".join(lines) if lines else "No players yet."))
     if len(result) > 1000:
         logger.warning(
             f"[debt-warning] Sign-Ups field for {session_id or 'unknown session'} "

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -995,6 +995,43 @@ async def get_debt_history(
         return list(entries)
 
 
+async def _negative_pair_balances(guild_id: str, player_ids=None):
+    """Grouped pairwise balances that are negative (player owes counterparty).
+
+    Single source of truth for the ledger's debt-sign convention — both the
+    guild-wide debt rows and the per-player total-owed map derive from it.
+    """
+    query = (
+        select(
+            DebtLedger.player_id,
+            DebtLedger.counterparty_id,
+            func.sum(DebtLedger.amount).label('balance')
+        )
+        .where(DebtLedger.guild_id == guild_id)
+        .group_by(DebtLedger.player_id, DebtLedger.counterparty_id)
+        .having(func.sum(DebtLedger.amount) < 0)
+        .order_by(func.sum(DebtLedger.amount).asc())
+    )
+    if player_ids is not None:
+        query = query.where(DebtLedger.player_id.in_(list(player_ids)))
+    async with db_session() as session:
+        result = await session.execute(query)
+        return result.all()
+
+
+async def get_total_owed_map(guild_id: str, player_ids) -> dict[str, int]:
+    """Total outstanding debt per player: the sum of their negative pair
+    balances as a positive int. Being owed money does not offset owing.
+    Players with no outstanding debt are absent from the map."""
+    if not player_ids:
+        return {}
+    rows = await _negative_pair_balances(guild_id, player_ids=player_ids)
+    totals: dict[str, int] = {}
+    for row in rows:
+        totals[row.player_id] = totals.get(row.player_id, 0) + int(-row.balance)
+    return totals
+
+
 async def get_guild_debt_rows(guild_id: str) -> list:
     """
     Get all debt relationships for a guild (from debtor perspective).
@@ -1008,20 +1045,7 @@ async def get_guild_debt_rows(guild_id: str) -> list:
     Returns:
         List of Row objects with player_id, counterparty_id, balance attributes
     """
-    async with db_session() as session:
-        query = (
-            select(
-                DebtLedger.player_id,
-                DebtLedger.counterparty_id,
-                func.sum(DebtLedger.amount).label('balance')
-            )
-            .where(DebtLedger.guild_id == guild_id)
-            .group_by(DebtLedger.player_id, DebtLedger.counterparty_id)
-            .having(func.sum(DebtLedger.amount) < 0)
-            .order_by(func.sum(DebtLedger.amount).asc())
-        )
-        result = await session.execute(query)
-        return result.all()
+    return await _negative_pair_balances(guild_id)
 
 
 async def get_top_net_creditors(guild_id: str, limit: int = 3) -> list:

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -1729,11 +1729,18 @@ class TestMostInvolvedPlayers:
 class TestGetTotalOwedMap:
     """get_total_owed_map: sum of negative pair balances per player, batched."""
 
+    async def _owe(self, guild, debtor, creditor, amount, source_type="draft"):
+        await create_ledger_entries(
+            guild_id=guild, debtor_id=debtor, creditor_id=creditor,
+            amount=amount, source_type=source_type,
+            source_id=f"s-{debtor}-{creditor}-{amount}",
+        )
+
     @pytest.mark.asyncio
     async def test_being_owed_does_not_offset_owing(self, test_db):
         # Alice owes Bob 30; Carol owes Alice 100. Alice's total owed is 30.
-        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
-        await create_ledger_entries("g1", "carol", "alice", 100, "draft", "s2")
+        await self._owe("g1", "alice", "bob", 30)
+        await self._owe("g1", "carol", "alice", 100)
         owed = await get_total_owed_map("g1", ["alice", "bob", "carol"])
         assert owed["alice"] == 30
         assert owed["carol"] == 100
@@ -1741,10 +1748,10 @@ class TestGetTotalOwedMap:
 
     @pytest.mark.asyncio
     async def test_multiple_debts_sum_and_settlements_offset(self, test_db):
-        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
-        await create_ledger_entries("g1", "alice", "carol", 40, "draft", "s2")
+        await self._owe("g1", "alice", "bob", 30)
+        await self._owe("g1", "alice", "carol", 40)
         # Alice pays Bob 10 back (settlement: bob as debtor, alice as creditor)
-        await create_ledger_entries("g1", "bob", "alice", 10, "settlement", "x1")
+        await self._owe("g1", "bob", "alice", 10, source_type="settlement")
         owed = await get_total_owed_map("g1", ["alice"])
         assert owed == {"alice": 60}      # (30-10) + 40
 
@@ -1755,14 +1762,24 @@ class TestGetTotalOwedMap:
 
     @pytest.mark.asyncio
     async def test_guild_scoped(self, test_db):
-        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
+        await self._owe("g1", "alice", "bob", 30)
         assert await get_total_owed_map("g2", ["alice"]) == {}
 
+
+class TestGetGuildDebtRows:
+    """Regression pin for get_guild_debt_rows after it moved onto the shared
+    negative-pair-balance query."""
+
     @pytest.mark.asyncio
-    async def test_get_guild_debt_rows_unchanged_by_refactor(self, test_db):
-        # Regression pin: same rows, debtor perspective, largest debt first.
-        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
-        await create_ledger_entries("g1", "carol", "bob", 70, "draft", "s2")
+    async def test_debtor_perspective_largest_debt_first(self, test_db):
+        await create_ledger_entries(
+            guild_id="g1", debtor_id="alice", creditor_id="bob",
+            amount=30, source_type="draft", source_id="s1",
+        )
+        await create_ledger_entries(
+            guild_id="g1", debtor_id="carol", creditor_id="bob",
+            amount=70, source_type="draft", source_id="s2",
+        )
         rows = await get_guild_debt_rows("g1")
         assert [(r.player_id, r.counterparty_id, r.balance) for r in rows] == [
             ("carol", "bob", -70), ("alice", "bob", -30)]

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -21,7 +21,9 @@ from services.debt_service import (
     create_debt_entries_from_stakes,
     adjust_debt,
     get_guild_debt_stats,
-    get_debt_history
+    get_debt_history,
+    get_total_owed_map,
+    get_guild_debt_rows
 )
 from models.stake import StakeInfo
 from models.stake_pairing import StakePairing
@@ -1722,3 +1724,45 @@ class TestMostInvolvedPlayers:
         await self._owe("other", "z", "y", 99)    # different guild
         result = await get_most_involved_players(g, limit=1)
         assert result == [("a", 2)]
+
+
+class TestGetTotalOwedMap:
+    """get_total_owed_map: sum of negative pair balances per player, batched."""
+
+    @pytest.mark.asyncio
+    async def test_being_owed_does_not_offset_owing(self, test_db):
+        # Alice owes Bob 30; Carol owes Alice 100. Alice's total owed is 30.
+        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
+        await create_ledger_entries("g1", "carol", "alice", 100, "draft", "s2")
+        owed = await get_total_owed_map("g1", ["alice", "bob", "carol"])
+        assert owed["alice"] == 30
+        assert owed["carol"] == 100
+        assert "bob" not in owed          # owed money, owes nothing
+
+    @pytest.mark.asyncio
+    async def test_multiple_debts_sum_and_settlements_offset(self, test_db):
+        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
+        await create_ledger_entries("g1", "alice", "carol", 40, "draft", "s2")
+        # Alice pays Bob 10 back (settlement: bob as debtor, alice as creditor)
+        await create_ledger_entries("g1", "bob", "alice", 10, "settlement", "x1")
+        owed = await get_total_owed_map("g1", ["alice"])
+        assert owed == {"alice": 60}      # (30-10) + 40
+
+    @pytest.mark.asyncio
+    async def test_empty_and_absent_players(self, test_db):
+        assert await get_total_owed_map("g1", []) == {}
+        assert await get_total_owed_map("g1", ["nobody"]) == {}
+
+    @pytest.mark.asyncio
+    async def test_guild_scoped(self, test_db):
+        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
+        assert await get_total_owed_map("g2", ["alice"]) == {}
+
+    @pytest.mark.asyncio
+    async def test_get_guild_debt_rows_unchanged_by_refactor(self, test_db):
+        # Regression pin: same rows, debtor perspective, largest debt first.
+        await create_ledger_entries("g1", "alice", "bob", 30, "draft", "s1")
+        await create_ledger_entries("g1", "carol", "bob", 70, "draft", "s2")
+        rows = await get_guild_debt_rows("g1")
+        assert [(r.player_id, r.counterparty_id, r.balance) for r in rows] == [
+            ("carol", "bob", -70), ("alice", "bob", -30)]

--- a/tests/test_debt_warning.py
+++ b/tests/test_debt_warning.py
@@ -1,0 +1,71 @@
+"""Tests for the staked-signup debt warning marker and Sign-Ups formatter."""
+from helpers.debt_warning import debt_warning_suffix, format_staked_sign_ups
+
+
+def _fmt(sign_ups, stakes, owed=None, threshold=50):
+    return format_staked_sign_ups(
+        sign_ups, stakes, owed or {}, threshold,
+        display_name_for=lambda uid, stored: stored,
+    )
+
+
+# ---- debt_warning_suffix -------------------------------------------------------------
+
+def test_suffix_at_and_above_threshold():
+    assert debt_warning_suffix(50, 50) == " ⚠️ owes 50 tix"
+    assert debt_warning_suffix(75, 50) == " ⚠️ owes 75 tix"
+
+
+def test_suffix_below_threshold_or_no_debt():
+    assert debt_warning_suffix(49, 50) == ""
+    assert debt_warning_suffix(0, 50) == ""
+    assert debt_warning_suffix(None, 50) == ""
+
+
+def test_suffix_threshold_zero_disables():
+    assert debt_warning_suffix(1000, 0) == ""
+
+
+# ---- format_staked_sign_ups ----------------------------------------------------------
+
+def test_parity_with_legacy_format_when_no_debts():
+    """Byte-identical to the pre-extraction update_draft_message output."""
+    sign_ups = {"1": "Alice", "2": "Bob", "3": "Carol"}
+    stakes = {
+        "1": {"amount": 50, "is_capped": True},
+        "2": {"amount": 100, "is_capped": False},
+    }
+    out = _fmt(sign_ups, stakes)
+    assert out == (
+        "**Players (3):**\n"
+        "🏎️ 100 tix: Bob\n"      # uncapped, highest stake first
+        "🧢 50 tix: Alice\n"
+        "❌ Not set: Carol"        # "Not set" sorts last
+    )
+
+
+def test_flagged_player_gets_suffix():
+    sign_ups = {"1": "Alice", "2": "Bob"}
+    stakes = {"1": {"amount": 50, "is_capped": True},
+              "2": {"amount": 20, "is_capped": True}}
+    out = _fmt(sign_ups, stakes, owed={"1": 75, "2": 30}, threshold=50)
+    assert "🧢 50 tix: Alice ⚠️ owes 75 tix" in out
+    assert "🧢 20 tix: Bob" in out and "Bob ⚠️" not in out
+
+
+def test_not_set_line_can_carry_suffix():
+    out = _fmt({"1": "Alice"}, {}, owed={"1": 90}, threshold=50)
+    assert out == "**Players (1):**\n❌ Not set: Alice ⚠️ owes 90 tix"
+
+
+def test_empty_signups():
+    assert _fmt({}, {}) == "**Players (0):**\nNo players yet."
+
+
+def test_overflow_logs_warning(capsys):
+    from loguru import logger
+    import sys
+    logger.add(sys.stderr, level="WARNING")
+    sign_ups = {str(i): "N" * 60 for i in range(20)}   # force > 1000 chars
+    _fmt(sign_ups, {})
+    assert "exceeds single-field limit" in capsys.readouterr().err

--- a/tests/test_debt_warning.py
+++ b/tests/test_debt_warning.py
@@ -65,7 +65,10 @@ def test_empty_signups():
 def test_overflow_logs_warning(capsys):
     from loguru import logger
     import sys
-    logger.add(sys.stderr, level="WARNING")
-    sign_ups = {str(i): "N" * 60 for i in range(20)}   # force > 1000 chars
-    _fmt(sign_ups, {})
-    assert "exceeds single-field limit" in capsys.readouterr().err
+    hid = logger.add(sys.stderr, level="WARNING")
+    try:
+        sign_ups = {str(i): "N" * 60 for i in range(20)}   # force > 1000 chars
+        _fmt(sign_ups, {})
+        assert "exceeds single-field limit" in capsys.readouterr().err
+    finally:
+        logger.remove(hid)

--- a/tests/test_debt_warning.py
+++ b/tests/test_debt_warning.py
@@ -1,4 +1,8 @@
 """Tests for the staked-signup debt warning marker and Sign-Ups formatter."""
+import sys
+
+from loguru import logger
+
 from helpers.debt_warning import debt_warning_suffix, format_staked_sign_ups
 
 
@@ -63,8 +67,6 @@ def test_empty_signups():
 
 
 def test_overflow_logs_warning(capsys):
-    from loguru import logger
-    import sys
     hid = logger.add(sys.stderr, level="WARNING")
     try:
         sign_ups = {str(i): "N" * 60 for i in range(20)}   # force > 1000 chars

--- a/tests/test_debt_warning_threshold.py
+++ b/tests/test_debt_warning_threshold.py
@@ -1,0 +1,41 @@
+"""Tests for stakes.debt_warning_threshold config: default, opt-out, migration."""
+from unittest.mock import patch
+
+import config as config_module
+from config import DEFAULT_DEBT_WARNING_THRESHOLD, get_debt_warning_threshold
+
+
+def test_defaults_to_50_when_key_missing():
+    with patch("config.get_config", return_value={"stakes": {}}):
+        assert get_debt_warning_threshold(123) == DEFAULT_DEBT_WARNING_THRESHOLD == 50
+
+
+def test_defaults_apply_without_stakes_block():
+    with patch("config.get_config", return_value={}):
+        assert get_debt_warning_threshold(123) == 50
+
+
+def test_explicit_zero_disables():
+    with patch("config.get_config", return_value={"stakes": {"debt_warning_threshold": 0}}):
+        assert get_debt_warning_threshold(123) == 0
+
+
+def _migrate_fake_guild(stakes):
+    guild_id = "999000999000999000"
+    config_module.bot_config.configs[guild_id] = {"stakes": dict(stakes)}
+    try:
+        with patch.object(config_module.bot_config, "save_config"):
+            config_module.migrate_configs()
+        return config_module.bot_config.configs[guild_id]["stakes"]
+    finally:
+        del config_module.bot_config.configs[guild_id]
+
+
+def test_migrate_configs_adds_threshold_when_missing():
+    stakes = _migrate_fake_guild({"stake_multiple": 10})
+    assert stakes["debt_warning_threshold"] == 50
+
+
+def test_migrate_configs_keeps_explicit_zero():
+    stakes = _migrate_fake_guild({"debt_warning_threshold": 0})
+    assert stakes["debt_warning_threshold"] == 0

--- a/tests/test_refresh_open_staked_queues.py
+++ b/tests/test_refresh_open_staked_queues.py
@@ -1,0 +1,47 @@
+"""refresh_open_staked_queues: re-render open staked queue messages so debt
+markers reflect a just-completed settlement; always best-effort."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils import refresh_open_staked_queues
+
+
+def _db_returning(sessions):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = sessions
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=result)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=ctx)
+
+
+@pytest.mark.asyncio
+async def test_refreshes_each_open_staked_session():
+    sessions = [SimpleNamespace(session_id="s1"), SimpleNamespace(session_id="s2")]
+    update = AsyncMock()
+    with patch("utils.AsyncSessionLocal", _db_returning(sessions)), \
+         patch("views.update_draft_message", update):
+        await refresh_open_staked_queues(bot="BOT", guild_id="g1")
+    assert update.await_count == 2
+    assert {c.args[1] for c in update.await_args_list} == {"s1", "s2"}
+
+
+@pytest.mark.asyncio
+async def test_one_failed_refresh_does_not_stop_the_rest():
+    sessions = [SimpleNamespace(session_id="s1"), SimpleNamespace(session_id="s2")]
+    update = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    with patch("utils.AsyncSessionLocal", _db_returning(sessions)), \
+         patch("views.update_draft_message", update):
+        await refresh_open_staked_queues(bot="BOT", guild_id="g1")   # must not raise
+    assert update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_query_failure_is_swallowed():
+    broken = MagicMock(side_effect=RuntimeError("db down"))
+    with patch("utils.AsyncSessionLocal", broken):
+        await refresh_open_staked_queues(bot="BOT", guild_id="g1")   # must not raise

--- a/tests/test_refresh_open_staked_queues.py
+++ b/tests/test_refresh_open_staked_queues.py
@@ -45,3 +45,14 @@ async def test_query_failure_is_swallowed():
     broken = MagicMock(side_effect=RuntimeError("db down"))
     with patch("utils.AsyncSessionLocal", broken):
         await refresh_open_staked_queues(bot="BOT", guild_id="g1")   # must not raise
+
+
+def test_all_three_debt_mutation_flows_schedule_queue_refresh():
+    """Settlement, transfer, and admin adjust must all trigger the queue
+    refresh; a dropped call silently reintroduces stale warnings."""
+    import inspect
+    import debt_views.settle_views as settle_views
+    import cogs.debt_admin_commands as debt_admin
+
+    assert inspect.getsource(settle_views).count("refresh_open_staked_queues") >= 3  # import + 2 sites
+    assert inspect.getsource(debt_admin).count("refresh_open_staked_queues") >= 2    # import + 1 site

--- a/utils.py
+++ b/utils.py
@@ -1273,11 +1273,11 @@ async def refresh_open_staked_queues(bot, guild_id: str) -> None:
         logger.warning(f"[debt-warning] open-queue lookup failed for guild {guild_id}: {e}")
         return
     from views import update_draft_message  # lazy: views imports utils
-    for ds in open_sessions:
+    for draft_session in open_sessions:
         try:
-            await update_draft_message(bot, ds.session_id)
+            await update_draft_message(bot, draft_session.session_id)
         except Exception as e:
-            logger.warning(f"[debt-warning] queue refresh failed for {ds.session_id}: {e}")
+            logger.warning(f"[debt-warning] queue refresh failed for {draft_session.session_id}: {e}")
 
 
 async def remove_lock_after_delay(draft_session_id, delay):

--- a/utils.py
+++ b/utils.py
@@ -1254,6 +1254,31 @@ async def update_debt_summary_for_guild(bot, guild_id: str):
         logger.error(f"Error updating debt summary for guild {guild_id}: {e}")
 
 
+async def refresh_open_staked_queues(bot, guild_id: str) -> None:
+    """Best-effort re-render of the queue message of every open staked session
+    in a guild (still in signup phase: teams_start_time unset), so debt-warning
+    markers reflect a just-completed settlement/transfer/adjustment without
+    waiting for the next signup event. Never raises: a display refresh must
+    not break the debt flow that triggered it."""
+    try:
+        async with AsyncSessionLocal() as db_session:
+            stmt = select(DraftSession).filter(
+                DraftSession.guild_id == str(guild_id),
+                DraftSession.session_type == "staked",
+                DraftSession.teams_start_time.is_(None),
+            )
+            result = await db_session.execute(stmt)
+            open_sessions = result.scalars().all()
+    except Exception as e:
+        logger.warning(f"[debt-warning] open-queue lookup failed for guild {guild_id}: {e}")
+        return
+    for ds in open_sessions:
+        try:
+            from views import update_draft_message  # lazy: views imports utils
+            await update_draft_message(bot, ds.session_id)
+        except Exception as e:
+            logger.warning(f"[debt-warning] queue refresh failed for {ds.session_id}: {e}")
+
 
 async def remove_lock_after_delay(draft_session_id, delay):
     await asyncio.sleep(delay)

--- a/utils.py
+++ b/utils.py
@@ -1272,9 +1272,9 @@ async def refresh_open_staked_queues(bot, guild_id: str) -> None:
     except Exception as e:
         logger.warning(f"[debt-warning] open-queue lookup failed for guild {guild_id}: {e}")
         return
+    from views import update_draft_message  # lazy: views imports utils
     for ds in open_sessions:
         try:
-            from views import update_draft_message  # lazy: views imports utils
             await update_draft_message(bot, ds.session_id)
         except Exception as e:
             logger.warning(f"[debt-warning] queue refresh failed for {ds.session_id}: {e}")

--- a/views.py
+++ b/views.py
@@ -5,7 +5,7 @@ import pytz
 from datetime import datetime, timedelta
 from discord import SelectOption
 from discord.ui import Button, View, Select, select
-from config import is_test_mode, should_reset_on_signup, get_queue_inactivity_minutes
+from config import is_test_mode, should_reset_on_signup, get_queue_inactivity_minutes, get_debt_warning_threshold
 from notification_service import send_ready_check_dms
 from ready_check import ReadyCheckView, ReadyCheckSession
 from draft_organization.stake_calculator import calculate_stakes_with_strategy
@@ -16,6 +16,7 @@ from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
 from helpers.utils import get_cube_thumbnail_url
 from helpers.display_names import get_display_name, get_display_name_by_id
+from helpers.debt_warning import format_staked_sign_ups
 from utils import (
     calculate_pairings,
     get_formatted_stake_pairs,
@@ -2211,36 +2212,27 @@ async def update_draft_message(bot, session_id):
         guild = channel.guild
 
         if draft_session.session_type == "staked":
-            sign_ups_list = []
-            for user_id, stored_name in draft_session.sign_ups.items():
-                # Get display name with crown icon
-                display_name = get_display_name_by_id(user_id, guild, stored_name)
-                # Default to "Not set" if no stake has been set yet
-                if user_id in stake_info_by_player:
-                    stake_amount = stake_info_by_player[user_id]['amount']
-                    is_capped = stake_info_by_player[user_id]['is_capped']
-                    capped_emoji = "🧢" if is_capped else "🏎️"  # Cap emoji for capped, lightning for uncapped
-                    sign_ups_list.append((user_id, display_name, stake_amount, is_capped, capped_emoji))
-                else:
-                    sign_ups_list.append((user_id, display_name, "Not set", True, "❓"))
-
-            # Sort by stake amount (highest first)
-            # Convert "Not set" to -1 for sorting purposes
-            def sort_key(item):
-                stake = item[2]
-                return -1 if stake == "Not set" else stake
-
-            sign_ups_list.sort(key=sort_key, reverse=True)
-
-            # Format with stakes and capping status
-            formatted_sign_ups = []
-            for user_id, display_name, stake_amount, is_capped, emoji in sign_ups_list:
-                if stake_amount == "Not set":
-                    formatted_sign_ups.append(f"❌ Not set: {display_name}")
-                else:
-                    formatted_sign_ups.append(f"{emoji} {stake_amount} tix: {display_name}")
-
-            sign_ups_str = f"**Players ({sign_up_count}):**\n" + ('\n'.join(formatted_sign_ups) if formatted_sign_ups else 'No players yet.')
+            # Debt warnings: best-effort, render-time only. A lookup failure
+            # renders the plain list — it must never block the embed update.
+            owed_map = {}
+            threshold = get_debt_warning_threshold(draft_session.guild_id)
+            if threshold:
+                try:
+                    from services.debt_service import get_total_owed_map
+                    owed_map = await get_total_owed_map(
+                        str(draft_session.guild_id), list(draft_session.sign_ups.keys())
+                    )
+                except Exception as e:
+                    logger.warning(f"[debt-warning] lookup failed for {session_id}: {e}; "
+                                   "rendering without markers")
+            sign_ups_str = format_staked_sign_ups(
+                draft_session.sign_ups,
+                stake_info_by_player,
+                owed_map,
+                threshold,
+                display_name_for=lambda uid, stored: get_display_name_by_id(uid, guild, stored),
+                session_id=session_id,
+            )
         else:
             if draft_session.sign_ups:
                 # Get display names with crown icons


### PR DESCRIPTION
## What

Players whose **total outstanding debt** (sum of what they owe across all players — being owed money doesn't offset) meets the guild's threshold get a warning on the **staked** queue embed's Sign-Ups line, visible to everyone:

```
🧢 50 tix: punkguy ⚠️ owes 75 tix
```

Nothing is blocked — it's a heads-up for the other players before they agree to stakes. Warnings compute at render time (stored sign_ups names are never touched — the #349 lesson) and clear automatically: settlements, transfers, and admin adjustments best-effort re-render open staked queues, so paying up removes the ⚠️ promptly.

## Pieces

- `stakes.debt_warning_threshold` guild config (default **50** tix, `0` disables; migrated in on startup)
- `debt_service.get_total_owed_map(...)` — batched, built on the same grouped pair-balance query as `get_guild_debt_rows` (shared `_negative_pair_balances` helper; regression-pinned)
- `helpers/debt_warning.py` — suffix + pure `format_staked_sign_ups` (parity test locks byte-identical legacy output; overflow past the 1000-char field limit logs a WARNING)
- `views.update_draft_message` staked branch delegates to the formatter; debt lookup is best-effort (failure → plain list, never a broken embed)
- `utils.refresh_open_staked_queues` — never-raises re-render of open staked queues, scheduled from the three debt-mutation flows

## Testing

- 27 new tests across debt_service / config / formatter / refresh helper + source-pin for the three mutation hooks
- Full suite: **823 passed, 9 skipped**
- Built via subagent-driven TDD with per-task review; final whole-branch review clean (2 minor cleanups applied); design spec was adversarially reviewed by Codex before implementation

**Before merge:** one manual TEST_MODE pass is recommended (seed a debtor ≥50 tix → staked queue shows the marker → settle → marker clears without a signup event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv