### PR TITLE
fix(trophy-quiz): edit the ephemeral flow in place to stop double submits

### DIFF
--- a/quiz_views_module/trophy_quiz_views.py
+++ b/quiz_views_module/trophy_quiz_views.py
@@ -51,6 +51,17 @@ def _build_pilots_line(decks: list) -> str:
     return f"🔎 Piloted by — {names}"
 
 
+def _build_guess_line(decks: list, guesses: list) -> str:
+    """Restate the player's locked guess. Needed because the flow edits the
+    original guess prompt away (#355), so without this line the player can no
+    longer see what they picked when deciding to keep or change."""
+    parts = ", ".join(
+        f"Deck {deck['slot']}: **{record_label(guess)}**"
+        for deck, guess in zip(decks, guesses)
+    )
+    return f"📝 Your guess — {parts}"
+
+
 def _build_emoji_line(result) -> str:
     """Leak-safe per-deck emoji: 🟩 only when BOTH the overall direction call and
     that deck's exact record were correct, else ⬛. Never reveals which deck or
@@ -256,28 +267,37 @@ async def _finalize(quiz_id: str, user_id: str, final_guesses: list, changed: bo
     return True
 
 
-async def _send_final_reveal(interaction, quiz_id: str, decks: list, guesses: list, changed: bool, prefix: str = ""):
-    """Send the full ephemeral result (records + score + optional −2 line) plus a
+async def _respond(interaction, content: str, view, edit: bool):
+    """Deliver a step of the ephemeral quiz flow. edit=True replaces the message
+    the clicked component lives on (in-place transition — the previous prompt and
+    its buttons disappear, so a stale Submit can't be pressed again, #355);
+    edit=False sends a new ephemeral message (used from the public quiz message,
+    which must never be edited into per-user state)."""
+    if edit:
+        await interaction.response.edit_message(content=content, view=view)
+    else:
+        await interaction.response.send_message(content, view=view, ephemeral=True)
+
+
+async def _send_final_reveal(interaction, quiz_id: str, decks: list, guesses: list, changed: bool, prefix: str = "", edit: bool = False):
+    """Show the full ephemeral result (records + score + optional −2 line) plus a
     Share button, for a finalized submission."""
     result = score_submission(guesses, [deck["wins"] for deck in decks])
     lines = build_reveal_lines(decks, guesses, result, changed=changed)
     emoji_line = _build_emoji_line(result)
     display_id = await _load_display_id(quiz_id)
     total = apply_change_cost(result["total"], changed)
-    await interaction.response.send_message(
-        prefix + "\n".join(lines),
-        ephemeral=True,
-        view=TrophyShareView(
-            user=interaction.user,
-            emoji_line=emoji_line,
-            total_points=total,
-            quiz_id=quiz_id,
-            display_id=display_id,
-        ),
+    view = TrophyShareView(
+        user=interaction.user,
+        emoji_line=emoji_line,
+        total_points=total,
+        quiz_id=quiz_id,
+        display_id=display_id,
     )
+    await _respond(interaction, prefix + "\n".join(lines), view, edit)
 
 
-async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub) -> bool:
+async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub, edit: bool = False) -> bool:
     """If `sub` is a finalized submission, show its committed result (with the
     "already submitted" prefix) and return True so the caller stops. Returns
     False when there's nothing to show (no submission, or still pending)."""
@@ -285,24 +305,21 @@ async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub) -> b
         return False
     await _send_final_reveal(
         interaction, quiz_id, decks, sub.guesses, sub.changed_answer,
-        prefix="*(You already submitted this quiz)*\n",
+        prefix="*(You already submitted this quiz)*\n", edit=edit,
     )
     return True
 
 
-async def _reveal_names_and_decide(interaction, quiz_id: str, decks: list, user, initial_guesses: list):
+async def _reveal_names_and_decide(interaction, quiz_id: str, decks: list, user, initial_guesses: list, edit: bool = False):
     """Reveal ONLY the pilots' names (not records/score) and present the
     Keep / Pay-2-to-change choice on the player's locked initial guess."""
     content = (
         f"{_build_pilots_line(decks)}\n"
+        f"{_build_guess_line(decks, initial_guesses)}\n"
         f"Now that you know who piloted each deck, keep your answer or pay "
         f"**{CHANGE_COST} points** to change it."
     )
-    await interaction.response.send_message(
-        content,
-        view=TrophyDecideView(quiz_id, decks, user, initial_guesses),
-        ephemeral=True,
-    )
+    await _respond(interaction, content, TrophyDecideView(quiz_id, decks, user, initial_guesses), edit)
 
 
 class TrophyQuizView(discord.ui.View):
@@ -391,7 +408,11 @@ class TrophyGuessView(discord.ui.View):
 
     initial_guesses=None -> INITIAL mode: Submit persists the pending row and
     reveals names. initial_guesses set -> CHANGE mode: Submit finalizes with the
-    revised guess, charging CHANGE_COST iff it differs from the initial."""
+    revised guess, charging CHANGE_COST iff it differs from the initial.
+
+    Submit EDITS this view's own message into the next step (then stops the
+    view), so the whole flow lives in one ephemeral message and a lingering
+    Submit prompt can't be pressed again after the reveal (#355)."""
 
     def __init__(self, quiz_id: str, decks: list, user, initial_guesses: list = None):
         super().__init__(timeout=300)
@@ -432,23 +453,27 @@ class TrophyGuessView(discord.ui.View):
                 return
             guesses = [self.selections[slot] for slot in slots]
 
+            # Every response below edits THIS message into the next step of the
+            # flow (edit=True), so the Submit prompt is consumed by its first
+            # click — pressing Submit again can't spawn duplicate prompts (#355).
             if self.initial_guesses is None:
                 # INITIAL submit: persist pending + reveal names + decide.
                 created = await _persist_pending(
                     self.quiz_id, user_id, get_display_name(interaction.user), guesses)
                 if not created:
-                    # A submission already exists (concurrent double-submit or a
-                    # resume). Route to the right state rather than duplicate.
+                    # A submission already exists (a double-submit from a second
+                    # Play prompt, or a resume). Route to the right state — on the
+                    # LOCKED stored guess — rather than duplicate.
                     sub = await _get_submission(self.quiz_id, user_id)
-                    if await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub):
-                        return
-                    initial = sub.guesses if sub is not None else guesses
-                    await _reveal_names_and_decide(
-                        interaction, self.quiz_id, self.decks, interaction.user, initial)
+                    if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub, edit=True):
+                        initial = sub.guesses if sub is not None else guesses
+                        await _reveal_names_and_decide(
+                            interaction, self.quiz_id, self.decks, interaction.user, initial, edit=True)
+                    self.stop()
                     return
                 logger.info(f"User {user_id} made an initial trophy guess on {self.quiz_id}")
                 await _reveal_names_and_decide(
-                    interaction, self.quiz_id, self.decks, interaction.user, guesses)
+                    interaction, self.quiz_id, self.decks, interaction.user, guesses, edit=True)
             else:
                 # CHANGE submit: finalize with the revised guess (charge iff changed).
                 changed = guesses != self.initial_guesses
@@ -461,17 +486,21 @@ class TrophyGuessView(discord.ui.View):
                     final_changed = sub.changed_answer if sub is not None else changed
                     await _send_final_reveal(
                         interaction, self.quiz_id, self.decks, final_guesses,
-                        final_changed, prefix="*(You already submitted this quiz)*\n")
+                        final_changed, prefix="*(You already submitted this quiz)*\n", edit=True)
+                    self.stop()
                     return
                 logger.info(
                     f"User {user_id} finalized trophy quiz {self.quiz_id} via change "
                     f"(changed={changed})")
-                await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed)
+                await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, edit=True)
+            self.stop()
 
 
 class TrophyDecideView(discord.ui.View):
     """Ephemeral Keep / Pay-2-to-change choice shown after names are revealed.
-    Operates on the player's locked initial guess (persisted as a pending row)."""
+    Operates on the player's locked initial guess (persisted as a pending row).
+    Both buttons edit this message into the next step (result / revise view),
+    so the choice can't be double-clicked into duplicate prompts (#355)."""
 
     def __init__(self, quiz_id: str, decks: list, user, initial_guesses: list):
         super().__init__(timeout=300)
@@ -494,7 +523,9 @@ class TrophyDecideView(discord.ui.View):
             sub = await _get_submission(self.quiz_id, user_id)
             guesses = sub.guesses if sub is not None else self.initial_guesses
             changed = sub.changed_answer if sub is not None else False
-            await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, prefix=prefix)
+            # Edit this prompt into the result so Keep/Change can't be re-clicked (#355).
+            await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, prefix=prefix, edit=True)
+            self.stop()
 
     @discord.ui.button(
         label=f"🔎 Pay {CHANGE_COST} to change",
@@ -505,11 +536,16 @@ class TrophyDecideView(discord.ui.View):
         async with self._lock:
             user_id = str(interaction.user.id)
             sub = await _get_submission(self.quiz_id, user_id)
-            if await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub):
-                return
-            await interaction.response.send_message(
-                f"Revise your records, then **Submit** (−{CHANGE_COST} points if you change anything):",
-                view=TrophyGuessView(self.quiz_id, self.decks, interaction.user,
-                                     initial_guesses=self.initial_guesses),
-                ephemeral=True,
-            )
+            if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub, edit=True):
+                # Edit this prompt into the revise view (pilots line kept visible,
+                # since editing replaces the message that showed it).
+                await interaction.response.edit_message(
+                    content=(
+                        f"{_build_pilots_line(self.decks)}\n"
+                        f"{_build_guess_line(self.decks, self.initial_guesses)}\n"
+                        f"Revise your records, then **Submit** (−{CHANGE_COST} points if you change anything):"
+                    ),
+                    view=TrophyGuessView(self.quiz_id, self.decks, interaction.user,
+                                         initial_guesses=self.initial_guesses),
+                )
+            self.stop()

--- a/tests/test_trophy_quiz_views.py
+++ b/tests/test_trophy_quiz_views.py
@@ -42,13 +42,14 @@ _DECKS = [
 
 class _FakeResponse:
     def __init__(self):
-        self.sent = []
+        self.sent = []      # new ephemeral messages (from the public quiz message)
+        self.edited = []    # in-place edits of the flow's own ephemeral message
 
     async def send_message(self, content=None, **kwargs):
         self.sent.append((content, kwargs))
 
     async def edit_message(self, **kwargs):
-        pass
+        self.edited.append(kwargs)
 
 
 def _interaction(user):
@@ -146,12 +147,16 @@ async def test_initial_submit_persists_pending_and_reveals_names_only(test_db):
     sub = await _submission("q1", "1")
     assert sub is not None and sub.finalized is False        # pending
     assert sub.guesses == [3, 0] and sub.points_earned == 0
-    # names revealed, but NOT records/score
-    content = interaction.response.sent[-1][0]
+    # names revealed IN PLACE — the guess prompt is edited, no new message (#355)
+    assert interaction.response.sent == []
+    edited = interaction.response.edited[-1]
+    content = edited["content"]
     assert "<@u1>" in content and "<@u2>" in content
     assert "went" not in content and "pts" not in content
+    # the locked guess is restated (the prompt that showed it was edited away)
+    assert "Your guess" in content and "3-0" in content and "0-3" in content
     # a Decide view is offered
-    assert isinstance(interaction.response.sent[-1][1].get("view"), TrophyDecideView)
+    assert isinstance(edited.get("view"), TrophyDecideView)
     # participants not incremented yet
     async with AsyncSessionLocal() as s:
         qs = await s.get(TrophyQuizSession, "q1")
@@ -289,6 +294,84 @@ async def test_finalize_idempotent_across_separate_views(test_db):
     assert qs.total_participants == 1                        # atomic finalize → once
     sub = await _submission("q1", "1")
     assert sub.finalized is True and sub.points_earned == 10
+
+
+# ---- single-message flow (no double prompts, #355) -------------------------
+
+@pytest.mark.asyncio
+async def test_second_submit_from_stale_prompt_resumes_locked_guess(test_db):
+    """#355: with two guess prompts open (Play clicked twice), the second Submit
+    must not spawn a duplicate flow — it edits into the Keep/Change step on the
+    FIRST submit's locked guess and never sends an extra message."""
+    await _seed_session()
+    user = SimpleNamespace(id=1, display_name="Alice", name="a")
+    gv1 = TrophyGuessView("q1", _DECKS, user)
+    gv1.selections = {"A": 3, "B": 0}
+    await gv1.submit_button.callback(_interaction(user))
+
+    gv2 = TrophyGuessView("q1", _DECKS, user)   # a second, stale prompt
+    gv2.selections = {"A": 0, "B": 3}           # different picks — must not count
+    interaction = _interaction(user)
+    await gv2.submit_button.callback(interaction)
+
+    assert interaction.response.sent == []       # no duplicate prompt
+    view = interaction.response.edited[-1]["view"]
+    assert isinstance(view, TrophyDecideView)
+    assert view.initial_guesses == [3, 0]        # locked to the first submit
+    sub = await _submission("q1", "1")
+    assert sub.guesses == [3, 0] and sub.finalized is False
+
+
+@pytest.mark.asyncio
+async def test_flow_edits_one_message_through_change_path(test_db):
+    """#355: submit → decide → pay-to-change → submit all EDIT the one ephemeral
+    message; each replaced view is stopped so its prompt can't fire again."""
+    await _seed_session()
+    user = SimpleNamespace(id=1, display_name="Alice", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    gv.selections = {"A": 0, "B": 3}
+    i1 = _interaction(user)
+    await gv.submit_button.callback(i1)
+    assert i1.response.sent == []
+    decide = i1.response.edited[-1]["view"]
+    assert isinstance(decide, TrophyDecideView)
+    assert gv.is_finished()                      # consumed prompt is dead
+
+    i2 = _interaction(user)
+    await decide.change_button.callback(i2)
+    assert i2.response.sent == []
+    change_view = i2.response.edited[-1]["view"]
+    assert isinstance(change_view, TrophyGuessView)
+    revise_content = i2.response.edited[-1]["content"]
+    assert "<@u1>" in revise_content                      # pilots stay visible
+    assert "Your guess" in revise_content and "0-3" in revise_content  # initial guess restated
+    assert decide.is_finished()
+
+    change_view.selections = {"A": 3, "B": 0}
+    i3 = _interaction(user)
+    await change_view.submit_button.callback(i3)
+    assert i3.response.sent == []
+    assert isinstance(i3.response.edited[-1]["view"], TrophyShareView)
+    assert "pts" in i3.response.edited[-1]["content"]
+    assert change_view.is_finished()
+
+
+@pytest.mark.asyncio
+async def test_keep_edits_decide_prompt_into_result(test_db):
+    await _seed_session()
+    user = SimpleNamespace(id=1, display_name="Alice", name="a")
+    gv = TrophyGuessView("q1", _DECKS, user)
+    gv.selections = {"A": 3, "B": 0}
+    await gv.submit_button.callback(_interaction(user))
+
+    decide = TrophyDecideView("q1", _DECKS, user, [3, 0])
+    interaction = _interaction(user)
+    await decide.keep_button.callback(interaction)
+    assert interaction.response.sent == []
+    edited = interaction.response.edited[-1]
+    assert isinstance(edited["view"], TrophyShareView)
+    assert "pts" in edited["content"]
+    assert decide.is_finished()
 
 
 # ---- share (leak-safe, thread-routed) --------------------------------------


### PR DESCRIPTION
Fixes #355.

## Problem

After the initial Submit, the guess prompt (dropdowns + Submit) stayed alive while the "who piloted / keep or change" step arrived as a *new* ephemeral message. Pressing the stale Submit again spawned duplicate Keep/Change prompts and generally weird state. (The data layer was already race-safe — pending row + atomic finalize — this was purely the UI stacking messages.)

## Fix

Every step of the per-player flow now **edits its one ephemeral message in place** and stops the replaced view:

- guess prompt → *(Submit)* → pilots revealed + Keep / Pay-2-to-change
- → *(Pay 2)* → revise dropdowns (pre-filled)
- → *(Submit / Keep)* → final result + Share button

The consumed prompt disappears with its buttons, so it can't be re-pressed. A stale prompt from clicking Play twice still routes safely to the locked stored guess. The public quiz message is never edited — it always answers with a fresh ephemeral.

Since editing removes the message that displayed the player's picks, the Keep/Change and revise prompts now restate them: `📝 Your guess — Deck A: **3-0**, Deck B: **0-3**`.

## Testing

- New regression tests: stale-prompt resubmit routes to the locked guess with no extra message; the full submit→decide→change→submit chain edits one message with each replaced view stopped; Keep consumes its prompt.
- Full suite passes (907 passed, 10 skipped).
- Manually clicked through in a test guild (including the double-Play / stale-Submit repro).


https://github.com/user-attachments/assets/29301c7b-12e4-4efc-b618-29e6fabdf70d


🤖 Generated with [Claude Code](https://claude.com/claude-code)