### PR TITLE
Raise upset callout threshold to 40%

### DIFF
--- a/helpers/skill.py
+++ b/helpers/skill.py
@@ -117,7 +117,7 @@ def is_established(games):
 # are deliberate (owner's criterion): if the win itself moved the ratings
 # enough to erase the upset, it wasn't much of an upset. See
 # docs/superpowers/specs/2026-07-31-upset-victory-callout-design.md.
-UPSET_THRESHOLD = 0.35
+UPSET_THRESHOLD = 0.40
 LEGENDARY_UPSET_THRESHOLD = 0.25
 
 # TEST_MODE only: pinned (mu, sigma, games) making synthetic test users a
@@ -154,7 +154,7 @@ def winner_probability_from_stats(stats_map, winner_ids, loser_ids):
 
 
 def upset_tier(winner_prob):
-    """'legendary' below 25%, 'upset' below 35%, else None. Strict <."""
+    """'legendary' below 25%, 'upset' below 40%, else None. Strict <."""
     if winner_prob < LEGENDARY_UPSET_THRESHOLD:
         return "legendary"
     if winner_prob < UPSET_THRESHOLD:

--- a/tests/test_upset_helpers.py
+++ b/tests/test_upset_helpers.py
@@ -34,13 +34,13 @@ def test_known_gap_matches_elo_logistic():
 
 
 def test_thresholds_have_expected_values():
-    assert UPSET_THRESHOLD == 0.35
+    assert UPSET_THRESHOLD == 0.40
     assert LEGENDARY_UPSET_THRESHOLD == 0.25
 
 
 def test_upset_tier_boundaries():
-    assert upset_tier(0.349) == "upset"
-    assert upset_tier(0.35) is None
+    assert upset_tier(0.399) == "upset"
+    assert upset_tier(0.40) is None
     assert upset_tier(0.249) == "legendary"
     assert upset_tier(0.25) == "upset"      # strict <, so exactly 0.25 is the lower tier's edge
     assert upset_tier(0.5) is None
@@ -78,7 +78,7 @@ def test_apply_upset_decoration_legendary_tier():
 
 def test_apply_upset_decoration_no_tier_is_passthrough():
     assert apply_upset_decoration("T", "D", 0.60) == ("T", "D")
-    assert apply_upset_decoration("T", "D", 0.35) == ("T", "D")
+    assert apply_upset_decoration("T", "D", 0.40) == ("T", "D")
 
 
 def test_apply_upset_decoration_long_title_skips_prefix_to_respect_discord_limit():


### PR DESCRIPTION
## Summary
- `UPSET_THRESHOLD` 0.35 → 0.40 (`helpers/skill.py`); `LEGENDARY_UPSET_THRESHOLD` unchanged at 0.25
- Boundary tests updated (`upset_tier(0.399) == "upset"`, `upset_tier(0.40) is None`; passthrough test moved to the new edge)

## Why
Audit of prod data (2026-08-10): zero callouts fired since the feature launched — 29 decisive Lotus drafts since Aug 1, closest miss at 35.2% winner probability. At 40%, that same sample would have produced 3 callouts (35.2%, 37.9%, 39.5%), which matches the intended "occasional flair" cadence.

## Testing
- `tests/test_upset_helpers.py` + `tests/test_upset_victory_decoration.py`: 20 passed
- Full suite: 945 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NivLmd1mP6jyniSKQxSwHT