### PR TITLE
feat(debt): readable draft context with jump links in all debt panels

### DIFF
--- a/cogs/debt_admin_commands.py
+++ b/cogs/debt_admin_commands.py
@@ -310,6 +310,9 @@ class DebtAdminCommands(commands.Cog):
                 color=discord.Color.purple()
             )
 
+            from debt_views.helpers import describe_draft_sources
+            draft_labels = await describe_draft_sources(ctx.guild, entries)
+
             # Group entries by (source_id, debtor, creditor) to show each
             # debt pair separately — a single draft can produce multiple pairs.
             # We key on the sorted player pair so both sides collapse into one line.
@@ -345,7 +348,7 @@ class DebtAdminCommands(commands.Cog):
 
                 # Add source-specific info
                 if rep_entry.source_type == 'draft':
-                    source_info = f"Draft #{rep_entry.source_id}"
+                    source_info = draft_labels.get(rep_entry.source_id, f"Draft #{rep_entry.source_id}")
                 elif rep_entry.source_type == 'settlement':
                     source_info = "Settlement"
                     if rep_entry.created_by:

--- a/cogs/debt_commands.py
+++ b/cogs/debt_commands.py
@@ -26,7 +26,7 @@ from debt_views.settle_views import (
     AmountInputView,
     PublicSettleDebtsView
 )
-from debt_views.helpers import get_member_name, get_member_name_plain, format_entry_source, build_guild_debt_embed, build_guild_debt_embed_pages
+from debt_views.helpers import get_member_name, get_member_name_plain, format_entry_source, describe_draft_sources, build_guild_debt_embed, build_guild_debt_embed_pages
 from database.db_session import db_session
 from models.debt_ledger import DebtLedger
 from models.debt_summary_message import DebtSummaryMessage
@@ -161,9 +161,10 @@ class DebtCommands(commands.Cog):
 
         # Breakdown since last settlement
         if entries:
+            draft_labels = await describe_draft_sources(ctx.guild, entries)
             breakdown_lines = []
             for entry in entries[-15:]:  # Last 15 entries
-                source = format_entry_source(entry)
+                source = format_entry_source(entry, draft_labels)
                 date_str = entry.created_at.strftime("%b %d") if entry.created_at else ""
 
                 if entry.amount < 0:
@@ -237,10 +238,11 @@ class DebtCommands(commands.Cog):
         )
 
         if entries:
+            draft_labels = await describe_draft_sources(ctx.guild, entries)
             history_lines = []
             for entry in entries:
                 date_str = entry.created_at.strftime("%b %d") if entry.created_at else "?"
-                source = format_entry_source(entry)
+                source = format_entry_source(entry, draft_labels)
 
                 if entry.amount < 0:
                     history_lines.append(f"{date_str}: {source} - You owe {abs(entry.amount)} tix")
@@ -318,9 +320,10 @@ class DebtCommands(commands.Cog):
 
         # Show breakdown
         if entries:
+            draft_labels = await describe_draft_sources(ctx.guild, entries)
             breakdown_lines = []
             for entry in entries[-10:]:
-                source = format_entry_source(entry)
+                source = format_entry_source(entry, draft_labels)
 
                 if entry.amount < 0:
                     breakdown_lines.append(f"{source}: You owe {abs(entry.amount)} tix")

--- a/debt_views/helpers.py
+++ b/debt_views/helpers.py
@@ -6,7 +6,12 @@ across debt_commands.py and settle_views.py.
 """
 import discord
 import aiohttp
+from sqlalchemy import select
+
+from config import get_config
+from database.db_session import db_session
 from helpers.display_names import get_member_name, get_member_name_plain
+from models.draft_session import DraftSession
 
 # Network errors that are transient and should be logged but not re-raised
 TRANSIENT_ERRORS = (
@@ -16,17 +21,22 @@ TRANSIENT_ERRORS = (
 )
 
 
-def format_entry_source(entry) -> str:
+def format_entry_source(entry, draft_labels: dict | None = None) -> str:
     """
     Format a debt ledger entry's source for display.
 
     Args:
         entry: A DebtLedger model instance
+        draft_labels: Optional {session_id: label} from describe_draft_sources;
+            draft entries fall back to the raw "Draft #<session_id>" form when
+            no label is available.
 
     Returns:
-        Formatted string like "Draft #123" or "Settlement"
+        Formatted string like "[LSVCube · Jul 29](jump-url)" or "Settlement"
     """
     if entry.source_type == 'draft':
+        if draft_labels and entry.source_id in draft_labels:
+            return draft_labels[entry.source_id]
         return f"Draft #{entry.source_id}"
     elif entry.source_type == 'settlement':
         return "Settlement"
@@ -34,6 +44,55 @@ def format_entry_source(entry) -> str:
         return "Transfer"
     else:
         return entry.source_type.title()
+
+
+def _draft_label(cube, when, guild_id=None, channel_id=None, message_id=None) -> str:
+    """"[LSVCube · Jul 29](jump-url)" — or the same text unlinked when the
+    draft has no surviving victory message to jump to."""
+    text = cube or "Draft"
+    if when:
+        text += f" · {when.strftime('%b %d')}"
+    if guild_id and channel_id and message_id:
+        return f"[{text}](https://discord.com/channels/{guild_id}/{channel_id}/{message_id})"
+    return text
+
+
+async def describe_draft_sources(guild: discord.Guild, entries) -> dict[str, str]:
+    """
+    Readable labels for the draft entries among `entries`:
+    {session_id: "[<cube> · <date>](link)"}.
+
+    The link targets the draft's victory post in the guild's results channel —
+    the one draft message that survives channel cleanup (team/draft-chat
+    messages are deleted after a draft). Drafts without a victory message get
+    unlinked text; session ids with no surviving DraftSession row are omitted
+    so format_entry_source falls back to the legacy "Draft #id" form.
+    """
+    session_ids = {e.source_id for e in entries if e.source_type == "draft"}
+    if not session_ids:
+        return {}
+
+    async with db_session() as session:
+        rows = (await session.execute(
+            select(DraftSession).where(DraftSession.session_id.in_(session_ids))
+        )).scalars().all()
+
+    results_channel_name = get_config(guild.id).get("channels", {}).get("draft_results")
+    results_channel = (
+        discord.utils.get(guild.text_channels, name=results_channel_name)
+        if results_channel_name else None
+    )
+
+    return {
+        ds.session_id: _draft_label(
+            ds.cube,
+            ds.teams_start_time or ds.draft_start_time,
+            guild_id=guild.id,
+            channel_id=results_channel.id if results_channel else None,
+            message_id=ds.victory_message_id_results_channel,
+        )
+        for ds in rows
+    }
 
 
 def build_guild_debt_embed(guild: discord.Guild, rows: list, include_description: bool = True) -> discord.Embed:

--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -19,7 +19,7 @@ from services.debt_service import (
     create_debt_transfer
 )
 from notification_service import send_debt_transfer_dms, send_settlement_notification_dm
-from .helpers import TRANSIENT_ERRORS, get_member_name, get_member_name_plain, format_entry_source, build_user_balance_embed
+from .helpers import TRANSIENT_ERRORS, get_member_name, get_member_name_plain, format_entry_source, describe_draft_sources, build_user_balance_embed
 
 
 async def _build_settle_entry_view(
@@ -206,9 +206,10 @@ class CounterpartySelectView(View):
 
             # Show breakdown
             if entries:
+                draft_labels = await describe_draft_sources(self.guild, entries)
                 breakdown_lines = []
                 for entry in entries[-10:]:  # Last 10 entries
-                    source = format_entry_source(entry)
+                    source = format_entry_source(entry, draft_labels)
 
                     if entry.amount < 0:
                         breakdown_lines.append(f"{source}: You owe {abs(entry.amount)} tix")

--- a/tests/test_draft_source_labels.py
+++ b/tests/test_draft_source_labels.py
@@ -1,0 +1,112 @@
+"""Tests for readable draft context in debt panels: _draft_label /
+describe_draft_sources / format_entry_source's draft_labels parameter.
+
+The label replaces the unreadable "Draft #<64-char session id>" with
+"[<cube> · <date>](victory-message link)"; the link targets the results
+channel because it's the one draft message surviving channel cleanup.
+"""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from debt_views.helpers import _draft_label, describe_draft_sources, format_entry_source
+
+JUL29 = datetime(2026, 7, 29, 15, 18)
+
+
+# ---- _draft_label --------------------------------------------------------------------
+
+def test_label_linked_when_victory_message_exists():
+    assert _draft_label("LSVCube", JUL29, guild_id=1, channel_id=2, message_id=3) == \
+        "[LSVCube · Jul 29](https://discord.com/channels/1/2/3)"
+
+
+def test_label_unlinked_without_victory_message():
+    assert _draft_label("LSVCube", JUL29, guild_id=1, channel_id=2, message_id=None) == \
+        "LSVCube · Jul 29"
+
+
+def test_label_degrades_without_cube_or_date():
+    assert _draft_label(None, JUL29) == "Draft · Jul 29"
+    assert _draft_label("LSVCube", None) == "LSVCube"
+
+
+# ---- format_entry_source -------------------------------------------------------------
+
+def _draft_entry(source_id="sid1"):
+    return SimpleNamespace(source_type="draft", source_id=source_id)
+
+
+def test_format_uses_label_when_available():
+    assert format_entry_source(_draft_entry(), {"sid1": "[LSVCube · Jul 29](u)"}) == \
+        "[LSVCube · Jul 29](u)"
+
+
+def test_format_falls_back_to_legacy_form():
+    assert format_entry_source(_draft_entry("long-id")) == "Draft #long-id"
+    assert format_entry_source(_draft_entry("long-id"), {}) == "Draft #long-id"
+
+
+def test_format_non_draft_types_unchanged():
+    assert format_entry_source(SimpleNamespace(source_type="settlement", source_id="x")) == "Settlement"
+    assert format_entry_source(SimpleNamespace(source_type="transfer", source_id="x")) == "Transfer"
+
+
+# ---- describe_draft_sources ----------------------------------------------------------
+
+def _guild_with_results_channel(channel_id=777):
+    guild = MagicMock()
+    guild.id = 42
+    channel = MagicMock()
+    channel.id = channel_id
+    channel.name = "team-draft-results"
+    guild.text_channels = [channel]
+    return guild
+
+
+def _db_returning(sessions):
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = sessions
+    db = MagicMock()
+
+    async def execute(_q):
+        return result
+    db.execute = execute
+    ctx = MagicMock()
+
+    async def aenter(*a):
+        return db
+
+    async def aexit(*a):
+        return None
+    ctx.__aenter__ = aenter
+    ctx.__aexit__ = aexit
+    return MagicMock(return_value=ctx)
+
+
+@pytest.mark.asyncio
+async def test_labels_linked_and_unlinked_per_session():
+    sessions = [
+        SimpleNamespace(session_id="s1", cube="LSVCube", teams_start_time=JUL29,
+                        draft_start_time=None, victory_message_id_results_channel="999"),
+        SimpleNamespace(session_id="s2", cube="PowerLSV", teams_start_time=None,
+                        draft_start_time=JUL29, victory_message_id_results_channel=None),
+    ]
+    entries = [SimpleNamespace(source_type="draft", source_id="s1"),
+               SimpleNamespace(source_type="draft", source_id="s2"),
+               SimpleNamespace(source_type="settlement", source_id="x")]
+    with patch("debt_views.helpers.db_session", _db_returning(sessions)), \
+         patch("debt_views.helpers.get_config",
+               return_value={"channels": {"draft_results": "team-draft-results"}}):
+        labels = await describe_draft_sources(_guild_with_results_channel(), entries)
+    assert labels["s1"] == "[LSVCube · Jul 29](https://discord.com/channels/42/777/999)"
+    assert labels["s2"] == "PowerLSV · Jul 29"     # no victory message -> unlinked
+
+
+@pytest.mark.asyncio
+async def test_no_draft_entries_short_circuits():
+    entries = [SimpleNamespace(source_type="settlement", source_id="x")]
+    # db_session deliberately unpatched: reaching it would blow up the test
+    assert await describe_draft_sources(_guild_with_results_channel(), entries) == {}


### PR DESCRIPTION
## What

Stacked on #372. Draft entries in every debt panel currently render as `Draft #816653090345320488-1785506122`. They now render as:

```
[LSVCube · Jul 29](jump link): You owe 30 tix
```

The link jumps to the draft's **victory post in the results channel** — deliberately chosen because it's the one draft message that survives channel cleanup (team/draft-chat messages are deleted after each draft). Coverage:

- `/debts with` breakdown
- `/debts history` (incl. the new active_only view)
- `/debts summary`-adjacent third panel
- Settle-flow confirmation breakdown
- `/debt_admin history` (grouped view)

## Fallbacks

- Draft has no victory message → unlinked `LSVCube · Jul 29`
- Session row gone / unknown id → legacy `Draft #<id>` (no behavior cliff)
- Missing cube or date → degrade gracefully (`Draft · Jul 29` / `LSVCube`)

## How

New `describe_draft_sources(guild, entries)` batch-resolves one label map per panel render (single `IN` query + one config/channel lookup — no per-entry queries), and `format_entry_source` gains an optional `draft_labels` parameter with the old string as fallback. When #356 (friendly_id) merges, the label builder is the single place to teach about it.

## Testing

8 new tests: linked/unlinked/degraded labels, fallback semantics, batch resolution with mixed sessions, and a short-circuit guard proving settlement-only panels never touch the DB. Full suite: **866 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo9FeuRzrrMbaVZrdxKmv