### PR TITLE
Fix two skill-rating data bugs and heal player_stats

### DIFF
--- a/alembic/versions/skillheal0rpt_reheal_trueskill_real_snowflakes.py
+++ b/alembic/versions/skillheal0rpt_reheal_trueskill_real_snowflakes.py
@@ -1,0 +1,32 @@
+"""re-heal trueskill: rate real post-2021 snowflakes, undo re-report double counts
+
+The tskill0backfl backfill treated every id >= TEST_USER_ID_BASE (9e17) as a
+synthetic test user, but real Discord accounts created after ~late 2021 also
+live above 9e17 — their games were silently dropped (some players were wiped
+to zero). Separately, the live result path re-applied a full rating update on
+every re-selection of a result, double-counting games. _is_test_user is now
+bounded to the synthetic allocator band and the live path is guarded, so one
+fresh replay of the intact match_results ledger heals player_stats exactly.
+Data-only migration: no schema change. Downgrade is a no-op.
+
+Revision ID: skillheal0rpt
+Revises: trophreguess0
+Create Date: 2026-08-04
+"""
+from alembic import op
+
+from helpers.skill import backfill_skill_ratings
+
+revision = "skillheal0rpt"
+down_revision = "trophreguess0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    backfill_skill_ratings(op.get_bind())
+
+
+def downgrade():
+    # One-way data recompute; nothing to reverse.
+    pass

--- a/helpers/skill.py
+++ b/helpers/skill.py
@@ -5,8 +5,9 @@ the single environment (draw probability 0 — these matches never draw) plus th
 small pure helpers used by the live update path (utils.py), the session-type
 guard (views.py), the display slices, and the backfill migration. Keeping the
 environment and the backfill in one place guarantees live and historical values
-are computed identically. The backfill also skips TEST_MODE users; the live
-path does not, which only matters under TEST_MODE.
+are computed identically: both rate every 1v1 result in rated session types,
+with no player filtering (prod data contains no synthetic TEST_MODE users, and
+a divergence here once silently dropped thousands of real games).
 
 Only depends on ``trueskill`` and ``sqlalchemy`` so it is safe to import from an
 Alembic migration (no app-model imports).
@@ -16,7 +17,7 @@ from collections import defaultdict
 from sqlalchemy import text
 from trueskill import TrueSkill
 
-from helpers.test_users import TEST_USER_ID_BASE
+from helpers.test_users import TEST_USER_ID_BASE, TEST_USER_ID_CEILING
 
 # All library defaults except draw_probability: mu0=25, sigma0=25/3, beta=25/6,
 # tau=25/300. These match the player_stats column defaults.
@@ -34,15 +35,34 @@ ESTABLISHED_GAMES = 20
 
 
 def _is_test_user(player_id):
-    """True for synthetic TEST_MODE users. Non-numeric ids (legacy/imported) are
-    treated as real, never crashing the backfill."""
+    """True for synthetic TEST_MODE users: the sequential allocator band only.
+    Real post-2021 Discord snowflakes are also >= TEST_USER_ID_BASE and must
+    never match. Used solely for the TEST_MODE display floor
+    (utils._fetch_player_stats_map) — never to filter rating updates."""
     pid = str(player_id)
-    return pid.isdigit() and int(pid) >= TEST_USER_ID_BASE
+    return pid.isdigit() and TEST_USER_ID_BASE <= int(pid) < TEST_USER_ID_CEILING
 
 
 def rating_counts_for(session_type):
     """True iff a draft of this session type should update skill ratings."""
     return session_type in RATING_SESSION_TYPES
+
+
+def rating_update_action(previous_winner_id, new_winner_id):
+    """What the live path must do when a result is (re)submitted.
+
+    'apply'     — first real report: one incremental TrueSkill update.
+    'none'      — nothing rateable changed (no-play report, or a re-report
+                  keeping the same winner, e.g. a 2-0 -> 2-1 score fix).
+    'recompute' — the stored winner changed (flip or un-report): the old
+                  update is baked into player_stats and TrueSkill updates
+                  are order-dependent, so heal by replaying the ledger.
+    """
+    if previous_winner_id is None:
+        return "apply" if new_winner_id else "none"
+    if previous_winner_id == new_winner_id:
+        return "none"
+    return "recompute"
 
 
 # Display anchoring: a new player shows exactly RATING_ANCHOR; each TrueSkill
@@ -181,8 +201,8 @@ def backfill_skill_ratings(connection):
     """Recompute μ/σ and games-won/lost for every player from scratch.
 
     Resets all player_stats to the prior with zero rating-games, then replays all
-    random/staked/premade 1v1 results chronologically per guild (excluding test
-    users, self-matches, and rows whose winner is not one of the two players) and
+    random/staked/premade 1v1 results chronologically per guild (excluding
+    self-matches and rows whose winner is not one of the two players) and
     writes the final values back. Streaks, drafts_participated, and elo_rating are
     left untouched. Takes a SQLAlchemy Connection so it works from an Alembic
     migration (op.get_bind()) and from tests.
@@ -210,8 +230,6 @@ def backfill_skill_ratings(connection):
         if not player1_id or not player2_id or player1_id == player2_id:
             continue
         if winner_id not in (player1_id, player2_id):
-            continue
-        if _is_test_user(player1_id) or _is_test_user(player2_id):
             continue
         loser_id = player2_id if winner_id == player1_id else player1_id
         kw = (guild_id, winner_id)

--- a/helpers/test_users.py
+++ b/helpers/test_users.py
@@ -7,6 +7,12 @@ draft session's sign_ups names (see utils.generate_seating_order).
 
 TEST_USER_ID_BASE = 900000000000000000
 
+# Synthetic ids are allocated sequentially from the base (see next_id below),
+# so anything at or past this ceiling is a real Discord snowflake. Post-2021
+# accounts have ids >= 9e17 too — a bare ">= TEST_USER_ID_BASE" check
+# misclassifies them as test users.
+TEST_USER_ID_CEILING = TEST_USER_ID_BASE + 1000
+
 
 def plan_premade_test_users(team_a, team_b, team_a_name, team_b_name,
                             team_size=3, existing_ids=None):
@@ -26,6 +32,10 @@ def plan_premade_test_users(team_a, team_b, team_a_name, team_b_name,
         candidate = TEST_USER_ID_BASE
         while str(candidate) in taken:
             candidate += 1
+        if candidate >= TEST_USER_ID_CEILING:
+            # Enforce the band at the producer: everything at or past the
+            # ceiling is classified as a real account (helpers/skill.py).
+            raise RuntimeError("synthetic test-user id band exhausted")
         taken.add(str(candidate))
         return str(candidate)
 

--- a/tests/test_premade_test_users.py
+++ b/tests/test_premade_test_users.py
@@ -121,3 +121,17 @@ async def test_seating_order_excludes_team_ids_removed_from_sign_ups():
     ids = [uid for uid, _ in order]
     assert "999" not in ids                              # stale id not seated
     assert set(ids) <= set(draft_session.sign_ups)       # every seated id is in sign_ups
+
+
+def test_next_id_never_leaves_the_synthetic_band():
+    # _is_test_user classifies only [TEST_USER_ID_BASE, TEST_USER_ID_CEILING) as
+    # synthetic, so the allocator must refuse to mint ids past the ceiling —
+    # otherwise classification and allocation drift apart silently (the shape
+    # of the bug that once dropped real players' games).
+    from helpers.test_users import TEST_USER_ID_BASE, TEST_USER_ID_CEILING, plan_premade_test_users
+    full_band = {str(i) for i in range(TEST_USER_ID_BASE, TEST_USER_ID_CEILING)}
+    try:
+        plan_premade_test_users([], [], "A", "B", team_size=1, existing_ids=full_band)
+    except RuntimeError:
+        return
+    raise AssertionError("allocator minted an id outside the synthetic band")

--- a/tests/test_result_rereport.py
+++ b/tests/test_result_rereport.py
@@ -1,0 +1,106 @@
+"""Re-submitting a match result must not double-apply rating updates.
+
+apply_result_report is the live-path entry: first reports apply one
+incremental TrueSkill update; same-winner re-reports (score corrections,
+a teammate reporting again) do nothing; winner changes heal player_stats
+by replaying the match_results ledger from scratch.
+"""
+import os
+import tempfile
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from database.models_base import Base
+from database.db_session import AsyncSessionLocal
+from models.draft_session import DraftSession
+from models.player import PlayerStats
+from models.match import MatchResult
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose()
+    os.unlink(tmp.name)
+
+
+async def _seed_match(winner_id="1"):
+    async with AsyncSessionLocal() as session:
+        session.add(DraftSession(
+            session_id="s1", guild_id="g", session_type="staked"))
+        mr = MatchResult(
+            session_id="s1", match_number=1,
+            player1_id="1", player2_id="2",
+            player1_wins=2, player2_wins=0, winner_id=winner_id)
+        session.add(mr)
+        await session.commit()
+        return mr.id
+
+
+async def _stats(pid):
+    async with AsyncSessionLocal() as session:
+        return (await session.execute(
+            select(PlayerStats).where(
+                PlayerStats.player_id == pid, PlayerStats.guild_id == "g")
+        )).scalars().first()
+
+
+@pytest.mark.asyncio
+async def test_same_winner_rereport_does_not_double_count(test_db):
+    from utils import apply_result_report
+    match_id = await _seed_match(winner_id="1")
+
+    async with AsyncSessionLocal() as session:
+        mr = await session.get(MatchResult, match_id)
+    action, extensions = await apply_result_report(mr, previous_winner_id=None)
+    assert action == "apply" and extensions is not None
+
+    first = await _stats("1")
+    mu_after_first, games_after_first = first.true_skill_mu, first.games_won
+
+    # Score correction / duplicate report: same winner selected again.
+    async with AsyncSessionLocal() as session:
+        mr = await session.get(MatchResult, match_id)
+    action, extensions = await apply_result_report(mr, previous_winner_id="1")
+    assert action == "none" and extensions is None
+
+    again = await _stats("1")
+    assert again.games_won == games_after_first
+    assert again.true_skill_mu == mu_after_first
+
+
+@pytest.mark.asyncio
+async def test_winner_flip_recomputes_from_ledger(test_db):
+    from utils import apply_result_report
+    match_id = await _seed_match(winner_id="1")
+
+    async with AsyncSessionLocal() as session:
+        mr = await session.get(MatchResult, match_id)
+    await apply_result_report(mr, previous_winner_id=None)          # 1 beat 2
+
+    # Correction: player 2 actually won. Flip the stored row, then report.
+    async with AsyncSessionLocal() as session:
+        mr = await session.get(MatchResult, match_id)
+        mr.winner_id = "2"
+        mr.player1_wins, mr.player2_wins = 0, 2
+        await session.commit()
+    async with AsyncSessionLocal() as session:
+        mr = await session.get(MatchResult, match_id)
+    action, extensions = await apply_result_report(mr, previous_winner_id="1")
+    assert action == "recompute" and extensions is None
+
+    # Stats now reflect the ledger as if the wrong report never happened.
+    p1, p2 = await _stats("1"), await _stats("2")
+    assert (p1.games_won, p1.games_lost) == (0, 1)
+    assert (p2.games_won, p2.games_lost) == (1, 0)
+    assert p2.true_skill_mu > 25.0
+    assert p1.true_skill_mu < 25.0

--- a/tests/test_skill_helpers.py
+++ b/tests/test_skill_helpers.py
@@ -3,9 +3,11 @@ from helpers.skill import (
     PRIOR_MU,
     PRIOR_SIGMA,
     SKILL_ENV,
+    _is_test_user,
     is_established,
     new_ratings,
     rating_counts_for,
+    rating_update_action,
     skill_rating,
 )
 
@@ -55,6 +57,39 @@ def test_is_established_threshold():
     assert is_established(19) is False
     assert is_established(20) is True
     assert is_established(21) is True
+
+
+def test_is_test_user_flags_only_the_synthetic_allocator_band():
+    # Synthetic ids are allocated sequentially from TEST_USER_ID_BASE
+    # (helpers/test_users.py), so only a narrow band above the base is synthetic.
+    assert _is_test_user("900000000000000000") is True
+    assert _is_test_user("900000000000000005") is True
+    # Real Discord accounts created after ~late 2021 also have ids >= 9e17 and
+    # must never be treated as test users (their games were being dropped).
+    assert _is_test_user("903674293626470420") is False
+    assert _is_test_user("1306388347043971156") is False
+    # Pre-2021 accounts and legacy non-numeric ids are real.
+    assert _is_test_user("491700834850177024") is False
+    assert _is_test_user("legacy-user") is False
+
+
+def test_rating_update_action_first_report_applies():
+    assert rating_update_action(None, "1") == "apply"
+
+
+def test_rating_update_action_no_play_report_does_nothing():
+    assert rating_update_action(None, None) == "none"
+
+
+def test_rating_update_action_same_winner_rereport_does_nothing():
+    # Score-only corrections (2-0 -> 2-1) must not re-apply the rating update.
+    assert rating_update_action("1", "1") == "none"
+
+
+def test_rating_update_action_winner_change_recomputes():
+    assert rating_update_action("1", "2") == "recompute"
+    # Un-reporting (winner -> No Match Played) also invalidates the old update.
+    assert rating_update_action("1", None) == "recompute"
 
 
 def test_new_ratings_moves_winner_up_loser_down_and_shrinks_sigma():

--- a/tests/test_trueskill_backfill.py
+++ b/tests/test_trueskill_backfill.py
@@ -79,21 +79,55 @@ def test_reset_wipes_prior_values_for_unrated_players():
     assert (gw, gl) == (0, 0)
 
 
-def test_swiss_and_test_users_excluded():
+def test_swiss_excluded():
     conn = _conn()
     _add_player(conn, "1"); _add_player(conn, "2")
-    big = str(900000000000000000 + 5)
-    _add_player(conn, big)
     _add_session(conn, "sw", "swiss", "2026-01-01")
     _add_match(conn, 1, "sw", "1", "2", "1", "2026-01-01T10:00:00")   # swiss: ignored
-    _add_session(conn, "sp", "premade", "2026-01-02")
-    _add_match(conn, 2, "sp", "1", big, "1", "2026-01-02T10:00:00")   # test user: ignored
 
     backfill_skill_ratings(conn)
 
     # Player 1 played only ignored matches -> stays at the prior with 0 games.
     mu, sig, gw, gl = _rating(conn, "1")
     assert mu == PRIOR_MU and (gw, gl) == (0, 0)
+
+
+def test_backfill_rates_everyone_the_live_path_rates():
+    # The live path has never filtered test users, so the backfill must not
+    # either — a prod DB contains no synthetic ids (TEST_MODE never runs
+    # there), and in a TEST_MODE dev DB rating them is harmless. Any filter
+    # divergence between the two paths is how real games got dropped once.
+    conn = _conn()
+    _add_player(conn, "1")
+    synthetic = str(900000000000000000 + 5)
+    _add_session(conn, "sp", "premade", "2026-01-02")
+    _add_match(conn, 1, "sp", "1", synthetic, "1", "2026-01-02T10:00:00")
+
+    backfill_skill_ratings(conn)
+
+    mu, sig, gw, gl = _rating(conn, "1")
+    assert (gw, gl) == (1, 0)
+    assert mu > PRIOR_MU
+    assert _rating(conn, synthetic) is not None
+
+
+def test_real_post2021_snowflakes_are_rated_not_dropped():
+    conn = _conn()
+    _add_player(conn, "1")
+    # Discord snowflake from a 2024-created account: numerically above
+    # TEST_USER_ID_BASE but a real player whose games must count.
+    real_new_account = "1306388347043971156"
+    _add_session(conn, "sp", "premade", "2026-01-01")
+    _add_match(conn, 1, "sp", "1", real_new_account, "1", "2026-01-01T10:00:00")
+
+    backfill_skill_ratings(conn)
+
+    w = _rating(conn, "1")
+    assert (w[2], w[3]) == (1, 0)
+    l = _rating(conn, real_new_account)
+    assert l is not None
+    assert (l[2], l[3]) == (0, 1)
+    assert l[0] < PRIOR_MU
 
 
 def test_premade_player_without_row_gets_inserted():

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import random
 import discord
 import asyncio
 import pytz
-from sqlalchemy import update, select, func, or_, desc, and_
+from sqlalchemy import update, select, func, or_, desc, and_, create_engine
 from datetime import datetime, timedelta
 from session import AsyncSessionLocal, get_draft_session, StakeInfo, Challenge, PlayerLimit, DraftSession, MatchResult, PlayerStats, Match, Team, WeeklyLimit, StakePairing
 from sqlalchemy.orm import selectinload, joinedload
@@ -35,8 +35,10 @@ from helpers.skill import (
     PRIOR_MU,
     PRIOR_SIGMA,
     apply_upset_decoration,
+    backfill_skill_ratings,
     new_ratings,
     rating_counts_for,
+    rating_update_action,
     winner_probability_from_stats,
 )
 from services.ring_bearer_service import update_ring_bearer_for_guild
@@ -1970,6 +1972,55 @@ def _new_player_stats_row(player_id, guild_id):
         team_drafts_lost=0,
         team_drafts_tied=0,
     )
+
+
+async def recompute_skill_ratings():
+    """Heal player_stats by replaying the full match_results ledger.
+
+    Used when a reported winner is corrected: the wrong incremental update is
+    already baked into mu/sigma and TrueSkill updates are order-dependent, so
+    the only exact repair is a from-scratch replay. Streaks and
+    drafts_participated are left untouched (same contract as the backfill).
+
+    The replay is tens of thousands of pure-CPU TrueSkill updates, so it runs
+    in a worker thread on its own short-lived sync connection (to the same
+    database AsyncSessionLocal is bound to) instead of stalling the event loop.
+    """
+    url = AsyncSessionLocal.kw["bind"].url.render_as_string(
+        hide_password=False).replace("+aiosqlite", "")
+
+    def _replay():
+        engine = create_engine(url)
+        try:
+            with engine.begin() as conn:
+                backfill_skill_ratings(conn)
+        finally:
+            engine.dispose()
+
+    await asyncio.to_thread(_replay)
+
+
+async def apply_result_report(match_result, previous_winner_id):
+    """Live-path rating bookkeeping for a submitted or re-submitted result.
+
+    previous_winner_id must be the row's winner as it was BEFORE this report
+    was written — capture it before mutating the row, or a first report is
+    indistinguishable from a duplicate. Only the first report of a winner
+    applies an incremental update; re-selecting a result (score corrections,
+    a teammate reporting the same match) must not double-count; a winner
+    change heals by replaying the ledger.
+
+    Returns (action, streak_extensions): the rating_update_action taken, and
+    streak extensions when an incremental update ran (else None). Callers
+    should gate first-report-only side effects (streak storage, ring-bearer
+    transfer) on action == "apply".
+    """
+    action = rating_update_action(previous_winner_id, match_result.winner_id)
+    if action == "apply":
+        return action, await update_player_stats_and_elo(match_result)
+    if action == "recompute":
+        await recompute_skill_ratings()
+    return action, None
 
 
 async def update_player_stats_and_elo(match_result):

--- a/views.py
+++ b/views.py
@@ -28,7 +28,7 @@ from utils import (
     split_content_for_embed,
     update_draft_summary_message,
     check_and_post_victory_or_draw,
-    update_player_stats_and_elo,
+    apply_result_report,
     check_weekly_limits,
     update_player_stats_for_draft,
     add_links_to_embed_safely,
@@ -1793,9 +1793,10 @@ class MatchResultSelect(Select):
 
                     if match_result:
                         # Update the match result based on the selection
+                        previous_winner_id = match_result.winner_id
                         match_result.player1_wins = player1_wins
                         match_result.player2_wins = player2_wins
-                        if winner_indicator != '0':  
+                        if winner_indicator != '0':
                             winner_id = match_result.player1_id if winner_indicator == '1' else match_result.player2_id
                         match_result.winner_id = winner_id
                         match_result.result_submitted_at = datetime.now()
@@ -1804,28 +1805,32 @@ class MatchResultSelect(Select):
 
                         from helpers.skill import rating_counts_for
                         if draft_session and rating_counts_for(draft_session.session_type):
-                            streak_extensions = await update_player_stats_and_elo(match_result)
+                            # Only a first report applies an incremental rating
+                            # update; re-reports must not double-count and a
+                            # winner correction replays the ledger instead.
+                            action, streak_extensions = await apply_result_report(match_result, previous_winner_id)
 
-                            # Store streak extension info for ring bearer check later
-                            from utils import store_match_streak_extensions
-                            store_match_streak_extensions(
-                                self.session_id,
-                                match_result.player1_id,
-                                match_result.player2_id,
-                                streak_extensions
-                            )
-
-                            # Check for ring bearer transfer if there was a winner
-                            if winner_id:
-                                loser_id = match_result.player2_id if winner_id == match_result.player1_id else match_result.player1_id
-                                from services.ring_bearer_service import check_match_defeat_transfer
-                                await check_match_defeat_transfer(
-                                    bot=self.bot,
-                                    guild_id=str(draft_session.guild_id),
-                                    winner_id=winner_id,
-                                    loser_id=loser_id,
-                                    session_id=self.session_id
+                            if action == "apply":
+                                # Store streak extension info for ring bearer check later
+                                from utils import store_match_streak_extensions
+                                store_match_streak_extensions(
+                                    self.session_id,
+                                    match_result.player1_id,
+                                    match_result.player2_id,
+                                    streak_extensions
                                 )
+
+                                # Check for ring bearer transfer if there was a winner
+                                if winner_id:
+                                    loser_id = match_result.player2_id if winner_id == match_result.player1_id else match_result.player1_id
+                                    from services.ring_bearer_service import check_match_defeat_transfer
+                                    await check_match_defeat_transfer(
+                                        bot=self.bot,
+                                        guild_id=str(draft_session.guild_id),
+                                        winner_id=winner_id,
+                                        loser_id=loser_id,
+                                        session_id=self.session_id
+                                    )
             
             if draft_session:
                 await update_draft_summary_message(self.bot, self.session_id)


### PR DESCRIPTION
## Summary

Two long-standing bugs corrupted `player_stats` in opposite directions. `match_results` is intact (verified against every backup back to July 2025 — append-only, zero deletions), so a corrected replay heals everything exactly.

**Bug 1 — backfill dropped real players' games.** `backfill_skill_ratings` filtered out every id ≥ 9e17 as a synthetic test user, but real Discord accounts created after ~late 2021 also live above 9e17. The July backfill silently dropped **3,447 real matches**, wiping some players to zero (e.g. 931 real games → 57 stored). Prod contains no synthetic users at all (TEST_MODE never runs there), so the filter's only lifetime effect was destroying real data. It is **removed**: the backfill now rates exactly what the live path rates. `_is_test_user` survives only for the TEST_MODE display floor, bounded to the synthetic allocator band (`TEST_USER_ID_CEILING`), and `next_id()` now enforces the band at the producer.

**Bug 2 — every result re-selection double-counted.** The result dropdown re-applied a full TrueSkill update on every selection, so score corrections and duplicate reports double-counted games (one player gained 23 stored games from 13 real matches in two days; ~5.6% of one veteran's stored games were phantoms). The live path now routes through `rating_update_action` (pure, tested): first report → one incremental update; same-winner re-report → no-op; winner correction → exact heal by replaying the ledger (`recompute_skill_ratings`, run in a worker thread off the event loop). Streak and ring-bearer side effects are gated the same way — they were double-firing too.

**Healing:** the `skillheal0rpt` migration re-runs the fixed backfill on deploy.

## Verification

- TDD throughout; every new test watched failing first. Full suite: 873 passed.
- On a fresh prod copy after migration: all 937 `player_stats` rows exactly equal an independent clean replay of the ledger (zero mismatches).
- Known limitation (pre-existing): winner corrections heal ratings but not streak columns — the backfill has never managed streaks, and observed flip frequency is ~zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)