### PR TITLE
fix(quiz): per-instance dispatch ids for ephemeral views + #381 flow cleanup

### DIFF
--- a/quiz_views_module/quiz_views.py
+++ b/quiz_views_module/quiz_views.py
@@ -643,7 +643,9 @@ class QuizGuessView(discord.ui.View):
         label="Submit Guesses",
         style=discord.ButtonStyle.success,
         row=4  # Place in last row (after 4 dropdowns)
-        # Note: custom_id for buttons in ephemeral views doesn't need to be unique per user
+        # No custom_id: ephemeral views NEED per-instance auto ids — a fixed
+        # id would make all live instances share one dispatch slot (see
+        # tests/test_quiz_view_dispatch.py for the mechanism and proof).
     )
     async def submit_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Process submission and show results"""

--- a/quiz_views_module/quiz_views.py
+++ b/quiz_views_module/quiz_views.py
@@ -282,10 +282,12 @@ class ShareResultView(discord.ui.View):
         self.quiz_id = quiz_id
         self.bonus_type = bonus_type
 
+    # No custom_id on this ephemeral view's button: a fixed id would make
+    # every live instance share one dispatch slot (see the trophy quiz's
+    # TrophyShareView.share_button for the full explanation).
     @discord.ui.button(
         label="📤 Share Results Publicly",
         style=discord.ButtonStyle.primary,
-        custom_id="share_quiz_results"
     )
     async def share_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Post results publicly to the channel."""

--- a/quiz_views_module/trophy_quiz_views.py
+++ b/quiz_views_module/trophy_quiz_views.py
@@ -138,10 +138,16 @@ class TrophyShareView(discord.ui.View):
             return f"[Trophy Quiz #{self.display_id}]({message_link})"
         return f"Trophy Quiz #{self.display_id}"
 
+    # No custom_id on ephemeral-view buttons: py-cord registers ephemeral
+    # views with message_id=None, so a fixed id would make every live
+    # instance share ONE dispatch slot (newest evicts the rest -> clicks
+    # misroute, and once that instance stops, the evicted prompt's buttons
+    # dispatch to nothing). Auto-generated per-instance ids keep each
+    # prompt's routing exact. Only persistent views (timeout=None,
+    # re-registered on restart) need fixed ids.
     @discord.ui.button(
         label="📤 Share Results Publicly",
         style=discord.ButtonStyle.primary,
-        custom_id="share_trophy_quiz_results",
     )
     async def share_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         """Post results publicly to the channel — score + emoji line only."""
@@ -435,10 +441,10 @@ class TrophyGuessView(discord.ui.View):
                 default_wins=prefill.get(deck["slot"]) if prefill else None,
             ))
 
+    # No custom_id: per-instance auto id (see TrophyShareView.share_button).
     @discord.ui.button(
         label="Submit",
         style=discord.ButtonStyle.success,
-        custom_id="trophy_quiz_guess_submit",
         row=2,
     )
     async def submit_button(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -510,10 +516,10 @@ class TrophyDecideView(discord.ui.View):
         self.initial_guesses = initial_guesses
         self._lock = asyncio.Lock()
 
+    # No custom_id: per-instance auto id (see TrophyShareView.share_button).
     @discord.ui.button(
         label="Keep my answer",
         style=discord.ButtonStyle.success,
-        custom_id="trophy_quiz_keep",
     )
     async def keep_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         async with self._lock:
@@ -527,10 +533,10 @@ class TrophyDecideView(discord.ui.View):
             await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, prefix=prefix, edit=True)
             self.stop()
 
+    # No custom_id: per-instance auto id (see TrophyShareView.share_button).
     @discord.ui.button(
         label=f"🔎 Pay {CHANGE_COST} to change",
         style=discord.ButtonStyle.secondary,
-        custom_id="trophy_quiz_change",
     )
     async def change_button(self, button: discord.ui.Button, interaction: discord.Interaction):
         async with self._lock:

--- a/quiz_views_module/trophy_quiz_views.py
+++ b/quiz_views_module/trophy_quiz_views.py
@@ -138,12 +138,10 @@ class TrophyShareView(discord.ui.View):
             return f"[Trophy Quiz #{self.display_id}]({message_link})"
         return f"Trophy Quiz #{self.display_id}"
 
-    # No custom_id on ephemeral-view buttons: py-cord registers ephemeral
-    # views with message_id=None, so a fixed id would make every live
-    # instance share ONE dispatch slot (newest evicts the rest -> clicks
-    # misroute, and once that instance stops, the evicted prompt's buttons
-    # dispatch to nothing). Auto-generated per-instance ids keep each
-    # prompt's routing exact. Only persistent views (timeout=None,
+    # No custom_id on ephemeral-view buttons: a fixed id makes every live
+    # instance share ONE dispatch slot, misrouting clicks and dead-ending
+    # stopped prompts — see tests/test_quiz_view_dispatch.py for the full
+    # mechanism and proof. Only persistent views (timeout=None,
     # re-registered on restart) need fixed ids.
     @discord.ui.button(
         label="📤 Share Results Publicly",
@@ -277,15 +275,23 @@ async def _respond(interaction, content: str, view, edit: bool):
     """Deliver a step of the ephemeral quiz flow. edit=True replaces the message
     the clicked component lives on (in-place transition — the previous prompt and
     its buttons disappear, so a stale Submit can't be pressed again, #355);
-    edit=False sends a new ephemeral message (used from the public quiz message,
-    which must never be edited into per-user state)."""
+    edit=False sends a new ephemeral message. The flow helpers default to
+    edit=True — the safe in-flow behavior — so ONLY the entry point from the
+    public quiz message (play_button, which must never edit that shared
+    message into per-user state) passes edit=False explicitly."""
     if edit:
         await interaction.response.edit_message(content=content, view=view)
     else:
         await interaction.response.send_message(content, view=view, ephemeral=True)
 
 
-async def _send_final_reveal(interaction, quiz_id: str, decks: list, guesses: list, changed: bool, prefix: str = "", edit: bool = False):
+def _flow_header(decks: list, guesses: list) -> str:
+    """The pilots + locked-guess header every post-reveal step restates —
+    each edit replaces the message that previously displayed it (#355)."""
+    return f"{_build_pilots_line(decks)}\n{_build_guess_line(decks, guesses)}"
+
+
+async def _send_final_reveal(interaction, quiz_id: str, decks: list, guesses: list, changed: bool, prefix: str = "", edit: bool = True):
     """Show the full ephemeral result (records + score + optional −2 line) plus a
     Share button, for a finalized submission."""
     result = score_submission(guesses, [deck["wins"] for deck in decks])
@@ -303,7 +309,7 @@ async def _send_final_reveal(interaction, quiz_id: str, decks: list, guesses: li
     await _respond(interaction, prefix + "\n".join(lines), view, edit)
 
 
-async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub, edit: bool = False) -> bool:
+async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub, edit: bool = True) -> bool:
     """If `sub` is a finalized submission, show its committed result (with the
     "already submitted" prefix) and return True so the caller stops. Returns
     False when there's nothing to show (no submission, or still pending)."""
@@ -316,12 +322,11 @@ async def _reveal_if_finalized(interaction, quiz_id: str, decks: list, sub, edit
     return True
 
 
-async def _reveal_names_and_decide(interaction, quiz_id: str, decks: list, user, initial_guesses: list, edit: bool = False):
+async def _reveal_names_and_decide(interaction, quiz_id: str, decks: list, user, initial_guesses: list, edit: bool = True):
     """Reveal ONLY the pilots' names (not records/score) and present the
     Keep / Pay-2-to-change choice on the player's locked initial guess."""
     content = (
-        f"{_build_pilots_line(decks)}\n"
-        f"{_build_guess_line(decks, initial_guesses)}\n"
+        f"{_flow_header(decks, initial_guesses)}\n"
         f"Now that you know who piloted each deck, keep your answer or pay "
         f"**{CHANGE_COST} points** to change it."
     )
@@ -380,10 +385,14 @@ class TrophyQuizView(discord.ui.View):
         Keep/Change choice (pending submission), or show the result (finalized)."""
         user_id = str(interaction.user.id)
         sub = await _get_submission(self.quiz_id, user_id)
-        if await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub):
+        # edit=False: this is the one entry point clicked on the PUBLIC quiz
+        # message, which must never be edited into per-user state — every
+        # step answers with a fresh ephemeral from here.
+        if await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub, edit=False):
             return
         if sub is not None:  # pending: resume on the locked initial guess
-            await _reveal_names_and_decide(interaction, self.quiz_id, self.decks, interaction.user, sub.guesses)
+            await _reveal_names_and_decide(interaction, self.quiz_id, self.decks,
+                                           interaction.user, sub.guesses, edit=False)
             return
         await interaction.response.send_message(
             "Guess each deck's record, then hit **Submit**:",
@@ -459,9 +468,12 @@ class TrophyGuessView(discord.ui.View):
                 return
             guesses = [self.selections[slot] for slot in slots]
 
-            # Every response below edits THIS message into the next step of the
-            # flow (edit=True), so the Submit prompt is consumed by its first
-            # click — pressing Submit again can't spawn duplicate prompts (#355).
+            # Every response below edits THIS message into the next step of
+            # the flow, so the Submit prompt is consumed by its first click —
+            # pressing Submit again can't spawn duplicate prompts (#355).
+            # Branches never early-return: they all fall through to the ONE
+            # trailing stop(), which an exception skips (leaving the view
+            # alive and the click retryable).
             if self.initial_guesses is None:
                 # INITIAL submit: persist pending + reveal names + decide.
                 created = await _persist_pending(
@@ -471,15 +483,14 @@ class TrophyGuessView(discord.ui.View):
                     # Play prompt, or a resume). Route to the right state — on the
                     # LOCKED stored guess — rather than duplicate.
                     sub = await _get_submission(self.quiz_id, user_id)
-                    if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub, edit=True):
+                    if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub):
                         initial = sub.guesses if sub is not None else guesses
                         await _reveal_names_and_decide(
-                            interaction, self.quiz_id, self.decks, interaction.user, initial, edit=True)
-                    self.stop()
-                    return
-                logger.info(f"User {user_id} made an initial trophy guess on {self.quiz_id}")
-                await _reveal_names_and_decide(
-                    interaction, self.quiz_id, self.decks, interaction.user, guesses, edit=True)
+                            interaction, self.quiz_id, self.decks, interaction.user, initial)
+                else:
+                    logger.info(f"User {user_id} made an initial trophy guess on {self.quiz_id}")
+                    await _reveal_names_and_decide(
+                        interaction, self.quiz_id, self.decks, interaction.user, guesses)
             else:
                 # CHANGE submit: finalize with the revised guess (charge iff changed).
                 changed = guesses != self.initial_guesses
@@ -492,13 +503,12 @@ class TrophyGuessView(discord.ui.View):
                     final_changed = sub.changed_answer if sub is not None else changed
                     await _send_final_reveal(
                         interaction, self.quiz_id, self.decks, final_guesses,
-                        final_changed, prefix="*(You already submitted this quiz)*\n", edit=True)
-                    self.stop()
-                    return
-                logger.info(
-                    f"User {user_id} finalized trophy quiz {self.quiz_id} via change "
-                    f"(changed={changed})")
-                await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, edit=True)
+                        final_changed, prefix="*(You already submitted this quiz)*\n")
+                else:
+                    logger.info(
+                        f"User {user_id} finalized trophy quiz {self.quiz_id} via change "
+                        f"(changed={changed})")
+                    await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed)
             self.stop()
 
 
@@ -525,12 +535,18 @@ class TrophyDecideView(discord.ui.View):
         async with self._lock:
             user_id = str(interaction.user.id)
             did = await _finalize(self.quiz_id, user_id, self.initial_guesses, False, self.decks)
-            prefix = "" if did else "*(You already submitted this quiz)*\n"
-            sub = await _get_submission(self.quiz_id, user_id)
-            guesses = sub.guesses if sub is not None else self.initial_guesses
-            changed = sub.changed_answer if sub is not None else False
+            if did:
+                # The common path: we just committed exactly these values —
+                # no need to read back what we wrote.
+                prefix, guesses, changed = "", self.initial_guesses, False
+            else:
+                # Finalized elsewhere first — show the committed result.
+                sub = await _get_submission(self.quiz_id, user_id)
+                prefix = "*(You already submitted this quiz)*\n"
+                guesses = sub.guesses if sub is not None else self.initial_guesses
+                changed = sub.changed_answer if sub is not None else False
             # Edit this prompt into the result so Keep/Change can't be re-clicked (#355).
-            await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, prefix=prefix, edit=True)
+            await _send_final_reveal(interaction, self.quiz_id, self.decks, guesses, changed, prefix=prefix)
             self.stop()
 
     # No custom_id: per-instance auto id (see TrophyShareView.share_button).
@@ -542,16 +558,15 @@ class TrophyDecideView(discord.ui.View):
         async with self._lock:
             user_id = str(interaction.user.id)
             sub = await _get_submission(self.quiz_id, user_id)
-            if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub, edit=True):
-                # Edit this prompt into the revise view (pilots line kept visible,
-                # since editing replaces the message that showed it).
-                await interaction.response.edit_message(
-                    content=(
-                        f"{_build_pilots_line(self.decks)}\n"
-                        f"{_build_guess_line(self.decks, self.initial_guesses)}\n"
-                        f"Revise your records, then **Submit** (−{CHANGE_COST} points if you change anything):"
-                    ),
-                    view=TrophyGuessView(self.quiz_id, self.decks, interaction.user,
-                                         initial_guesses=self.initial_guesses),
+            if not await _reveal_if_finalized(interaction, self.quiz_id, self.decks, sub):
+                # Edit this prompt into the revise view, restating the flow
+                # header (editing replaces the message that showed it).
+                await _respond(
+                    interaction,
+                    f"{_flow_header(self.decks, self.initial_guesses)}\n"
+                    f"Revise your records, then **Submit** (−{CHANGE_COST} points if you change anything):",
+                    TrophyGuessView(self.quiz_id, self.decks, interaction.user,
+                                    initial_guesses=self.initial_guesses),
+                    edit=True,
                 )
             self.stop()

--- a/tests/test_quiz_view_dispatch.py
+++ b/tests/test_quiz_view_dispatch.py
@@ -23,14 +23,18 @@ from unittest.mock import patch
 
 import pytest
 
+import discord
 from discord.ui.item import Item
 from discord.ui.view import View, ViewStore
 
+from quiz_views_module.quiz_views import ShareResultView
 from quiz_views_module.trophy_quiz_views import (
     TrophyDecideView, TrophyGuessView, TrophyShareView)
 
-DECKS = [{"slot": "A", "wins": 3, "user_id": "u1"},
-         {"slot": "B", "wins": 0, "user_id": "u2"}]
+# Only "slot" is read by the views under test (dropdown labels/keys).
+DECKS = [{"slot": "A"}, {"slot": "B"}]
+
+BUTTON = discord.ComponentType.button.value
 
 
 def _user(uid):
@@ -38,12 +42,16 @@ def _user(uid):
 
 
 def _ephemeral_views(uid):
-    """One instance of every per-user ephemeral trophy-quiz view."""
+    """One instance of every per-user ephemeral quiz view (both quiz
+    modules) — extend this list when adding a new ephemeral view so the
+    per-instance-id invariant covers it."""
     return [
         TrophyGuessView("qz", DECKS, _user(uid)),
         TrophyDecideView("qz", DECKS, _user(uid), [3, 0]),
         TrophyShareView(user=_user(uid), emoji_line="🟩", total_points=5,
                         quiz_id="qz", display_id=1),
+        ShareResultView(user=_user(uid), emoji_line="🟩", total_points=5,
+                        correct_count=1),
     ]
 
 
@@ -62,7 +70,7 @@ async def test_ephemeral_views_have_per_instance_component_ids():
 
 def _dispatched_to(store, custom_id, message_id, routed):
     routed.clear()
-    store.dispatch(2, custom_id, SimpleNamespace(
+    store.dispatch(BUTTON, custom_id, SimpleNamespace(
         message=SimpleNamespace(id=message_id), data={}))
     return routed[0] if routed else None
 

--- a/tests/test_quiz_view_dispatch.py
+++ b/tests/test_quiz_view_dispatch.py
@@ -1,0 +1,99 @@
+"""Ephemeral quiz views must dispatch per-instance, not per-class.
+
+py-cord's ViewStore keys live views by (component_type, message_id,
+custom_id) — and ephemeral views sent via interaction.response.send_message
+are registered with message_id=None (the message id isn't known at send
+time), so a HARDCODED custom_id collapses every live instance of that view
+into a single process-wide dispatch slot: the newest registration silently
+evicts the previous one. With two players (or one player pressing Play
+twice) the evicted prompt's clicks misroute into the newest instance, and
+once that instance stops (the #355 edit-in-place flow stops each consumed
+view), the evicted prompt's buttons dispatch to nothing — Discord shows
+"This interaction failed", permanently.
+
+The fix: ephemeral views must let py-cord auto-generate a unique custom_id
+per instance (omit the custom_id argument). Only PERSISTENT views
+(timeout=None, re-registered on restart) need fixed ids.
+
+These tests exercise py-cord's real ViewStore dispatch — not the button
+callbacks directly, which would bypass the routing layer under test.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from discord.ui.item import Item
+from discord.ui.view import View, ViewStore
+
+from quiz_views_module.trophy_quiz_views import (
+    TrophyDecideView, TrophyGuessView, TrophyShareView)
+
+DECKS = [{"slot": "A", "wins": 3, "user_id": "u1"},
+         {"slot": "B", "wins": 0, "user_id": "u2"}]
+
+
+def _user(uid):
+    return SimpleNamespace(id=uid)
+
+
+def _ephemeral_views(uid):
+    """One instance of every per-user ephemeral trophy-quiz view."""
+    return [
+        TrophyGuessView("qz", DECKS, _user(uid)),
+        TrophyDecideView("qz", DECKS, _user(uid), [3, 0]),
+        TrophyShareView(user=_user(uid), emoji_line="🟩", total_points=5,
+                        quiz_id="qz", display_id=1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_views_have_per_instance_component_ids():
+    """No dispatchable component may share a custom_id across two fresh
+    instances — a shared id means a shared (and evictable) dispatch slot.
+    (async: discord View construction requires a running event loop.)"""
+    for a, b in zip(_ephemeral_views(1), _ephemeral_views(2)):
+        ids_a = {c.custom_id for c in a.children if c.is_dispatchable()}
+        ids_b = {c.custom_id for c in b.children if c.is_dispatchable()}
+        shared = ids_a & ids_b
+        assert not shared, (
+            f"{type(a).__name__} shares dispatch ids across instances: {shared}")
+
+
+def _dispatched_to(store, custom_id, message_id, routed):
+    routed.clear()
+    store.dispatch(2, custom_id, SimpleNamespace(
+        message=SimpleNamespace(id=message_id), data={}))
+    return routed[0] if routed else None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_guess_prompts_dispatch_independently():
+    """Two live guess prompts (two players, or one player double-clicking
+    Play): each Submit routes to its own view, and one view stopping must
+    not kill the other's buttons."""
+    routed = []
+    with patch.object(View, "_dispatch_item",
+                      lambda self, item, i: routed.append(self)), \
+         patch.object(Item, "refresh_state", lambda self, i: None):
+        store = ViewStore(state=SimpleNamespace())
+        view_a = TrophyGuessView("qz", DECKS, _user(1))
+        view_b = TrophyGuessView("qz", DECKS, _user(2))
+        # Register exactly as InteractionResponse.send_message does for
+        # ephemerals: with no message id.
+        store.add_view(view_a, message_id=None)
+        store.add_view(view_b, message_id=None)
+
+        def submit_id(v):
+            return next(c.custom_id for c in v.children
+                        if getattr(c, "label", "") == "Submit")
+
+        # A clicks Submit on A's message; the payload carries the custom_id
+        # baked into A's message components.
+        assert _dispatched_to(store, submit_id(view_a), 111, routed) is view_a
+        assert _dispatched_to(store, submit_id(view_b), 222, routed) is view_b
+
+        # A's flow advances and its consumed view stops (#355 behavior) —
+        # B's prompt must remain fully dispatchable.
+        view_a.stop()
+        assert _dispatched_to(store, submit_id(view_b), 222, routed) is view_b


### PR DESCRIPTION
Follow-up to #381 (merged). Post-merge review found a verified dispatch-layer bug its callback-level tests couldn't see, plus cleanup opportunities in the merged flow.

## The bug

py-cord registers views sent via `interaction.response.send_message` with `message_id=None` (the ephemeral message id isn't known at send time), and its `ViewStore` keys dispatch by `(component_type, message_id, custom_id)`. A **hardcoded** `custom_id` therefore collapses every live instance of an ephemeral view into one process-wide dispatch slot — the newest registration silently evicts the rest.

With two players on the same trophy quiz (or one player pressing Play twice):
1. the evicted prompt's Submit **misroutes into the newest instance** (wrong user's view — "select a record for both decks" despite having picked, or submitting someone else's picks), and
2. after #381's (correct) stop-on-consume hygiene, the evicted prompt's buttons dispatch to **nothing** — "This interaction failed", permanently. #381's stale-prompt routing never actually executes.

Verified experimentally against py-cord's real `ViewStore` before writing the fix; the new `tests/test_quiz_view_dispatch.py` reproduces it at the dispatch layer (the layer the existing tests bypass by invoking callbacks directly) and was confirmed failing pre-fix for exactly these reasons.

**Fix**: drop `custom_id` from the ephemeral views' buttons (trophy Submit/Keep/Change/Share + the regular quiz's Share, which had the same latent bug) so py-cord auto-generates a unique id per instance. Persistent views (`trophy_quiz_play`, `view_decklists`, `quiz_make_guesses`) keep their fixed ids — they're re-registered on restart and need them.

## Simplify pass on the merged #381 flow

- Flow helpers default to `edit=True`; only `play_button` (the public-message entry point that must never edit) passes `edit=False` explicitly — previously 8 call sites each had to remember the safe value, and forgetting one silently reintroduced #355.
- `change_button` goes through the `_respond` dispatcher; the restated pilots+guess header is built once by `_flow_header`.
- `submit_button` funnels to one trailing `stop()` (exceptions still skip it, keeping failed clicks retryable).
- `keep_button` skips re-reading the submission it just wrote on the common path.
- The stale `quiz_views.py` comment claiming ephemeral `custom_id`s "don't need to be unique per user" — the exact disproven claim — now points at the dispatch test as canonical.

## Testing

- New dispatch-level tests (real `ViewStore`): per-instance id invariant across all four ephemeral quiz views, correct routing for two concurrent prompts, one view stopping not killing another's buttons. Red pre-fix, green post-fix.
- Full suite: 930 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNQ9PeNfT5bzXR1E38Wp9C