### PR TITLE
feat: debt warning triggers on week-old outstanding debt over 100 tix

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,8 +16,8 @@ DRAFTMANCER_BASE_URL = "https://draftmancer.com"
 # bot auto-creates when invited — so "Scryfall" works with zero guild setup.
 DEFAULT_BOTS_WITH_DRAFT_ACCESS = ["Scryfall"]
 
-# Tix total-owed at/above which a staked signup line shows a debt warning.
-# 0 disables the warning for a guild.
+# Tix of week-old outstanding debt strictly above which a staked signup line
+# shows a debt warning. 0 disables the warning for a guild.
 DEFAULT_DEBT_WARNING_THRESHOLD = 100
 
 def is_test_mode() -> bool:
@@ -439,6 +439,8 @@ def migrate_configs():
         # Rebase debt_warning_threshold from the old total-debt default to the
         # aged-debt default (the knob now measures week-old outstanding debt;
         # 50 was the universal old default, so 50 == unconfigured intent)
+        # Note: value-based with no one-shot marker — re-fires every startup,
+        # so a deliberate post-migration value of exactly 50 won't stick.
         if "stakes" in config and config["stakes"].get("debt_warning_threshold") == 50:
             config["stakes"]["debt_warning_threshold"] = 100
             updated = True

--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ DEFAULT_BOTS_WITH_DRAFT_ACCESS = ["Scryfall"]
 
 # Tix total-owed at/above which a staked signup line shows a debt warning.
 # 0 disables the warning for a guild.
-DEFAULT_DEBT_WARNING_THRESHOLD = 50
+DEFAULT_DEBT_WARNING_THRESHOLD = 100
 
 def is_test_mode() -> bool:
     """Returns True if TEST_MODE env var is set to a truthy value."""
@@ -399,8 +399,9 @@ def get_bots_with_draft_access(guild_id):
     return config.get("roles", {}).get("bots_with_draft_access", list(DEFAULT_BOTS_WITH_DRAFT_ACCESS))
 
 def get_debt_warning_threshold(guild_id):
-    """Tix total-owed at/above which a staked signup shows a debt warning
-    to other players. 0 (or missing stakes config entirely) disables."""
+    """Tix of week-old outstanding debt above which (strictly) a staked signup
+    shows a debt warning to other players. 0 (or missing stakes config
+    entirely) disables."""
     config = get_config(guild_id)
     return config.get("stakes", {}).get("debt_warning_threshold", DEFAULT_DEBT_WARNING_THRESHOLD)
 
@@ -433,6 +434,13 @@ def migrate_configs():
         # Add debt_warning_threshold if missing (staked signup debt warnings)
         if "stakes" in config and "debt_warning_threshold" not in config["stakes"]:
             config["stakes"]["debt_warning_threshold"] = DEFAULT_DEBT_WARNING_THRESHOLD
+            updated = True
+
+        # Rebase debt_warning_threshold from the old total-debt default to the
+        # aged-debt default (the knob now measures week-old outstanding debt;
+        # 50 was the universal old default, so 50 == unconfigured intent)
+        if "stakes" in config and config["stakes"].get("debt_warning_threshold") == 50:
+            config["stakes"]["debt_warning_threshold"] = 100
             updated = True
 
         # Add timeout configuration if missing

--- a/helpers/debt_warning.py
+++ b/helpers/debt_warning.py
@@ -6,19 +6,28 @@ are never modified (see PR #349 — decorating stored names broke seating)."""
 from loguru import logger
 
 
-def debt_warning_suffix(total_owed, threshold) -> str:
-    """The trailing marker (e.g. " ⚠️ owes 75 tix") when total_owed reaches
-    threshold, else "". A falsy threshold disables warnings entirely."""
-    if not threshold or not total_owed or total_owed < threshold:
+# Days a debt must remain outstanding before it counts toward the warning
+# threshold. Code constant on purpose — the threshold is per-guild config,
+# the age window is not (YAGNI until someone asks).
+DEBT_WARNING_AGE_DAYS = 7
+
+
+def debt_warning_suffix(total_owed, old_owed, threshold) -> str:
+    """The trailing marker (e.g. " ⚠️ owes 150 tix") when the player's
+    week-old outstanding debt strictly exceeds threshold. Displays the total
+    outstanding amount; triggers on the aged portion only. A falsy threshold
+    disables warnings entirely."""
+    if not threshold or not old_owed or old_owed <= threshold:
         return ""
     return f" ⚠️ owes {total_owed} tix"
 
 
-def format_staked_sign_ups(sign_ups, stake_info_by_player, owed_map, threshold,
-                           display_name_for, session_id: str = "") -> str:
+def format_staked_sign_ups(sign_ups, stake_info_by_player, owed_map, old_owed_map,
+                           threshold, display_name_for, session_id: str = "") -> str:
     """The staked draft message's Sign-Ups field text: one line per player with
-    stake, cap emoji, display name, and (over-threshold players only) the debt
-    warning suffix. Identical to the historical format when owed_map is empty."""
+    stake, cap emoji, display name, and (players whose week-old debt exceeds
+    threshold only) the debt warning suffix. Identical to the historical format
+    when the maps are empty."""
     entries = []
     for user_id, stored_name in sign_ups.items():
         display_name = display_name_for(user_id, stored_name)
@@ -37,7 +46,7 @@ def format_staked_sign_ups(sign_ups, stake_info_by_player, owed_map, threshold,
 
     lines = []
     for user_id, display_name, stake_amount, emoji in entries:
-        suffix = debt_warning_suffix(owed_map.get(user_id), threshold)
+        suffix = debt_warning_suffix(owed_map.get(user_id), old_owed_map.get(user_id), threshold)
         if stake_amount == "Not set":
             lines.append(f"❌ Not set: {display_name}{suffix}")
         else:

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -995,11 +995,13 @@ async def get_debt_history(
         return list(entries)
 
 
-async def _negative_pair_balances(guild_id: str, player_ids=None):
+async def _negative_pair_balances(guild_id: str, player_ids=None, created_before=None):
     """Grouped pairwise balances that are negative (player owes counterparty).
 
     Single source of truth for the ledger's debt-sign convention — both the
     guild-wide debt rows and the per-player total-owed map derive from it.
+    With created_before, sums only entries older than that instant — the
+    ledger is append-only, so this IS the pair balance as of that time.
     """
     query = (
         select(
@@ -1014,6 +1016,8 @@ async def _negative_pair_balances(guild_id: str, player_ids=None):
     )
     if player_ids is not None:
         query = query.where(DebtLedger.player_id.in_(list(player_ids)))
+    if created_before is not None:
+        query = query.where(DebtLedger.created_at < created_before)
     async with db_session() as session:
         result = await session.execute(query)
         return result.all()
@@ -1030,6 +1034,34 @@ async def get_total_owed_map(guild_id: str, player_ids) -> dict[str, int]:
     for row in rows:
         totals[row.player_id] = totals.get(row.player_id, 0) + int(-row.balance)
     return totals
+
+
+async def get_owed_maps(guild_id: str, player_ids, aged_cutoff) -> tuple[dict[str, int], dict[str, int]]:
+    """(total_owed_map, old_owed_map) for the given players.
+
+    total_owed_map: current outstanding debt per player (as get_total_owed_map).
+    old_owed_map: per player, the sum over creditor pairs of
+    min(owed_now, owed_as_of_aged_cutoff) — debt that is both currently
+    outstanding and was already owed at the cutoff. Settling always shrinks
+    it; debt incurred after the cutoff never enters it. Players with zero
+    in a map are absent from that map.
+    """
+    if not player_ids:
+        return {}, {}
+    now_rows = await _negative_pair_balances(guild_id, player_ids=player_ids)
+    aged_rows = await _negative_pair_balances(
+        guild_id, player_ids=player_ids, created_before=aged_cutoff
+    )
+    now_pairs = {(r.player_id, r.counterparty_id): int(-r.balance) for r in now_rows}
+    aged_pairs = {(r.player_id, r.counterparty_id): int(-r.balance) for r in aged_rows}
+    totals: dict[str, int] = {}
+    old_totals: dict[str, int] = {}
+    for (player_id, counterparty_id), owed_now in now_pairs.items():
+        totals[player_id] = totals.get(player_id, 0) + owed_now
+        aged = min(owed_now, aged_pairs.get((player_id, counterparty_id), 0))
+        if aged > 0:
+            old_totals[player_id] = old_totals.get(player_id, 0) + aged
+    return totals, old_totals
 
 
 async def get_guild_debt_rows(guild_id: str) -> list:

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -5,11 +5,11 @@ import pytest
 import pytest_asyncio
 import tempfile
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from database.models_base import Base
 from database.db_session import AsyncSessionLocal
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from models.debt_ledger import DebtLedger
 from services.debt_service import (
@@ -23,7 +23,8 @@ from services.debt_service import (
     get_guild_debt_stats,
     get_debt_history,
     get_total_owed_map,
-    get_guild_debt_rows
+    get_guild_debt_rows,
+    get_owed_maps
 )
 from models.stake import StakeInfo
 from models.stake_pairing import StakePairing
@@ -1783,3 +1784,97 @@ class TestGetGuildDebtRows:
         rows = await get_guild_debt_rows("g1")
         assert [(r.player_id, r.counterparty_id, r.balance) for r in rows] == [
             ("carol", "bob", -70), ("alice", "bob", -30)]
+
+
+class TestGetOwedMaps:
+    """get_owed_maps: (total, week-old) outstanding debt; old = per-pair
+    min(owed now, owed as of cutoff) — active debt that has aged."""
+
+    CUTOFF_DAYS = 7
+
+    def _cutoff(self):
+        return datetime.now() - timedelta(days=self.CUTOFF_DAYS)
+
+    async def _owe(self, guild, debtor, creditor, amount, source_type="draft",
+                   source_id=None):
+        await create_ledger_entries(
+            guild_id=guild, debtor_id=debtor, creditor_id=creditor,
+            amount=amount, source_type=source_type,
+            source_id=source_id or f"s-{debtor}-{creditor}-{amount}",
+        )
+
+    async def _backdate(self, source_id, days=8):
+        """Age both ledger entries of a source to `days` ago."""
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                await session.execute(
+                    update(DebtLedger)
+                    .where(DebtLedger.source_id == source_id)
+                    .values(created_at=datetime.now() - timedelta(days=days))
+                )
+
+    @pytest.mark.asyncio
+    async def test_untouched_old_debt_counts_in_full(self, test_db):
+        await self._owe("g1", "alice", "bob", 150, source_id="old1")
+        await self._backdate("old1")
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {"alice": 150}
+        assert old == {"alice": 150}
+
+    @pytest.mark.asyncio
+    async def test_settled_old_debt_counts_zero(self, test_db):
+        # Owed 200 for over a week, fully paid yesterday: no debt, no warning.
+        await self._owe("g1", "alice", "bob", 200, source_id="old2")
+        await self._backdate("old2")
+        await self._owe("g1", "bob", "alice", 200, source_type="settlement")
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {}
+        assert old == {}
+
+    @pytest.mark.asyncio
+    async def test_new_debt_gets_grace_week(self, test_db):
+        # Fresh 200 from last night: outstanding, but not old yet.
+        await self._owe("g1", "alice", "bob", 200)
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {"alice": 200}
+        assert old == {}
+
+    @pytest.mark.asyncio
+    async def test_paid_down_old_debt_counts_remainder(self, test_db):
+        # 200 aged, 150 paid this week: 50 outstanding, all of it old.
+        await self._owe("g1", "alice", "bob", 200, source_id="old3")
+        await self._backdate("old3")
+        await self._owe("g1", "bob", "alice", 150, source_type="settlement")
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {"alice": 50}
+        assert old == {"alice": 50}
+
+    @pytest.mark.asyncio
+    async def test_pair_min_fresh_debt_cannot_mask_paid_old_debt(self, test_db):
+        # Old 120 to bob fully paid this week; fresh 120 to carol incurred.
+        # Player-total math would see 120 then and 120 now and call it old;
+        # pair-level min must yield zero old debt.
+        await self._owe("g1", "alice", "bob", 120, source_id="old4")
+        await self._backdate("old4")
+        await self._owe("g1", "bob", "alice", 120, source_type="settlement")
+        await self._owe("g1", "alice", "carol", 120)
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {"alice": 120}
+        assert old == {}
+
+    @pytest.mark.asyncio
+    async def test_old_debt_sums_across_pairs(self, test_db):
+        await self._owe("g1", "alice", "bob", 60, source_id="old5")
+        await self._owe("g1", "alice", "carol", 70, source_id="old6")
+        await self._backdate("old5")
+        await self._backdate("old6")
+        totals, old = await get_owed_maps("g1", ["alice"], self._cutoff())
+        assert totals == {"alice": 130}
+        assert old == {"alice": 130}
+
+    @pytest.mark.asyncio
+    async def test_empty_players_and_guild_scoping(self, test_db):
+        assert await get_owed_maps("g1", [], self._cutoff()) == ({}, {})
+        await self._owe("g1", "alice", "bob", 150, source_id="old7")
+        await self._backdate("old7")
+        assert await get_owed_maps("g2", ["alice"], self._cutoff()) == ({}, {})

--- a/tests/test_debt_warning.py
+++ b/tests/test_debt_warning.py
@@ -6,28 +6,32 @@ from loguru import logger
 from helpers.debt_warning import debt_warning_suffix, format_staked_sign_ups
 
 
-def _fmt(sign_ups, stakes, owed=None, threshold=50):
+def _fmt(sign_ups, stakes, owed=None, old_owed=None, threshold=100):
     return format_staked_sign_ups(
-        sign_ups, stakes, owed or {}, threshold,
+        sign_ups, stakes, owed or {}, old_owed if old_owed is not None else (owed or {}),
+        threshold,
         display_name_for=lambda uid, stored: stored,
     )
 
 
 # ---- debt_warning_suffix -------------------------------------------------------------
 
-def test_suffix_at_and_above_threshold():
-    assert debt_warning_suffix(50, 50) == " ⚠️ owes 50 tix"
-    assert debt_warning_suffix(75, 50) == " ⚠️ owes 75 tix"
+def test_suffix_displays_total_but_triggers_on_old_debt():
+    assert debt_warning_suffix(150, 120, 100) == " ⚠️ owes 150 tix"
 
 
-def test_suffix_below_threshold_or_no_debt():
-    assert debt_warning_suffix(49, 50) == ""
-    assert debt_warning_suffix(0, 50) == ""
-    assert debt_warning_suffix(None, 50) == ""
+def test_suffix_strictly_greater_than_threshold():
+    assert debt_warning_suffix(150, 100, 100) == ""      # exactly at: no warning
+    assert debt_warning_suffix(150, 101, 100) == " ⚠️ owes 150 tix"
+
+
+def test_suffix_no_old_debt_means_no_warning_even_with_large_total():
+    assert debt_warning_suffix(500, 0, 100) == ""
+    assert debt_warning_suffix(500, None, 100) == ""
 
 
 def test_suffix_threshold_zero_disables():
-    assert debt_warning_suffix(1000, 0) == ""
+    assert debt_warning_suffix(1000, 900, 0) == ""
 
 
 # ---- format_staked_sign_ups ----------------------------------------------------------
@@ -52,14 +56,17 @@ def test_flagged_player_gets_suffix():
     sign_ups = {"1": "Alice", "2": "Bob"}
     stakes = {"1": {"amount": 50, "is_capped": True},
               "2": {"amount": 20, "is_capped": True}}
-    out = _fmt(sign_ups, stakes, owed={"1": 75, "2": 30}, threshold=50)
-    assert "🧢 50 tix: Alice ⚠️ owes 75 tix" in out
+    # Alice: 150 total, 120 of it old -> warns, displays the 150 total.
+    # Bob: 130 total but only 40 old -> under the bar, no marker.
+    out = _fmt(sign_ups, stakes, owed={"1": 150, "2": 130},
+               old_owed={"1": 120, "2": 40}, threshold=100)
+    assert "🧢 50 tix: Alice ⚠️ owes 150 tix" in out
     assert "🧢 20 tix: Bob" in out and "Bob ⚠️" not in out
 
 
 def test_not_set_line_can_carry_suffix():
-    out = _fmt({"1": "Alice"}, {}, owed={"1": 90}, threshold=50)
-    assert out == "**Players (1):**\n❌ Not set: Alice ⚠️ owes 90 tix"
+    out = _fmt({"1": "Alice"}, {}, owed={"1": 190}, threshold=100)
+    assert out == "**Players (1):**\n❌ Not set: Alice ⚠️ owes 190 tix"
 
 
 def test_empty_signups():

--- a/tests/test_debt_warning_threshold.py
+++ b/tests/test_debt_warning_threshold.py
@@ -5,14 +5,14 @@ import config as config_module
 from config import DEFAULT_DEBT_WARNING_THRESHOLD, get_debt_warning_threshold
 
 
-def test_defaults_to_50_when_key_missing():
+def test_defaults_to_100_when_key_missing():
     with patch("config.get_config", return_value={"stakes": {}}):
-        assert get_debt_warning_threshold(123) == DEFAULT_DEBT_WARNING_THRESHOLD == 50
+        assert get_debt_warning_threshold(123) == DEFAULT_DEBT_WARNING_THRESHOLD == 100
 
 
 def test_defaults_apply_without_stakes_block():
     with patch("config.get_config", return_value={}):
-        assert get_debt_warning_threshold(123) == 50
+        assert get_debt_warning_threshold(123) == 100
 
 
 def test_explicit_zero_disables():
@@ -33,9 +33,19 @@ def _migrate_fake_guild(stakes):
 
 def test_migrate_configs_adds_threshold_when_missing():
     stakes = _migrate_fake_guild({"stake_multiple": 10})
-    assert stakes["debt_warning_threshold"] == 50
+    assert stakes["debt_warning_threshold"] == 100
 
 
 def test_migrate_configs_keeps_explicit_zero():
     stakes = _migrate_fake_guild({"debt_warning_threshold": 0})
     assert stakes["debt_warning_threshold"] == 0
+
+
+def test_migration_rebases_old_default_50_to_100():
+    stakes = _migrate_fake_guild({"debt_warning_threshold": 50})
+    assert stakes["debt_warning_threshold"] == 100
+
+
+def test_migration_preserves_deliberate_values():
+    assert _migrate_fake_guild({"debt_warning_threshold": 75})["debt_warning_threshold"] == 75
+    assert _migrate_fake_guild({"debt_warning_threshold": 0})["debt_warning_threshold"] == 0

--- a/views.py
+++ b/views.py
@@ -16,7 +16,7 @@ from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
 from helpers.utils import get_cube_thumbnail_url
 from helpers.display_names import get_display_name, get_display_name_by_id
-from helpers.debt_warning import format_staked_sign_ups
+from helpers.debt_warning import format_staked_sign_ups, DEBT_WARNING_AGE_DAYS
 from utils import (
     calculate_pairings,
     get_formatted_stake_pairs,
@@ -2215,12 +2215,16 @@ async def update_draft_message(bot, session_id):
             # Debt warnings: best-effort, render-time only. A lookup failure
             # renders the plain list — it must never block the embed update.
             owed_map = {}
+            old_owed_map = {}
             threshold = get_debt_warning_threshold(draft_session.guild_id)
             if threshold:
                 try:
-                    from services.debt_service import get_total_owed_map
-                    owed_map = await get_total_owed_map(
-                        str(draft_session.guild_id), list(draft_session.sign_ups.keys())
+                    from services.debt_service import get_owed_maps
+                    aged_cutoff = datetime.now() - timedelta(days=DEBT_WARNING_AGE_DAYS)
+                    owed_map, old_owed_map = await get_owed_maps(
+                        str(draft_session.guild_id),
+                        list(draft_session.sign_ups.keys()),
+                        aged_cutoff,
                     )
                 except Exception as e:
                     logger.warning(f"[debt-warning] lookup failed for {session_id}: {e}; "
@@ -2229,6 +2233,7 @@ async def update_draft_message(bot, session_id):
                 draft_session.sign_ups,
                 stake_info_by_player,
                 owed_map,
+                old_owed_map,
                 threshold,
                 display_name_for=lambda uid, stored: get_display_name_by_id(uid, guild, stored),
                 session_id=session_id,


### PR DESCRIPTION
## Summary

The staked-signup debt warning now fires only on **active debt that has gone unpaid for over a week**, and only when that aged sum **strictly exceeds 100 tix** (previously: total outstanding debt ≥ 50). The warning still displays the player's full current debt; the aged portion is only the trigger. Fresh debt from recent drafts gets a week's grace, and settled debt never counts.

## Semantics

Old debt is computed per creditor pair as `min(owed_now, owed_a_week_ago)`, summed per player:

- Paid off this week → 0 (settlements always reduce, regardless of when the debt arose)
- Incurred this week → 0 (week's grace)
- Paid down this week → only the remainder counts
- The `min` is per **pair**, not per player total — fresh debt to one creditor can't mask paid-off debt to another

The ledger is append-only with `created_at` on every row, so "balance as of a week ago" is just the pair sum over entries older than the cutoff — no migration, no new columns.

## Changes

- `services/debt_service.py`: `_negative_pair_balances` gains an optional `created_before` filter; new `get_owed_maps(guild_id, player_ids, aged_cutoff)` returns `(total_owed_map, old_owed_map)`. `get_total_owed_map` untouched.
- `helpers/debt_warning.py`: `DEBT_WARNING_AGE_DAYS = 7` constant; `debt_warning_suffix(total_owed, old_owed, threshold)` triggers on `old_owed > threshold` (strict), displays `total_owed`; `format_staked_sign_ups` threads the second map through. Empty maps render byte-identical to the historical format.
- `views.py`: the staked sign-ups render fetches both maps with a 7-day cutoff; best-effort behavior (falsy threshold skips the lookup, failures log and render plain) unchanged.
- `config.py`: `DEFAULT_DEBT_WARNING_THRESHOLD` 50 → 100 with docstring/comments updated to the new semantics; `migrate_configs()` rebases explicit per-guild `50` (the old universal default) to `100` at startup — deliberate other values, including the `0` opt-out, are preserved. Guild config files aren't tracked, so prod picks this up via the migration on next restart.

## Test plan

- [x] 10 new tests: 7 service-level (DB-backed, including the pair-min-vs-player-min discriminating case and guild scoping) + strict-boundary/display-split formatter tests + migration rebase/preserve tests
- [x] Full suite at HEAD: `pipenv run python -m pytest` — 833 passed, 9 skipped, 0 failures
- [x] Reviewed: timezone convention (all `created_at` writers use naive-local `datetime.now`, matching the cutoff), settlement row direction, aged-query HAVING semantics, and migration ordering all verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tvd9n8wEXSp85kPJ5tTEp
