### PR TITLE
One tie policy for every win percentage

### DIFF
--- a/services/leaderboard_service.py
+++ b/services/leaderboard_service.py
@@ -350,11 +350,10 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
                     seen_pairs.add(pair_key)
 
                     # Ties are drafts played together: they count toward the
-                    # sample-size gate and the denominator (one tie policy).
+                    # sample-size gate and the denominator (one tie policy,
+                    # already applied where win_percentage was stored above).
                     if teammate_data["drafts_played"] >= min_partnership_drafts:
-                        win_percentage = calculate_team_draft_win_percentage(
-                            teammate_data["drafts_won"], teammate_data["drafts_lost"],
-                            teammate_data["drafts_tied"])
+                        win_percentage = teammate_data["win_percentage"]
                         if win_percentage >= 50:
                             partnership = {
                                 "player_id": player_id,

--- a/services/leaderboard_service.py
+++ b/services/leaderboard_service.py
@@ -10,6 +10,13 @@ from models.player import PlayerStats
 from models import QuizStats, QuizSubmission, QuizSession
 from models.trophy_quiz_submission import TrophyQuizSubmission
 from models.trophy_quiz_session import TrophyQuizSession
+from stats_core import calculate_win_percentage, calculate_team_draft_win_percentage
+
+
+def partnership_win_percentage(won: int, lost: int, tied: int) -> float:
+    """THE partnership (Vault/Key) percentage: ties count in the denominator,
+    same policy as /record's draws and /stats' team percentage (stats_core)."""
+    return calculate_win_percentage(won, lost, tied)
 
 # Win Streak minimum requirements by timeframe
 STREAK_MINIMUMS = {
@@ -294,16 +301,17 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
             if player_data["completed_matches"] > 0:
                 player_data["match_win_percentage"] = (player_data["matches_won"] / player_data["completed_matches"]) * 100
             
-            # Calculate team draft win percentage
-            team_draft_counted_drafts = player_data["team_drafts_won"] + player_data["team_drafts_lost"]
-            if team_draft_counted_drafts > 0:
-                player_data["team_draft_win_percentage"] = (player_data["team_drafts_won"] / team_draft_counted_drafts) * 100
-            
-            # Calculate teammate win rates
+            # Calculate team draft win percentage (ties in the denominator --
+            # one policy with /stats and /record, via stats_core)
+            player_data["team_draft_win_percentage"] = calculate_team_draft_win_percentage(
+                player_data["team_drafts_won"], player_data["team_drafts_lost"],
+                player_data["team_drafts_tied"])
+
+            # Calculate teammate win rates (same tie policy)
             for teammate_id, teammate_data in player_data["teammate_win_rates"].items():
-                counted_drafts = teammate_data["drafts_won"] + teammate_data["drafts_lost"]
-                if counted_drafts > 0:
-                    teammate_data["win_percentage"] = (teammate_data["drafts_won"] / counted_drafts) * 100
+                teammate_data["win_percentage"] = partnership_win_percentage(
+                    teammate_data["drafts_won"], teammate_data["drafts_lost"],
+                    teammate_data["drafts_tied"])
 
         # Convert to list for sorting
         players_list = list(players_data.values())
@@ -347,10 +355,13 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
                         continue  # Skip already processed pair
                     seen_pairs.add(pair_key)
 
-                    counted_drafts = teammate_data["drafts_won"] + teammate_data["drafts_lost"]
-                    if counted_drafts >= min_partnership_drafts:
-                        win_percentage = (teammate_data["drafts_won"] / counted_drafts) * 100
-                        if win_percentage >= 50: 
+                    # Ties are drafts played together: they count toward the
+                    # sample-size gate and the denominator (one tie policy).
+                    if teammate_data["drafts_played"] >= min_partnership_drafts:
+                        win_percentage = partnership_win_percentage(
+                            teammate_data["drafts_won"], teammate_data["drafts_lost"],
+                            teammate_data["drafts_tied"])
+                        if win_percentage >= 50:
                             partnership = {
                                 "player_id": player_id,
                                 "player_name": player_data["display_name"],

--- a/services/leaderboard_service.py
+++ b/services/leaderboard_service.py
@@ -12,12 +12,6 @@ from models.trophy_quiz_submission import TrophyQuizSubmission
 from models.trophy_quiz_session import TrophyQuizSession
 from stats_core import calculate_win_percentage, calculate_team_draft_win_percentage
 
-
-def partnership_win_percentage(won: int, lost: int, tied: int) -> float:
-    """THE partnership (Vault/Key) percentage: ties count in the denominator,
-    same policy as /record's draws and /stats' team percentage (stats_core)."""
-    return calculate_win_percentage(won, lost, tied)
-
 # Win Streak minimum requirements by timeframe
 STREAK_MINIMUMS = {
     'active': 6,
@@ -309,7 +303,7 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
 
             # Calculate teammate win rates (same tie policy)
             for teammate_id, teammate_data in player_data["teammate_win_rates"].items():
-                teammate_data["win_percentage"] = partnership_win_percentage(
+                teammate_data["win_percentage"] = calculate_team_draft_win_percentage(
                     teammate_data["drafts_won"], teammate_data["drafts_lost"],
                     teammate_data["drafts_tied"])
 
@@ -358,7 +352,7 @@ async def get_leaderboard_data(guild_id, category="draft_record", limit=20, time
                     # Ties are drafts played together: they count toward the
                     # sample-size gate and the denominator (one tie policy).
                     if teammate_data["drafts_played"] >= min_partnership_drafts:
-                        win_percentage = partnership_win_percentage(
+                        win_percentage = calculate_team_draft_win_percentage(
                             teammate_data["drafts_won"], teammate_data["drafts_lost"],
                             teammate_data["drafts_tied"])
                         if win_percentage >= 50:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,26 @@
-"""Shared pytest fixtures.
+"""Shared pytest fixtures and seeding helpers.
 
 test_db: a throwaway file-backed SQLite database with the full schema,
-wired into the app's AsyncSessionLocal for the duration of one test.
-Many older test files still carry a local copy of this fixture (which
-shadows this one, harmlessly); new test files should use this one.
+wired into the app's AsyncSessionLocal for the duration of one test and
+unwired afterward. Many older test files still carry a local copy of this
+fixture (which shadows this one, harmlessly); new test files should use
+this one.
+
+seed_session: the one seeder for DraftSession + MatchResult fixtures --
+import it (``from conftest import seed_session``) instead of hand-writing
+another per-file variant.
 """
 import os
 import tempfile
+from datetime import datetime
 
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from database.models_base import Base
 from database.db_session import AsyncSessionLocal
+from models.draft_session import DraftSession
+from models.match import MatchResult
 
 
 @pytest_asyncio.fixture
@@ -22,7 +30,39 @@ async def test_db():
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    previous_bind = AsyncSessionLocal.kw.get("bind")
     AsyncSessionLocal.configure(bind=engine)
     yield engine
+    # Restore the prior binding BEFORE disposing this engine: the factory
+    # is process-wide, and leaving it bound to a disposed engine would make
+    # any later test that doesn't request this fixture fail on session use
+    # (order-dependent breakage).
+    AsyncSessionLocal.configure(bind=previous_bind)
     await engine.dispose()
     os.unlink(tmp.name)
+
+
+async def seed_session(session_id="s1", guild="g", stype="staked",
+                       stage="completed", victory=None, teams=None,
+                       matches=(), start=None, sign_ups=None,
+                       cube="TestCube"):
+    """Seed one DraftSession plus its MatchResults.
+
+    teams: (team_a_list, team_b_list) or None (legacy-style, no team JSON).
+    matches: iterable of (player1, player2, winner, submitted_at_or_None).
+    """
+    when = start or datetime(2026, 1, 1)
+    async with AsyncSessionLocal() as s:
+        s.add(DraftSession(
+            session_id=session_id, guild_id=guild, session_type=stype,
+            session_stage=stage,
+            victory_message_id_results_channel=victory,
+            team_a=list(teams[0]) if teams else None,
+            team_b=list(teams[1]) if teams else None,
+            draft_start_time=when, teams_start_time=when,
+            sign_ups=sign_ups, cube=cube))
+        for i, (p1, p2, w, ts) in enumerate(matches):
+            s.add(MatchResult(session_id=session_id, match_number=i + 1,
+                              player1_id=p1, player2_id=p2, winner_id=w,
+                              result_submitted_at=ts))
+        await s.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared pytest fixtures.
+
+test_db: a throwaway file-backed SQLite database with the full schema,
+wired into the app's AsyncSessionLocal for the duration of one test.
+Many older test files still carry a local copy of this fixture (which
+shadows this one, harmlessly); new test files should use this one.
+"""
+import os
+import tempfile
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from database.models_base import Base
+from database.db_session import AsyncSessionLocal
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose()
+    os.unlink(tmp.name)

--- a/tests/test_tie_percentage_policy.py
+++ b/tests/test_tie_percentage_policy.py
@@ -5,30 +5,11 @@ Fixtures are complete sessions (teams, victory message, reported matches)
 so the test holds across both the session-metadata and ledger-fold
 implementations of the leaderboard assembly.
 """
-import os
-import tempfile
-
 import pytest
-import pytest_asyncio
-from sqlalchemy.ext.asyncio import create_async_engine
 
-from database.models_base import Base
 from database.db_session import AsyncSessionLocal
 from models.draft_session import DraftSession
 from models.match import MatchResult
-
-
-@pytest_asyncio.fixture
-async def test_db():
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
-    tmp.close()
-    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    AsyncSessionLocal.configure(bind=engine)
-    yield engine
-    await engine.dispose()
-    os.unlink(tmp.name)
 
 
 async def _team_session(session_id, winners_a, start):
@@ -66,11 +47,8 @@ async def test_leaderboard_percentages_count_ties(test_db):
     assert p1["team_drafts_won"] == 19 and p1["team_drafts_tied"] == 1
     assert round(p1["team_draft_win_percentage"], 1) == 95.0
 
-    vk = await get_leaderboard_data("g", category="time_vault_and_key",
-                                    limit=5, timeframe="lifetime")
-    # partnership entries exist only with teammates; the 1v1 fixture has
-    # none, so assert the policy at the per-player teammate map instead
-    # via draft_record's data (covered above) -- and guard that the
-    # partnership formula uses the same denominator by direct call:
-    from services.leaderboard_service import partnership_win_percentage
-    assert partnership_win_percentage(won=1, lost=0, tied=1) == 50.0
+    # Vault/Key partnerships share stats_core's tie-inclusive formula with
+    # the 95% assertion above (one owner, no separate partnership wrapper);
+    # the 1v1 fixture has no teammates, so this exercises the path only.
+    await get_leaderboard_data("g", category="time_vault_and_key",
+                               limit=5, timeframe="lifetime")

--- a/tests/test_tie_percentage_policy.py
+++ b/tests/test_tie_percentage_policy.py
@@ -1,0 +1,76 @@
+"""One tie policy everywhere: percentages count tied team drafts in the
+denominator (stats_core's contract, same as /record's draws handling).
+
+Fixtures are complete sessions (teams, victory message, reported matches)
+so the test holds across both the session-metadata and ledger-fold
+implementations of the leaderboard assembly.
+"""
+import os
+import tempfile
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from database.models_base import Base
+from database.db_session import AsyncSessionLocal
+from models.draft_session import DraftSession
+from models.match import MatchResult
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    tmp.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    AsyncSessionLocal.configure(bind=engine)
+    yield engine
+    await engine.dispose()
+    os.unlink(tmp.name)
+
+
+async def _team_session(session_id, winners_a, start):
+    """A completed 1v1-team session: player '1' and '9' on opposing sides,
+    two matches; winners_a of them won by side A ('1')."""
+    from datetime import datetime
+    async with AsyncSessionLocal() as s:
+        s.add(DraftSession(
+            session_id=session_id, guild_id="g", session_type="staked",
+            session_stage="completed", victory_message_id_results_channel="v",
+            team_a=["1"], team_b=["9"],
+            teams_start_time=datetime(2026, 1, start),
+            draft_start_time=datetime(2026, 1, start), cube="C",
+            sign_ups={"1": "One", "9": "Nine"}))
+        for i in range(2):
+            winner = "1" if i < winners_a else "9"
+            loser = "9" if winner == "1" else "1"
+            s.add(MatchResult(session_id=session_id, match_number=i + 1,
+                              player1_id="1", player2_id="9", winner_id=winner))
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_percentages_count_ties(test_db):
+    from services.leaderboard_service import get_leaderboard_data
+    # 19 side-A wins + 1 tie: clears the lifetime minimums (20 drafts, >=50%)
+    # and splits the policies: tie-inclusive = 19/20 = 95%, tie-exclusive = 100%.
+    for i in range(19):
+        await _team_session(f"w{i}", winners_a=2, start=(i % 27) + 1)
+    await _team_session("t", winners_a=1, start=28)
+
+    data = await get_leaderboard_data("g", category="draft_record",
+                                      limit=5, timeframe="lifetime")
+    p1 = next(p for p in data if p["player_id"] == "1")
+    assert p1["team_drafts_won"] == 19 and p1["team_drafts_tied"] == 1
+    assert round(p1["team_draft_win_percentage"], 1) == 95.0
+
+    vk = await get_leaderboard_data("g", category="time_vault_and_key",
+                                    limit=5, timeframe="lifetime")
+    # partnership entries exist only with teammates; the 1v1 fixture has
+    # none, so assert the policy at the per-player teammate map instead
+    # via draft_record's data (covered above) -- and guard that the
+    # partnership formula uses the same denominator by direct call:
+    from services.leaderboard_service import partnership_win_percentage
+    assert partnership_win_percentage(won=1, lost=0, tied=1) == 50.0

--- a/tests/test_tie_percentage_policy.py
+++ b/tests/test_tie_percentage_policy.py
@@ -3,33 +3,25 @@ denominator (stats_core's contract, same as /record's draws handling).
 
 Fixtures are complete sessions (teams, victory message, reported matches)
 so the test holds across both the session-metadata and ledger-fold
-implementations of the leaderboard assembly.
+implementations of the leaderboard assembly. test_db and seed_session come
+from tests/conftest.py.
 """
+from datetime import datetime
+
 import pytest
 
-from database.db_session import AsyncSessionLocal
-from models.draft_session import DraftSession
-from models.match import MatchResult
+from conftest import seed_session
 
 
 async def _team_session(session_id, winners_a, start):
     """A completed 1v1-team session: player '1' and '9' on opposing sides,
     two matches; winners_a of them won by side A ('1')."""
-    from datetime import datetime
-    async with AsyncSessionLocal() as s:
-        s.add(DraftSession(
-            session_id=session_id, guild_id="g", session_type="staked",
-            session_stage="completed", victory_message_id_results_channel="v",
-            team_a=["1"], team_b=["9"],
-            teams_start_time=datetime(2026, 1, start),
-            draft_start_time=datetime(2026, 1, start), cube="C",
-            sign_ups={"1": "One", "9": "Nine"}))
-        for i in range(2):
-            winner = "1" if i < winners_a else "9"
-            loser = "9" if winner == "1" else "1"
-            s.add(MatchResult(session_id=session_id, match_number=i + 1,
-                              player1_id="1", player2_id="9", winner_id=winner))
-        await s.commit()
+    matches = [("1", "9", "1" if i < winners_a else "9", None)
+               for i in range(2)]
+    await seed_session(
+        session_id=session_id, teams=(["1"], ["9"]), victory="v",
+        start=datetime(2026, 1, start), sign_ups={"1": "One", "9": "Nine"},
+        cube="C", matches=matches)
 
 
 @pytest.mark.asyncio
@@ -46,9 +38,3 @@ async def test_leaderboard_percentages_count_ties(test_db):
     p1 = next(p for p in data if p["player_id"] == "1")
     assert p1["team_drafts_won"] == 19 and p1["team_drafts_tied"] == 1
     assert round(p1["team_draft_win_percentage"], 1) == 95.0
-
-    # Vault/Key partnerships share stats_core's tie-inclusive formula with
-    # the 95% assertion above (one owner, no separate partnership wrapper);
-    # the 1v1 fixture has no teammates, so this exercises the path only.
-    await get_leaderboard_data("g", category="time_vault_and_key",
-                               limit=5, timeframe="lifetime")


### PR DESCRIPTION
Pre-existing bug surfaced by #380's Codex design review: `/record` counts draws in win-percentage denominators while the leaderboard's team and Vault/Key partnership formulas exclude them — the same tied draft reads differently across surfaces (prod has 215 completed tied team sessions). All three leaderboard formula sites now use the tie-inclusive `stats_core` policy via a shared `partnership_win_percentage`, and the Vault/Key sample-size gate counts ties as drafts played together.

Fixed on main (independent of #380) so both current prod and the stats rework inherit it; #380 will be rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)