### PR TITLE
feat(stats): show lifetime quiz stats in /stats

### DIFF
--- a/player_stats.py
+++ b/player_stats.py
@@ -613,6 +613,29 @@ async def create_stats_embed(user, stats_weekly, stats_monthly, stats_lifetime):
         value += "\n*New players start at 1500 · a 100-point gap ≈ 60% match favorite*"
         embed.add_field(name="🎯 Skill Rating", value=value, inline=False)
 
+    # 🧠 Quiz stats (injected by stats_display.get_stats_embed_for_player);
+    # omitted entirely for players who haven't played either quiz.
+    # "directionally right" = called which of the two decks did better.
+    pick_quiz = stats_lifetime.get('pick_quiz_stats')
+    trophy_quiz = stats_lifetime.get('trophy_quiz_stats')
+    if pick_quiz or trophy_quiz:
+        quiz_lines = []
+        if pick_quiz:
+            quiz_lines.append(
+                f"**Pick Quiz** ({pick_quiz['played']} played): "
+                f"{pick_quiz['points']} pts • "
+                f"{pick_quiz['accuracy']:.0f}% of picks guessed right • "
+                f"best quiz {pick_quiz['best']} pts"
+            )
+        if trophy_quiz:
+            direction_pct = trophy_quiz['direction_correct'] / trophy_quiz['played'] * 100
+            quiz_lines.append(
+                f"**Trophy Quiz** ({trophy_quiz['played']} played): "
+                f"{trophy_quiz['points']} pts • "
+                f"directionally right {direction_pct:.0f}%"
+            )
+        embed.add_field(name="🧠 Quiz Stats (lifetime)", value="\n".join(quiz_lines), inline=False)
+
     # Add cube-specific stats if any are available
     if stats_lifetime['cube_stats']:
         # Convert to list and sort by drafts_played in descending order

--- a/player_stats.py
+++ b/player_stats.py
@@ -303,7 +303,7 @@ async def create_stats_embed(user, stats_weekly, stats_monthly, stats_lifetime):
         value += "\n*New players start at 1500 · a 100-point gap ≈ 60% match favorite*"
         embed.add_field(name="🎯 Skill Rating", value=value, inline=False)
 
-# 🧠 Quiz stats (injected by stats_display.get_stats_embed_for_player);
+    # 🧠 Quiz stats (injected by stats_display.get_stats_embed_for_player);
     # omitted entirely for players who haven't played either quiz.
     # "directionally right" = called which of the two decks did better.
     pick_quiz = stats_lifetime.get('pick_quiz_stats')
@@ -318,11 +318,10 @@ async def create_stats_embed(user, stats_weekly, stats_monthly, stats_lifetime):
                 f"best quiz {pick_quiz['best']} pts"
             )
         if trophy_quiz:
-            direction_pct = trophy_quiz['direction_correct'] / trophy_quiz['played'] * 100
             quiz_lines.append(
                 f"**Trophy Quiz** ({trophy_quiz['played']} played): "
                 f"{trophy_quiz['points']} pts • "
-                f"directionally right {direction_pct:.0f}%"
+                f"directionally right {trophy_quiz['direction_pct']:.0f}%"
             )
         embed.add_field(name="🧠 Quiz Stats (lifetime)", value="\n".join(quiz_lines), inline=False)
 

--- a/stats_display.py
+++ b/stats_display.py
@@ -5,8 +5,9 @@ This module formats player_stats data into Discord displays. It sits at the top 
 """
 import discord
 from player_stats import create_stats_embed, get_player_statistics
-from sqlalchemy import select
+from sqlalchemy import Integer, cast, func, select
 from database.db_session import AsyncSessionLocal
+from models import QuizStats, TrophyQuizSession, TrophyQuizSubmission
 from models.player import PlayerStats
 from helpers.skill import is_established, skill_rating
 
@@ -33,6 +34,54 @@ async def _player_skill_rating(player_id, guild_id):
     mu, sigma, games_won, games_lost = row
     games = (games_won or 0) + (games_lost or 0)
     return skill_rating(mu, sigma, games), not is_established(games)
+
+
+async def _player_quiz_stats(player_id, guild_id):
+    """Lifetime quiz stats for one player, as (pick_quiz, trophy_quiz) dicts —
+    either is None when the player hasn't played that quiz type.
+
+    Pick quiz reads the already-aggregated QuizStats row. Trophy quiz has no
+    aggregate table, so finalized submissions are summed here, guild-scoped via
+    the quiz session (submissions don't carry guild_id) — the same shape the
+    trophy quiz leaderboard aggregates."""
+    async with AsyncSessionLocal() as session:
+        row = await session.get(QuizStats, (str(player_id), str(guild_id)))
+        result = await session.execute(
+            select(
+                func.count(),
+                func.coalesce(func.sum(TrophyQuizSubmission.points_earned), 0),
+                # cast: summing the raw Boolean column makes SQLAlchemy coerce
+                # the aggregate back to a bool (True), not a count
+                func.coalesce(func.sum(cast(TrophyQuizSubmission.direction_correct, Integer)), 0),
+            )
+            .join(TrophyQuizSession,
+                  TrophyQuizSubmission.quiz_id == TrophyQuizSession.quiz_id)
+            .where(
+                TrophyQuizSession.guild_id == str(guild_id),
+                TrophyQuizSubmission.player_id == str(player_id),
+                # Only committed answers count, matching the leaderboard; a
+                # pending row is an initial guess never Kept/Changed.
+                TrophyQuizSubmission.finalized.is_(True),
+            )
+        )
+        played, points, direction_correct = result.one()
+
+    pick = None
+    if row is not None and row.total_quizzes:
+        pick = {
+            "played": row.total_quizzes,
+            "accuracy": row.accuracy_percentage or 0.0,
+            "points": row.total_points,
+            "best": row.highest_quiz_score,
+        }
+    trophy = None
+    if played:
+        trophy = {
+            "played": played,
+            "points": points,
+            "direction_correct": direction_correct,
+        }
+    return pick, trophy
 
 
 async def get_stats_embed_for_player(
@@ -77,6 +126,11 @@ async def get_stats_embed_for_player(
     rating, provisional = await _player_skill_rating(player_id, guild_id)
     stats_lifetime['skill_rating'] = rating
     stats_lifetime['skill_provisional'] = provisional
+
+    # Lifetime quiz stats (pick + trophy), rendered as their own embed field.
+    pick_quiz, trophy_quiz = await _player_quiz_stats(player_id, guild_id)
+    stats_lifetime['pick_quiz_stats'] = pick_quiz
+    stats_lifetime['trophy_quiz_stats'] = trophy_quiz
 
     # Create and return the embed
     embed = await create_stats_embed(user, stats_weekly, stats_monthly, stats_lifetime)

--- a/stats_display.py
+++ b/stats_display.py
@@ -71,16 +71,20 @@ async def _player_quiz_stats(player_id, guild_id):
     if row is not None and row.total_quizzes:
         pick = {
             "played": row.total_quizzes,
+            # `or 0`: the columns are nullable in the schema; insert-time
+            # defaults make NULLs unlikely, but "None pts" must be impossible.
             "accuracy": row.accuracy_percentage or 0.0,
-            "points": row.total_points,
-            "best": row.highest_quiz_score,
+            "points": row.total_points or 0,
+            "best": row.highest_quiz_score or 0,
         }
     trophy = None
     if played:
         trophy = {
             "played": played,
             "points": points,
-            "direction_correct": direction_correct,
+            # Pre-computed like pick's `accuracy`: the embed builder
+            # formats, it doesn't do arithmetic.
+            "direction_pct": direction_correct / played * 100,
         }
     return pick, trophy
 

--- a/tests/test_stats_display.py
+++ b/tests/test_stats_display.py
@@ -256,7 +256,7 @@ class TestPlayerQuizStats:
         assert pick is None and trophy is None
 
     @pytest.mark.asyncio
-    async def test_pick_quiz_reads_aggregated_row(self, test_db):
+    async def test_pick_quiz_reads_aggregated_row_own_guild_only(self, test_db):
         from stats_display import _player_quiz_stats
         async with AsyncSessionLocal() as session:
             session.add(QuizStats(
@@ -264,6 +264,11 @@ class TestPlayerQuizStats:
                 total_quizzes=12, total_picks_attempted=48, total_picks_correct=23,
                 accuracy_percentage=47.9, total_points=156, highest_quiz_score=20,
                 current_perfect_streak=2, longest_perfect_streak=4))
+            session.add(QuizStats(   # same player, other guild: excluded
+                player_id="123", guild_id="other-guild", display_name="P",
+                total_quizzes=99, accuracy_percentage=99.0, total_points=999,
+                highest_quiz_score=99, current_perfect_streak=0,
+                longest_perfect_streak=0))
             await session.commit()
         pick, trophy = await _player_quiz_stats("123", "g")
         assert pick == {"played": 12, "accuracy": 47.9, "points": 156, "best": 20}
@@ -287,9 +292,11 @@ class TestPlayerQuizStats:
             await session.commit()
         pick, trophy = await _player_quiz_stats("123", "g")
         assert pick is None
-        # direction_correct must be a COUNT (2), not a boolean coerced to True —
-        # summing the raw Boolean column regresses to True and 2 catches it.
-        assert trophy == {"played": 3, "points": 20, "direction_correct": 2}
+        # direction_pct must derive from a COUNT (2/3), not a boolean coerced
+        # to True — summing the raw Boolean column regresses to True, which
+        # 66.67% catches (True/3 would be 33.3%).
+        assert trophy["played"] == 3 and trophy["points"] == 20
+        assert round(trophy["direction_pct"], 1) == 66.7
 
     @pytest.mark.asyncio
     async def test_embed_shows_quiz_field_with_both_types(self, test_db):

--- a/tests/test_stats_display.py
+++ b/tests/test_stats_display.py
@@ -11,6 +11,7 @@ from database.db_session import AsyncSessionLocal
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from stats_display import get_stats_embed_for_player
+from models import QuizStats, TrophyQuizSession, TrophyQuizSubmission
 from models.draft_session import DraftSession
 from models.player import PlayerStats
 from models.debt_ledger import DebtLedger
@@ -226,3 +227,112 @@ class TestGetStatsEmbedForPlayer:
         from stats_display import _player_skill_rating
         rating, provisional = await _player_skill_rating("999", "g")
         assert rating is None and provisional is None
+
+
+def _trophy_quiz_session(quiz_id, guild_id, display_id=1):
+    return TrophyQuizSession(
+        quiz_id=quiz_id, display_id=display_id, guild_id=guild_id, channel_id="c",
+        draft_session_id=f"d-{quiz_id}", posted_by="mod",
+        decks=[{"slot": "A", "drafter_id": "u1", "wins": 3},
+               {"slot": "B", "drafter_id": "u2", "wins": 0}],
+    )
+
+
+def _trophy_submission(quiz_id, player_id, points, direction_correct=True, finalized=True):
+    return TrophyQuizSubmission(
+        quiz_id=quiz_id, player_id=player_id, display_name="P",
+        guesses=[3, 0], direction_correct=direction_correct,
+        exact_points=[3, 3], points_earned=points, finalized=finalized,
+    )
+
+
+class TestPlayerQuizStats:
+    """Tests for _player_quiz_stats and the quiz field on the /stats embed."""
+
+    @pytest.mark.asyncio
+    async def test_none_when_no_quiz_history(self, test_db):
+        from stats_display import _player_quiz_stats
+        pick, trophy = await _player_quiz_stats("123", "g")
+        assert pick is None and trophy is None
+
+    @pytest.mark.asyncio
+    async def test_pick_quiz_reads_aggregated_row(self, test_db):
+        from stats_display import _player_quiz_stats
+        async with AsyncSessionLocal() as session:
+            session.add(QuizStats(
+                player_id="123", guild_id="g", display_name="P",
+                total_quizzes=12, total_picks_attempted=48, total_picks_correct=23,
+                accuracy_percentage=47.9, total_points=156, highest_quiz_score=20,
+                current_perfect_streak=2, longest_perfect_streak=4))
+            await session.commit()
+        pick, trophy = await _player_quiz_stats("123", "g")
+        assert pick == {"played": 12, "accuracy": 47.9, "points": 156, "best": 20}
+        assert trophy is None
+
+    @pytest.mark.asyncio
+    async def test_trophy_aggregates_finalized_own_guild_only(self, test_db):
+        from stats_display import _player_quiz_stats
+        async with AsyncSessionLocal() as session:
+            session.add(_trophy_quiz_session("q1", "g", display_id=1))
+            session.add(_trophy_quiz_session("q2", "g", display_id=2))
+            session.add(_trophy_quiz_session("q3", "g", display_id=3))
+            session.add(_trophy_quiz_session("q4", "g", display_id=4))
+            session.add(_trophy_quiz_session("q-other", "other-guild"))
+            session.add(_trophy_submission("q1", "123", points=10, direction_correct=True))
+            session.add(_trophy_submission("q2", "123", points=7, direction_correct=True))
+            session.add(_trophy_submission("q3", "123", points=3, direction_correct=False))
+            session.add(_trophy_submission("q4", "123", points=8, finalized=False))   # pending: excluded
+            session.add(_trophy_submission("q-other", "123", points=10))              # other guild: excluded
+            session.add(_trophy_submission("q1", "456", points=10))                   # other player: excluded
+            await session.commit()
+        pick, trophy = await _player_quiz_stats("123", "g")
+        assert pick is None
+        # direction_correct must be a COUNT (2), not a boolean coerced to True —
+        # summing the raw Boolean column regresses to True and 2 catches it.
+        assert trophy == {"played": 3, "points": 20, "direction_correct": 2}
+
+    @pytest.mark.asyncio
+    async def test_embed_shows_quiz_field_with_both_types(self, test_db):
+        async with AsyncSessionLocal() as session:
+            session.add(QuizStats(
+                player_id="123456789", guild_id="test_guild", display_name="P",
+                total_quizzes=5, accuracy_percentage=50.0, total_points=40,
+                highest_quiz_score=12, current_perfect_streak=1, longest_perfect_streak=2))
+            session.add(_trophy_quiz_session("q1", "test_guild"))
+            session.add(_trophy_submission("q1", "123456789", points=10))
+            await session.commit()
+
+        mock_bot = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = 123456789
+        mock_user.display_name = "TestPlayer"
+        mock_user.avatar = None
+        mock_bot.fetch_user.return_value = mock_user
+
+        embed = await get_stats_embed_for_player(
+            bot=mock_bot, player_id="123456789", guild_id="test_guild",
+            display_name="TestPlayer")
+
+        quiz_fields = [f for f in embed.fields if "Quiz" in f.name]
+        assert len(quiz_fields) == 1
+        value = quiz_fields[0].value
+        assert "Pick Quiz** (5 played)" in value
+        assert "50% of picks guessed right" in value
+        assert "streak" not in value.lower()
+        assert "Trophy Quiz** (1 played)" in value and "10 pts" in value
+        assert "directionally right 100%" in value
+
+    @pytest.mark.asyncio
+    async def test_embed_omits_quiz_field_without_quiz_history(self, test_db):
+        mock_bot = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = 123456789
+        mock_user.display_name = "TestPlayer"
+        mock_user.avatar = None
+        mock_bot.fetch_user.return_value = mock_user
+
+        embed = await get_stats_embed_for_player(
+            bot=mock_bot, player_id="123456789", guild_id="test_guild",
+            display_name="TestPlayer")
+
+        assert not any("Quiz" in f.name for f in embed.fields)


### PR DESCRIPTION
Adds a **🧠 Quiz Stats (lifetime)** field to the `/stats` embed so players can see their quiz history without digging through the leaderboard:

> **Pick Quiz** (8 played): 76 pts • 66% of picks guessed right • best quiz 14 pts
> **Trophy Quiz** (9 played): 45 pts • directionally right 11%

## Testing
<img width="665" height="591" alt="Screenshot 2026-08-06 at 10 40 07" src="https://github.com/user-attachments/assets/38db0ca7-d0cd-44a8-aa40-91ceb86b0f79" />
