### PR TITLE
Hotfix: linearize alembic heads (friendly_id vs skillheal0rpt)

### DIFF
--- a/alembic/versions/skillheal0rpt_reheal_trueskill_real_snowflakes.py
+++ b/alembic/versions/skillheal0rpt_reheal_trueskill_real_snowflakes.py
@@ -10,7 +10,7 @@ fresh replay of the intact match_results ledger heals player_stats exactly.
 Data-only migration: no schema change. Downgrade is a no-op.
 
 Revision ID: skillheal0rpt
-Revises: trophreguess0
+Revises: cc4fcb545e83
 Create Date: 2026-08-04
 """
 from alembic import op
@@ -18,7 +18,7 @@ from alembic import op
 from helpers.skill import backfill_skill_ratings
 
 revision = "skillheal0rpt"
-down_revision = "trophreguess0"
+down_revision = "cc4fcb545e83"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Prod is crash-looping on startup: `cc4fcb545e83` (add friendly_id, merged July 29 but never deployed — prod was still stamped `trophreguess0`) and `skillheal0rpt` (#376) both revise `trophreguess0`. Tonight's deploy delivered both fork branches at once, so `alembic upgrade head` fails with "Multiple head revisions" before applying anything — the database is untouched.

One-line fix: `skillheal0rpt` now revises `cc4fcb545e83`, restoring a linear chain. Verified on a fresh prod copy — the full sequence runs end to end (`friendly_id` → heal → guarded legacy import) and the imported state matches all prior verification (10,517 legacy matches, per-player counts equal the unified ledger).

Merge, then on the droplet: `git pull && sudo systemctl restart draftbot.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)