### PR TITLE
feat(debt): active_only filter on both debt history commands

### DIFF
--- a/cogs/debt_admin_commands.py
+++ b/cogs/debt_admin_commands.py
@@ -285,8 +285,7 @@ class DebtAdminCommands(commands.Cog):
             guild_id = str(ctx.guild.id)
             player_id = str(player.id) if player else None
 
-            entries = await get_debt_history(guild_id, player_id, limit, older_than_days,
-                                             active_only=active_only)
+            entries = await get_debt_history(guild_id, player_id, limit, older_than_days, active_only)
 
             if not entries:
                 filter_msg = f" for {player.display_name}" if player else ""

--- a/cogs/debt_admin_commands.py
+++ b/cogs/debt_admin_commands.py
@@ -268,13 +268,15 @@ class DebtAdminCommands(commands.Cog):
     @option("player", discord.User, description="Filter by specific player (optional)", required=False)
     @option("limit", int, description="Number of entries to show (max 100)", default=25, min_value=1, max_value=100)
     @option("older_than_days", int, description="Only show entries older than this many days (optional)", required=False, min_value=1)
+    @option("active_only", bool, description="Only entries for pairs with outstanding balances", default=False)
     @has_bot_manager_role()
     async def debt_admin_history(
         self,
         ctx: discord.ApplicationContext,
         player: discord.User = None,
         limit: int = 25,
-        older_than_days: int = None
+        older_than_days: int = None,
+        active_only: bool = False
     ):
         """View complete debt history (drafts, settlements, and admin modifications)."""
         await ctx.defer(ephemeral=True)
@@ -283,12 +285,15 @@ class DebtAdminCommands(commands.Cog):
             guild_id = str(ctx.guild.id)
             player_id = str(player.id) if player else None
 
-            entries = await get_debt_history(guild_id, player_id, limit, older_than_days)
+            entries = await get_debt_history(guild_id, player_id, limit, older_than_days,
+                                             active_only=active_only)
 
             if not entries:
                 filter_msg = f" for {player.display_name}" if player else ""
                 if older_than_days:
                     filter_msg += f" older than {older_than_days} days"
+                if active_only:
+                    filter_msg += " with active debt"
                 await ctx.followup.send(f"No debt history found{filter_msg}.", ephemeral=True)
                 return
 
@@ -298,6 +303,8 @@ class DebtAdminCommands(commands.Cog):
                 title += f" - {player.display_name}"
             if older_than_days:
                 title += f" (older than {older_than_days} days)"
+            if active_only:
+                title += " (active debts only)"
 
             embed = discord.Embed(
                 title=title,

--- a/cogs/debt_commands.py
+++ b/cogs/debt_commands.py
@@ -17,6 +17,7 @@ from services.debt_service import (
     get_all_balances_for,
     get_balance_with,
     get_entries_since_last_settlement,
+    get_active_debt_entries,
     create_settlement,
     get_guild_debt_rows
 )
@@ -191,7 +192,8 @@ class DebtCommands(commands.Cog):
 
     @debts.command(name="history", description="View full debt history with a player")
     @option("player", discord.Member, description="The player to check history with")
-    async def debts_history(self, ctx: discord.ApplicationContext, player: discord.Member):
+    @option("active_only", bool, description="Only the entries composing the current outstanding balance", default=False)
+    async def debts_history(self, ctx: discord.ApplicationContext, player: discord.Member, active_only: bool = False):
         """View full audit history with a specific player."""
         await ctx.defer(ephemeral=True)
 
@@ -203,23 +205,33 @@ class DebtCommands(commands.Cog):
             await ctx.followup.send("You can't have debts with yourself!")
             return
 
-        # Get ALL entries (not just since last settlement)
-        async with db_session() as session:
-            query = (
-                select(DebtLedger)
-                .where(
-                    DebtLedger.guild_id == guild_id,
-                    DebtLedger.player_id == user_id,
-                    DebtLedger.counterparty_id == counterparty_id
+        if active_only:
+            # Just the entries that add up to today's balance (empty when settled)
+            entries = await get_active_debt_entries(guild_id, user_id, counterparty_id)
+            if not entries:
+                await ctx.followup.send(
+                    f"No active debt with {player.display_name} — you're all settled up! 🎉"
                 )
-                .order_by(DebtLedger.created_at.desc())
-                .limit(50)
-            )
-            result = await session.execute(query)
-            entries = result.scalars().all()
+                return
+        else:
+            # Get ALL entries (not just since last settlement)
+            async with db_session() as session:
+                query = (
+                    select(DebtLedger)
+                    .where(
+                        DebtLedger.guild_id == guild_id,
+                        DebtLedger.player_id == user_id,
+                        DebtLedger.counterparty_id == counterparty_id
+                    )
+                    .order_by(DebtLedger.created_at.desc())
+                    .limit(50)
+                )
+                result = await session.execute(query)
+                entries = result.scalars().all()
 
         embed = discord.Embed(
-            title=f"Debt History with {player.display_name}",
+            title=(f"Active Debt with {player.display_name}" if active_only
+                   else f"Debt History with {player.display_name}"),
             color=discord.Color.purple()
         )
 

--- a/cogs/debt_commands.py
+++ b/cogs/debt_commands.py
@@ -206,14 +206,16 @@ class DebtCommands(commands.Cog):
             return
 
         if active_only:
-            # Just the entries that add up to today's balance (empty when settled)
+            title = f"Active Debt with {player.display_name}"
             entries = await get_active_debt_entries(guild_id, user_id, counterparty_id)
+            # No entries means the pair is settled up: say so rather than show an empty embed
             if not entries:
                 await ctx.followup.send(
                     f"No active debt with {player.display_name} — you're all settled up! 🎉"
                 )
                 return
         else:
+            title = f"Debt History with {player.display_name}"
             # Get ALL entries (not just since last settlement)
             async with db_session() as session:
                 query = (
@@ -230,8 +232,7 @@ class DebtCommands(commands.Cog):
                 entries = result.scalars().all()
 
         embed = discord.Embed(
-            title=(f"Active Debt with {player.display_name}" if active_only
-                   else f"Debt History with {player.display_name}"),
+            title=title,
             color=discord.Color.purple()
         )
 

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -5,7 +5,7 @@ import asyncio
 import uuid
 from datetime import datetime, timedelta
 from loguru import logger
-from sqlalchemy import select, func, or_
+from sqlalchemy import select, func, or_, tuple_
 from sqlalchemy.exc import OperationalError
 from database.db_session import db_session
 from models.debt_ledger import DebtLedger
@@ -984,7 +984,6 @@ async def get_debt_history(
             # A pair with outstanding debt shows a negative balance from exactly
             # one perspective; ledger rows exist from both, so admit both
             # orientations of every indebted pair.
-            from sqlalchemy import tuple_
             negative_rows = await _negative_pair_balances(guild_id)
             active_pairs = set()
             for row in negative_rows:

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -941,7 +941,8 @@ async def get_debt_history(
     guild_id: str,
     player_id: str = None,
     limit: int = 25,
-    older_than_days: int = None
+    older_than_days: int = None,
+    active_only: bool = False
 ) -> list[DebtLedger]:
     """
     Get history of all debt entries.
@@ -955,6 +956,8 @@ async def get_debt_history(
         player_id: Optional - filter to entries involving this player
         limit: Maximum number of entries to return (default 25, max 100)
         older_than_days: Optional - only return entries older than this many days
+        active_only: Optional - only return entries for pairs whose current
+            balance is nonzero (settled-to-zero relationships drop out)
 
     Returns:
         List of DebtLedger entries
@@ -977,6 +980,22 @@ async def get_debt_history(
                 )
             )
 
+        if active_only:
+            # A pair with outstanding debt shows a negative balance from exactly
+            # one perspective; ledger rows exist from both, so admit both
+            # orientations of every indebted pair.
+            from sqlalchemy import tuple_
+            negative_rows = await _negative_pair_balances(guild_id)
+            active_pairs = set()
+            for row in negative_rows:
+                active_pairs.add((row.player_id, row.counterparty_id))
+                active_pairs.add((row.counterparty_id, row.player_id))
+            if not active_pairs:
+                return []
+            query = query.where(
+                tuple_(DebtLedger.player_id, DebtLedger.counterparty_id).in_(active_pairs)
+            )
+
         if older_than_days is not None:
             cutoff = datetime.utcnow() - timedelta(days=older_than_days)
             query = query.where(DebtLedger.created_at < cutoff)
@@ -993,6 +1012,39 @@ async def get_debt_history(
         )
 
         return list(entries)
+
+
+async def get_active_debt_entries(
+    guild_id: str,
+    player_id: str,
+    counterparty_id: str
+) -> list[DebtLedger]:
+    """
+    Get the ledger entries that compose the player's CURRENT balance with a
+    counterparty: everything after the last moment the pair's running balance
+    touched zero. Returns [] when the current balance is zero (no active debt
+    in either direction). Newest first, matching the history displays.
+    """
+    async with db_session() as session:
+        query = (
+            select(DebtLedger)
+            .where(
+                DebtLedger.guild_id == guild_id,
+                DebtLedger.player_id == player_id,
+                DebtLedger.counterparty_id == counterparty_id,
+            )
+            .order_by(DebtLedger.created_at.asc(), DebtLedger.id.asc())
+        )
+        result = await session.execute(query)
+        entries = list(result.scalars().all())
+
+    running = 0
+    active_start = 0
+    for i, entry in enumerate(entries):
+        running += entry.amount
+        if running == 0:
+            active_start = i + 1
+    return list(reversed(entries[active_start:]))
 
 
 async def _negative_pair_balances(guild_id: str, player_ids=None, created_before=None):

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -1886,13 +1886,11 @@ class TestActiveDebtFilters:
     means composing the current nonzero balance — settled-to-zero relationships
     drop out entirely."""
 
-    _seq = 0
-
     async def _entry(self, guild, debtor, creditor, amount, source_type="draft"):
-        type(self)._seq += 1
         await create_ledger_entries(
             guild_id=guild, debtor_id=debtor, creditor_id=creditor,
-            amount=amount, source_type=source_type, source_id=f"active-{self._seq}",
+            amount=amount, source_type=source_type,
+            source_id=f"{source_type}-{debtor}-{creditor}-{amount}",
         )
 
     @pytest.mark.asyncio

--- a/tests/test_debt_service.py
+++ b/tests/test_debt_service.py
@@ -22,6 +22,7 @@ from services.debt_service import (
     adjust_debt,
     get_guild_debt_stats,
     get_debt_history,
+    get_active_debt_entries,
     get_total_owed_map,
     get_guild_debt_rows,
     get_owed_maps
@@ -1878,3 +1879,60 @@ class TestGetOwedMaps:
         await self._owe("g1", "alice", "bob", 150, source_id="old7")
         await self._backdate("old7")
         assert await get_owed_maps("g2", ["alice"], self._cutoff()) == ({}, {})
+
+
+class TestActiveDebtFilters:
+    """get_active_debt_entries + get_debt_history(active_only=True): 'active'
+    means composing the current nonzero balance — settled-to-zero relationships
+    drop out entirely."""
+
+    _seq = 0
+
+    async def _entry(self, guild, debtor, creditor, amount, source_type="draft"):
+        type(self)._seq += 1
+        await create_ledger_entries(
+            guild_id=guild, debtor_id=debtor, creditor_id=creditor,
+            amount=amount, source_type=source_type, source_id=f"active-{self._seq}",
+        )
+
+    @pytest.mark.asyncio
+    async def test_active_entries_empty_when_settled_to_zero(self, test_db):
+        await self._entry("g1", "alice", "bob", 30)
+        await self._entry("g1", "bob", "alice", 30, source_type="settlement")  # pays it off
+        assert await get_active_debt_entries("g1", "alice", "bob") == []
+
+    @pytest.mark.asyncio
+    async def test_active_entries_start_after_last_zero_balance(self, test_db):
+        await self._entry("g1", "alice", "bob", 30)                             # -30
+        await self._entry("g1", "bob", "alice", 30, source_type="settlement")   # 0: tab closed
+        await self._entry("g1", "alice", "bob", 40)                             # -40: new tab
+        await self._entry("g1", "bob", "alice", 15, source_type="settlement")   # -25: partial
+        entries = await get_active_debt_entries("g1", "alice", "bob")
+        assert [e.amount for e in entries] == [15, -40]      # newest first, only the open tab
+
+    @pytest.mark.asyncio
+    async def test_partial_settlement_does_not_close_the_tab(self, test_db):
+        await self._entry("g1", "alice", "bob", 30)
+        await self._entry("g1", "bob", "alice", 10, source_type="settlement")
+        await self._entry("g1", "alice", "bob", 20)
+        entries = await get_active_debt_entries("g1", "alice", "bob")
+        assert len(entries) == 3                             # balance never touched zero
+
+    @pytest.mark.asyncio
+    async def test_history_active_only_excludes_settled_pairs(self, test_db):
+        await self._entry("g1", "alice", "bob", 30)
+        await self._entry("g1", "bob", "alice", 30, source_type="settlement")   # settled pair
+        await self._entry("g1", "alice", "carol", 40)                           # active pair
+        entries = await get_debt_history("g1", active_only=True)
+        assert entries, "active pair's entries must be returned"
+        pairs = {(e.player_id, e.counterparty_id) for e in entries}
+        assert pairs == {("alice", "carol"), ("carol", "alice")}  # both orientations
+        # sanity: without the filter the settled pair is present
+        all_entries = await get_debt_history("g1")
+        assert any({e.player_id, e.counterparty_id} == {"alice", "bob"} for e in all_entries)
+
+    @pytest.mark.asyncio
+    async def test_history_active_only_empty_when_no_debt(self, test_db):
+        await self._entry("g1", "alice", "bob", 30)
+        await self._entry("g1", "bob", "alice", 30, source_type="settlement")
+        assert await get_debt_history("g1", active_only=True) == []


### PR DESCRIPTION
## What

Both debt history commands gain an `active_only` option (default off, so existing behavior is unchanged):

- **`/debts history @player active_only:true`** — shows only the entries that *compose the current outstanding balance*: everything after the last moment the pair's running balance touched zero. A settled-up pair gets "No active debt with X — you're all settled up! 🎉" instead of an empty embed. Title switches to "Active Debt with X".
- **`/debt_admin history active_only:true`** — restricts the ledger view to pairs whose current balance is nonzero (both perspectives of each indebted pair), composing with the existing `player`/`limit`/`older_than_days` filters. Title gains "(active debts only)".

## How

- New `get_active_debt_entries(guild, player, counterparty)` in `debt_service`: fetch the pair chronologically, track the running balance, return everything after its last zero-crossing (newest first). Zero balance → empty.
- `get_debt_history(..., active_only=True)`: computes the active pair set via the shared `_negative_pair_balances` helper (from #369) and filters in SQL with a tuple IN — no post-limit trimming.

## Testing

5 new tests: settled-to-zero → empty, active window starts after the last zero-crossing (partial settlements included in the open tab), partial settlement doesn't close the tab, guild-wide filter excludes settled pairs / keeps both orientations, empty guild case. Full suite: **858 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv