### PR TITLE
fix(draft): re-stamp the metadata footer when the cube changes

### DIFF
--- a/tests/test_draft_footer.py
+++ b/tests/test_draft_footer.py
@@ -110,3 +110,47 @@ def test_draft_session_embed_carries_the_footer():
     assert "timestamp" not in payload
     # No icon: the cube art is already the embed thumbnail.
     assert "icon_url" not in payload["footer"]
+
+
+@pytest.mark.asyncio
+async def test_update_draft_message_restamps_footer_after_cube_change():
+    """#383: Update Cube edited the Cube: field and thumbnail but left the
+    footer carrying the old cube name. update_draft_message must re-stamp it."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import views
+
+    stale = discord.Embed(title="Looking for Players!")
+    stale.add_field(name="Cube:", value="[LSVCube](https://cubecobra.com/cube/list/LSVCube)", inline=True)
+    stale.add_field(name="Sign-Ups:", value="**Players (0):**\nNo players yet.", inline=False)
+    stale.set_footer(text="ID: lightning-bolt-7 • Cube: LSVCube")
+
+    session = SimpleNamespace(
+        session_id="123456789012345678-1753500000",
+        friendly_id="lightning-bolt-7",
+        cube="ArenaChrome",  # the session was updated to a new cube
+        draft_channel_id="111",
+        message_id="222",
+        sign_ups={},
+        session_type="random",
+        packs_per_player=3,
+        cards_per_pack=15,
+    )
+
+    message = MagicMock()
+    message.embeds = [stale]
+    message.edit = AsyncMock()
+    channel = MagicMock()
+    channel.fetch_message = AsyncMock(return_value=message)
+    channel.guild = MagicMock()
+    bot = MagicMock()
+    bot.get_channel.return_value = channel
+
+    with patch.object(views, "get_draft_session", AsyncMock(return_value=session)):
+        await views.update_draft_message(bot, session.session_id)
+
+    message.edit.assert_awaited_once()
+    edited = message.edit.await_args.kwargs["embed"]
+    assert edited.footer.text == "ID: lightning-bolt-7 • Cube: ArenaChrome"
+    cube_field = next(f for f in edited.fields if f.name == "Cube:")
+    assert "ArenaChrome" in cube_field.value

--- a/views.py
+++ b/views.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import selectinload
 from helpers.utils import get_cube_thumbnail_url
 from helpers.display_names import get_display_name, get_display_name_by_id
 from helpers.debt_warning import format_staked_sign_ups, DEBT_WARNING_AGE_DAYS
+from helpers.draft_footer import apply_draft_footer_from_session
 from utils import (
     calculate_pairings,
     get_formatted_stake_pairs,
@@ -2317,7 +2318,11 @@ async def update_draft_message(bot, session_id):
         thumbnail_url = get_cube_thumbnail_url(draft_session.cube)
         embed.set_thumbnail(url=thumbnail_url)
         logger.info(f"Updated thumbnail for cube: {draft_session.cube}")
-        
+
+        # Re-stamp the metadata footer: the cube name it carries goes stale
+        # when Update Cube changes the session's cube (#383).
+        apply_draft_footer_from_session(embed, draft_session)
+
         await message.edit(embed=embed)
         logger.info(f"Successfully updated message for session ID: {session_id}")
 


### PR DESCRIPTION
Fixes #383

## Root cause

`update_draft_message` (views.py) refreshes the **Cube:** field, pack-format field, and thumbnail after **Update Cube**, but never re-applies the embed footer — so the footer kept showing `ID: <friendly-id> • Cube: <old-cube>` from when the signup embed was first created.

## Fix

One call before the message edit: `apply_draft_footer_from_session(embed, draft_session)` — the same helper every other footer site uses. This also covers any future path that changes session metadata and re-renders through `update_draft_message`.

## Testing

- **Regression test**: drives `update_draft_message` with a stale-footer embed (`Cube: LSVCube` in the footer, session updated to `ArenaChrome`) and asserts the edited embed's footer carries the new cube. Fails without the fix.
- **Full suite**: 906 passed, 10 skipped.
- **Live before/after** in a test guild (screenshots below): started a draft on LSVCube (`ID: barad-dur-69 • Cube: LSVCube`), used **Update Cube** → arenachrome — field + thumbnail updated, footer stayed `Cube: LSVCube` (the bug). With the fix, updating back to LSVCube brought the footer along.

### After

<img width="800" height="716" alt="pr-383-step1-start-lsvcube" src="https://github.com/user-attachments/assets/b64bcd91-6af7-4705-bd9f-9876568d0058" />

<img width="800" height="716" alt="pr-383-step2-picking-new-cube" src="https://github.com/user-attachments/assets/e0840091-d3c0-4f88-8c5e-ea4e7c61f067" />

<img width="800" height="716" alt="pr-383-step3-footer-updated" src="https://github.com/user-attachments/assets/c4719abc-0a16-4ada-9d49-113dbfe7c78f" />




🤖 Generated with [Claude Code](https://claude.com/claude-code)