### PR TITLE
MTGO tix wallet + tournament entry-fee escrow and payouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 card_analysis_cache/
 drafts.db.backup.*
 analysis_data/
+*.db-shm
+*.db-wal

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ drafts.db.backup.*
 analysis_data/
 *.db-shm
 *.db-wal
+
+# Local analysis scratch (scripts + caches live outside version control)
+analysis/

--- a/alembic/versions/mtgowallet01_add_mtgo_accounts_and_wallet_tx.py
+++ b/alembic/versions/mtgowallet01_add_mtgo_accounts_and_wallet_tx.py
@@ -1,0 +1,87 @@
+"""add mtgo_accounts and wallet_tx tables
+
+Revision ID: mtgowallet01
+Revises: trophreguess0
+Create Date: 2026-08-03
+
+Adds the two tables backing the MTGO escrow/wallet feature:
+  * mtgo_accounts — Discord id <-> MTGO username identity link.
+  * wallet_tx     — append-only tix claim ledger (balance = SUM of 'done' rows).
+
+Both are also in Base.metadata, so the bot's init_db() create_all() would create them
+anyway; this migration keeps the alembic graph authoritative for prod (systemd runs
+`alembic upgrade head` before start). Each create is guarded by an existence check so the
+migration is a no-op if create_all() happened to run first on a given database — it can
+never fail prod's ExecStartPre with a "table already exists" error.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'mtgowallet01'
+down_revision: Union[str, Sequence[str], None] = 'trophreguess0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_table(name: str) -> bool:
+    return name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if not _has_table('mtgo_accounts'):
+        op.create_table(
+            'mtgo_accounts',
+            sa.Column('discord_user_id', sa.String(length=64), nullable=False),
+            sa.Column('mtgo_username', sa.String(length=128), nullable=False),
+            sa.Column('mtgo_username_lower', sa.String(length=128), nullable=False),
+            sa.Column('verified', sa.Boolean(), nullable=True),
+            sa.Column('linked_at', sa.DateTime(), nullable=True),
+            sa.Column('guild_id', sa.String(length=64), nullable=True),
+            sa.PrimaryKeyConstraint('discord_user_id'),
+        )
+        with op.batch_alter_table('mtgo_accounts', schema=None) as batch_op:
+            batch_op.create_index(
+                batch_op.f('ix_mtgo_accounts_mtgo_username_lower'),
+                ['mtgo_username_lower'], unique=True)
+
+    if not _has_table('wallet_tx'):
+        op.create_table(
+            'wallet_tx',
+            sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column('guild_id', sa.String(length=64), nullable=False),
+            sa.Column('player_id', sa.String(length=64), nullable=False),
+            sa.Column('kind', sa.String(length=32), nullable=False),
+            sa.Column('amount', sa.Integer(), nullable=False),
+            sa.Column('status', sa.String(length=16), nullable=False),
+            sa.Column('counterparty_id', sa.String(length=64), nullable=True),
+            sa.Column('job_id', sa.String(length=64), nullable=True),
+            sa.Column('source', sa.String(length=64), nullable=True),
+            sa.Column('notes', sa.String(length=256), nullable=True),
+            sa.Column('created_at', sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint('id'),
+        )
+        with op.batch_alter_table('wallet_tx', schema=None) as batch_op:
+            batch_op.create_index(
+                'ix_wallet_tx_balance_lookup', ['guild_id', 'player_id', 'status'], unique=False)
+            batch_op.create_index(batch_op.f('ix_wallet_tx_guild_id'), ['guild_id'], unique=False)
+            batch_op.create_index(batch_op.f('ix_wallet_tx_job_id'), ['job_id'], unique=False)
+            batch_op.create_index(batch_op.f('ix_wallet_tx_player_id'), ['player_id'], unique=False)
+
+
+def downgrade() -> None:
+    if _has_table('wallet_tx'):
+        with op.batch_alter_table('wallet_tx', schema=None) as batch_op:
+            batch_op.drop_index(batch_op.f('ix_wallet_tx_player_id'))
+            batch_op.drop_index(batch_op.f('ix_wallet_tx_job_id'))
+            batch_op.drop_index(batch_op.f('ix_wallet_tx_guild_id'))
+            batch_op.drop_index('ix_wallet_tx_balance_lookup')
+        op.drop_table('wallet_tx')
+
+    if _has_table('mtgo_accounts'):
+        with op.batch_alter_table('mtgo_accounts', schema=None) as batch_op:
+            batch_op.drop_index(batch_op.f('ix_mtgo_accounts_mtgo_username_lower'))
+        op.drop_table('mtgo_accounts')

--- a/alembic/versions/mtgowallet01_add_mtgo_accounts_and_wallet_tx.py
+++ b/alembic/versions/mtgowallet01_add_mtgo_accounts_and_wallet_tx.py
@@ -1,7 +1,7 @@
 """add mtgo_accounts and wallet_tx tables
 
 Revision ID: mtgowallet01
-Revises: trophreguess0
+Revises: dispnamefill0
 Create Date: 2026-08-03
 
 Adds the two tables backing the MTGO escrow/wallet feature:
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'mtgowallet01'
-down_revision: Union[str, Sequence[str], None] = 'trophreguess0'
+down_revision: Union[str, Sequence[str], None] = 'dispnamefill0'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/tourneyescr01_add_tournament_entry_fee_and_participant_escrow.py
+++ b/alembic/versions/tourneyescr01_add_tournament_entry_fee_and_participant_escrow.py
@@ -1,0 +1,64 @@
+"""add tournament entry_fee and participant escrow gate
+
+Revision ID: tourneyescr01
+Revises: mtgowallet01
+Create Date: 2026-08-03
+
+Adds escrow support to tournaments:
+  * tournaments.entry_fee            — tix entry fee (0 = free; grandfathers existing rows).
+  * tournament_participants.status   — 'paid' | 'pending' (server_default 'paid' so every
+                                       existing participant and every free tournament is
+                                       already complete; new paid registrations set 'pending').
+  * tournament_participants.escrow_tx_id — the captain's WalletTx reserve holding the fee.
+  * tournament_participants.paid_at  — when escrow was secured.
+
+Unlike the wallet tables, these are COLUMNS on existing tables, which the bot's init_db
+create_all() will NOT add — so this migration is load-bearing, not just bookkeeping. Each
+add is guarded by a column-existence check for idempotency.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'tourneyescr01'
+down_revision: Union[str, Sequence[str], None] = 'mtgowallet01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table: str) -> set:
+    return {c['name'] for c in sa.inspect(op.get_bind()).get_columns(table)}
+
+
+def upgrade() -> None:
+    tournament_cols = _columns('tournaments')
+    if 'entry_fee' not in tournament_cols:
+        op.add_column('tournaments', sa.Column(
+            'entry_fee', sa.Integer(), nullable=False, server_default=sa.text('0')))
+
+    participant_cols = _columns('tournament_participants')
+    if 'status' not in participant_cols:
+        op.add_column('tournament_participants', sa.Column(
+            'status', sa.String(length=16), nullable=False, server_default=sa.text("'paid'")))
+    if 'escrow_tx_id' not in participant_cols:
+        op.add_column('tournament_participants', sa.Column(
+            'escrow_tx_id', sa.Integer(), nullable=True))
+    if 'paid_at' not in participant_cols:
+        op.add_column('tournament_participants', sa.Column(
+            'paid_at', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    participant_cols = _columns('tournament_participants')
+    drop_participant = [c for c in ('paid_at', 'escrow_tx_id', 'status') if c in participant_cols]
+    if drop_participant:
+        with op.batch_alter_table('tournament_participants', schema=None) as batch_op:
+            for col in drop_participant:
+                batch_op.drop_column(col)
+
+    if 'entry_fee' in _columns('tournaments'):
+        with op.batch_alter_table('tournaments', schema=None) as batch_op:
+            batch_op.drop_column('entry_fee')

--- a/alembic/versions/tourneypay01_add_tournament_payout_structure.py
+++ b/alembic/versions/tourneypay01_add_tournament_payout_structure.py
@@ -1,0 +1,39 @@
+"""add tournament payout_structure
+
+Revision ID: tourneypay01
+Revises: tourneyescr01
+Create Date: 2026-08-03
+
+Adds tournaments.payout_structure — how the prize pool is split at payout
+('winner_take_all' | 'top2' | 'top3' | 'top4'), declared at creation. server_default
+'winner_take_all' grandfathers existing rows. A column on an existing table, so create_all
+won't add it — this migration is load-bearing. Column-existence guarded for idempotency.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'tourneypay01'
+down_revision: Union[str, Sequence[str], None] = 'tourneyescr01'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _columns(table: str) -> set:
+    return {c['name'] for c in sa.inspect(op.get_bind()).get_columns(table)}
+
+
+def upgrade() -> None:
+    if 'payout_structure' not in _columns('tournaments'):
+        op.add_column('tournaments', sa.Column(
+            'payout_structure', sa.String(length=32), nullable=False,
+            server_default=sa.text("'winner_take_all'")))
+
+
+def downgrade() -> None:
+    if 'payout_structure' in _columns('tournaments'):
+        with op.batch_alter_table('tournaments', schema=None) as batch_op:
+            batch_op.drop_column('payout_structure')

--- a/alembic/versions/walletsafety01_add_mtgo_jobs_and_wallet_tx_unique_guards.py
+++ b/alembic/versions/walletsafety01_add_mtgo_jobs_and_wallet_tx_unique_guards.py
@@ -1,0 +1,75 @@
+"""add mtgo_jobs table and wallet_tx idempotency unique indexes
+
+Durability + concurrency hardening for the money paths (from the escrow review):
+
+* ``mtgo_jobs`` — durable record of every started serve job, so a startup
+  resumer can finish booking trades that completed after a poll timeout or
+  across a bot restart.
+
+* Partial UNIQUE indexes on ``wallet_tx`` turn the app-level SELECT-then-insert
+  idempotency checks into database guarantees (concurrent duplicate handlers
+  now conflict instead of double-booking):
+    - one settled booking per (job_id, kind)         — deposit/withdraw credits
+    - one leg per (source, kind) for pay/receive     — internal pays, payouts,
+      prize reallocations (also kills duplicate prize credits from a racing
+      double /tournament start)
+    - one live escrow reserve per source             — concurrent registers
+
+Revision ID: walletsafety01
+Revises: tourneypay01
+Create Date: 2026-08-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'walletsafety01'
+down_revision = 'tourneypay01'
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name):
+    bind = op.get_bind()
+    return sa.inspect(bind).has_table(name)
+
+
+def upgrade():
+    if not _has_table('mtgo_jobs'):
+        op.create_table(
+            'mtgo_jobs',
+            sa.Column('job_id', sa.String(64), primary_key=True, nullable=False),
+            sa.Column('kind', sa.String(16), nullable=False),
+            sa.Column('guild_id', sa.String(64), nullable=False),
+            sa.Column('player_id', sa.String(64), nullable=False),
+            sa.Column('mtgo_user', sa.String(128), nullable=False),
+            sa.Column('amount', sa.Integer(), nullable=False),
+            sa.Column('reserve_tx_id', sa.Integer(), nullable=True),
+            sa.Column('context', sa.String(64), nullable=True),
+            sa.Column('status', sa.String(16), nullable=False, server_default='pending'),
+            sa.Column('created_at', sa.DateTime(), nullable=True),
+            sa.Column('resolved_at', sa.DateTime(), nullable=True),
+        )
+        op.create_index('ix_mtgo_jobs_status', 'mtgo_jobs', ['status'])
+
+    # Partial unique indexes (SQLite supports WHERE on CREATE INDEX).
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_tx_job_kind "
+        "ON wallet_tx (job_id, kind) WHERE job_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_tx_transfer_legs "
+        "ON wallet_tx (source, kind) "
+        "WHERE kind IN ('pay', 'receive') AND source IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_wallet_tx_live_escrow "
+        "ON wallet_tx (source) WHERE kind = 'escrow' AND status = 'pending'"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS uq_wallet_tx_live_escrow")
+    op.execute("DROP INDEX IF EXISTS uq_wallet_tx_transfer_legs")
+    op.execute("DROP INDEX IF EXISTS uq_wallet_tx_job_kind")
+    if _has_table('mtgo_jobs'):
+        op.drop_table('mtgo_jobs')

--- a/bot.py
+++ b/bot.py
@@ -93,6 +93,10 @@ async def main():
         await re_register_tournament_views(bot)
         from tournament_nudge import re_register_premade_nudges
         await re_register_premade_nudges(bot)
+        # Resume polling any MTGO serve jobs (deposits/withdraws) that were still
+        # pending at the last shutdown, so completed trades always get booked.
+        from services.mtgo_resolution_service import resume_pending_jobs
+        await resume_pending_jobs()
         logger.info("Re-registered team finder")
 
     @bot.event

--- a/bot.py
+++ b/bot.py
@@ -93,10 +93,11 @@ async def main():
         await re_register_tournament_views(bot)
         from tournament_nudge import re_register_premade_nudges
         await re_register_premade_nudges(bot)
-        # Resume polling any MTGO serve jobs (deposits/withdraws) that were still
-        # pending at the last shutdown, so completed trades always get booked.
-        from services.mtgo_resolution_service import resume_pending_jobs
-        await resume_pending_jobs()
+        # Watchdog for MTGO serve jobs (deposits/withdraws): re-polls anything still
+        # pending — at startup and every 10 min — so a trade that completes after a
+        # poll timeout or across a restart always gets booked eventually.
+        from services.mtgo_resolution_service import pending_jobs_watchdog
+        bot.loop.create_task(pending_jobs_watchdog())
         logger.info("Re-registered team finder")
 
     @bot.event

--- a/cogs/mtgo_link_cog.py
+++ b/cogs/mtgo_link_cog.py
@@ -24,6 +24,22 @@ class MtgoLinkCommands(commands.Cog):
         self.bot = bot
         logger.info("MTGO link commands cog loaded")
 
+    @staticmethod
+    async def _send_link_result(ctx, status, detail, subject: str, conflict_extra: str = ""):
+        """One response ladder for both the self-serve and admin link paths —
+        ``subject`` is who got linked ('your Discord account' / a mention)."""
+        if status == "empty":
+            await ctx.followup.send("Please provide an MTGO username.", ephemeral=True)
+        elif status == "conflict":
+            await ctx.followup.send(
+                f"That MTGO username is already linked to <@{detail}>.{conflict_extra}",
+                ephemeral=True,
+            )
+        else:
+            await ctx.followup.send(
+                f"Linked {subject} to MTGO username **{detail}**.", ephemeral=True
+            )
+
     @discord.slash_command(
         name="link_mtgo",
         description="Link your MTGO username so your draft match results can be auto-recorded",
@@ -32,18 +48,9 @@ class MtgoLinkCommands(commands.Cog):
         await ctx.defer(ephemeral=True)
         guild_id = ctx.guild.id if ctx.guild else None
         status, detail = await MtgoAccount.link(ctx.author.id, username, guild_id)
-        if status == "empty":
-            await ctx.followup.send("Please provide your MTGO username.", ephemeral=True)
-        elif status == "conflict":
-            await ctx.followup.send(
-                f"That MTGO username is already linked to <@{detail}>. "
-                f"If it's really yours, ask an admin to reassign it with `/link_mtgo_for`.",
-                ephemeral=True,
-            )
-        else:
-            await ctx.followup.send(
-                f"Linked your Discord account to MTGO username **{detail}**.", ephemeral=True
-            )
+        await self._send_link_result(
+            ctx, status, detail, "your Discord account",
+            conflict_extra=" If it's really yours, ask an admin to reassign it with `/link_mtgo_for`.")
 
     @discord.slash_command(
         name="mtgo_whoami",
@@ -83,16 +90,7 @@ class MtgoLinkCommands(commands.Cog):
         await ctx.defer(ephemeral=True)
         guild_id = ctx.guild.id if ctx.guild else None
         status, detail = await MtgoAccount.link(player.id, username, guild_id)
-        if status == "empty":
-            await ctx.followup.send("Please provide an MTGO username.", ephemeral=True)
-        elif status == "conflict":
-            await ctx.followup.send(
-                f"That MTGO username is already linked to <@{detail}>.", ephemeral=True
-            )
-        else:
-            await ctx.followup.send(
-                f"Linked <@{player.id}> to MTGO username **{detail}**.", ephemeral=True
-            )
+        await self._send_link_result(ctx, status, detail, f"<@{player.id}>")
 
 
 def setup(bot):

--- a/cogs/mtgo_link_cog.py
+++ b/cogs/mtgo_link_cog.py
@@ -1,0 +1,99 @@
+"""
+Link a Discord user to their MTGO username.
+
+This is the identity bridge for auto-reporting spectated MTGO match results back to
+DraftBot: a completed MTGO game only exposes MTGO usernames, so we must be able to
+resolve those to Discord ids before a result can be attributed to the right players.
+
+Commands:
+- /link_mtgo <username>            link (or update) your own MTGO account
+- /mtgo_whoami                     show your linked MTGO account
+- /unlink_mtgo                     remove your link
+- /link_mtgo_for @user <username>  (admin) link on a player's behalf — for backfill
+"""
+import discord
+from discord.ext import commands
+from loguru import logger
+
+from models.mtgo_account import MtgoAccount
+from helpers.permissions import has_bot_manager_role
+
+
+class MtgoLinkCommands(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        logger.info("MTGO link commands cog loaded")
+
+    @discord.slash_command(
+        name="link_mtgo",
+        description="Link your MTGO username so your draft match results can be auto-recorded",
+    )
+    async def link_mtgo(self, ctx, username: str):
+        await ctx.defer(ephemeral=True)
+        guild_id = ctx.guild.id if ctx.guild else None
+        status, detail = await MtgoAccount.link(ctx.author.id, username, guild_id)
+        if status == "empty":
+            await ctx.followup.send("Please provide your MTGO username.", ephemeral=True)
+        elif status == "conflict":
+            await ctx.followup.send(
+                f"That MTGO username is already linked to <@{detail}>. "
+                f"If it's really yours, ask an admin to reassign it with `/link_mtgo_for`.",
+                ephemeral=True,
+            )
+        else:
+            await ctx.followup.send(
+                f"Linked your Discord account to MTGO username **{detail}**.", ephemeral=True
+            )
+
+    @discord.slash_command(
+        name="mtgo_whoami",
+        description="Show which MTGO username is linked to your Discord account",
+    )
+    async def mtgo_whoami(self, ctx):
+        await ctx.defer(ephemeral=True)
+        row = await MtgoAccount.get_for_discord(ctx.author.id)
+        if row is None:
+            await ctx.followup.send(
+                "You haven't linked an MTGO username yet. Use `/link_mtgo <username>`.",
+                ephemeral=True,
+            )
+        else:
+            await ctx.followup.send(
+                f"Your linked MTGO username is **{row.mtgo_username}**.", ephemeral=True
+            )
+
+    @discord.slash_command(
+        name="unlink_mtgo",
+        description="Remove the MTGO username linked to your Discord account",
+    )
+    async def unlink_mtgo(self, ctx):
+        await ctx.defer(ephemeral=True)
+        removed = await MtgoAccount.unlink(ctx.author.id)
+        await ctx.followup.send(
+            "Removed your MTGO link." if removed else "You had no MTGO link to remove.",
+            ephemeral=True,
+        )
+
+    @discord.slash_command(
+        name="link_mtgo_for",
+        description="(Admin) Link a player's MTGO username on their behalf",
+    )
+    @has_bot_manager_role()
+    async def link_mtgo_for(self, ctx, player: discord.Member, username: str):
+        await ctx.defer(ephemeral=True)
+        guild_id = ctx.guild.id if ctx.guild else None
+        status, detail = await MtgoAccount.link(player.id, username, guild_id)
+        if status == "empty":
+            await ctx.followup.send("Please provide an MTGO username.", ephemeral=True)
+        elif status == "conflict":
+            await ctx.followup.send(
+                f"That MTGO username is already linked to <@{detail}>.", ephemeral=True
+            )
+        else:
+            await ctx.followup.send(
+                f"Linked <@{player.id}> to MTGO username **{detail}**.", ephemeral=True
+            )
+
+
+def setup(bot):
+    bot.add_cog(MtgoLinkCommands(bot))

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -167,6 +167,106 @@ async def re_register_tournament_views(bot):
     logger.info(f"Re-registered {len(matches)} tournament play buttons")
 
 
+_PLACE_MEDALS = {1: "🥇", 2: "🥈", 3: "🥉"}
+
+
+def _format_payout_lines(allocations):
+    """Render [(place, captain_id, team_name, amount)] as medal-prefixed payout lines."""
+    return "\n".join(
+        f"{_PLACE_MEDALS.get(place, f'{place}.')} <@{cap}> (**{name}**) — **{amt} tix**"
+        for place, cap, name, amt in allocations
+    )
+
+
+class PayoutConfirmView(discord.ui.View):
+    """Final confirmation before disbursing a prize pool. Mirrors SettlementConfirmView:
+    invoker-only, 120s timeout, double-click guarded. Disburses only on Confirm; the actual
+    transfer (escrow.execute_payout) is idempotent, so a race can't double-pay."""
+
+    def __init__(self, guild_id, tournament_id, t_name, pool, struct, allocations, author_id):
+        super().__init__(timeout=120)
+        self.guild_id = guild_id
+        self.tournament_id = tournament_id
+        self.t_name = t_name
+        self.pool = pool
+        self.struct = struct
+        self.allocations = allocations
+        self.author_id = str(author_id)
+        self.message = None
+        self._processing = False
+
+    async def interaction_check(self, interaction):
+        if str(interaction.user.id) != self.author_id:
+            await interaction.response.send_message(
+                "Only the admin who started this payout can confirm it.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="Confirm payout", style=discord.ButtonStyle.success, emoji="🏦")
+    async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if self._processing:
+            await interaction.response.send_message("Payout is already processing…", ephemeral=True)
+            return
+        self._processing = True
+        await interaction.response.defer()
+        for item in self.children:
+            item.disabled = True
+        try:
+            res = await escrow.execute_payout(self.guild_id, self.tournament_id, self.allocations)
+            if not res.get("ok"):
+                self._processing = False
+                for item in self.children:
+                    item.disabled = False
+                await interaction.edit_original_response(
+                    content=f"❌ Payout failed: {res.get('error')}", view=self)
+                return
+            if res.get("already_paid"):
+                await interaction.edit_original_response(
+                    content=f"**{self.t_name}** was already paid out.", embed=None, view=None)
+                self.stop()
+                return
+            await interaction.edit_original_response(
+                content=f"✅ Paid out **{res['total']} tix** for **{self.t_name}**.", embed=None, view=None)
+            announcement = (
+                f"🏦 **{self.t_name}** — prize pool of **{self.pool} tix** paid out "
+                f"(*{escrow.describe_structure(self.struct)}*):\n{_format_payout_lines(self.allocations)}\n"
+                f"Winners can `/wallet withdraw` to MTGO or `/wallet pay` teammates."
+            )
+            try:
+                await interaction.channel.send(announcement)
+            except Exception as e:
+                logger.warning(f"[PayoutConfirm] public announcement failed: {e}")
+            logger.info(f"Tournament {self.tournament_id} paid out {res['total']} tix by {interaction.user.id}")
+            self.stop()
+        except Exception as e:
+            logger.error(f"[PayoutConfirm] execute failed: {e}")
+            self._processing = False
+            for item in self.children:
+                item.disabled = False
+            try:
+                await interaction.edit_original_response(content=f"❌ Payout error: {e}", view=self)
+            except Exception:
+                pass
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
+        if self._processing:
+            await interaction.response.send_message("Payout is processing, can't cancel now.", ephemeral=True)
+            return
+        await interaction.response.edit_message(content="Payout cancelled.", embed=None, view=None)
+        self.stop()
+
+    async def on_timeout(self):
+        for item in self.children:
+            item.disabled = True
+        if self.message is not None:
+            try:
+                await self.message.edit(content="Payout confirmation expired — run `/tournament payout` again.",
+                                        embed=None, view=None)
+            except Exception:
+                pass
+
+
 class TournamentCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -580,17 +680,22 @@ class TournamentCog(commands.Cog):
             if fee > 0:
                 pool = await escrow.prize_pool(str(ctx.guild.id), tournament_id)
                 if pool > 0 and not await escrow.is_paid_out(tournament_id):
-                    payout_hint = f"\n🏦 Prize pool: **{pool} tix** — run `/tournament payout` to distribute it."
-            await ctx.followup.send(f"🏁 **{tournament_name}** is complete! {champ_text}{payout_hint}")
+                    payout_hint = (f"\n🏦 Prize pool: **{pool} tix** — run `/tournament payout` "
+                                   f"(this tournament is #{tournament_id}) to distribute it.")
+            await ctx.followup.send(f"🏁 **{tournament_name}** (#{tournament_id}) is complete! {champ_text}{payout_hint}")
             await update_standings_message(self.bot, tournament_id)
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
 
-    @tournament.command(name="payout", description="Admin: distribute the prize pool to the winners")
+    @tournament.command(name="payout", description="Admin: distribute a tournament's prize pool to the winners")
     @has_bot_manager_role()
     async def payout(
         self,
         ctx,
+        tournament_id: discord.Option(
+            int, "Which tournament to pay out (defaults to the most recently finished)",
+            required=False, default=None
+        ),
         structure: discord.Option(
             str, "Override the declared payout split",
             choices=["winner_take_all", "top2", "top3", "top4"], required=False, default=None
@@ -598,12 +703,25 @@ class TournamentCog(commands.Cog):
     ):
         if not await self._check_enabled(ctx):
             return
-        await ctx.defer()
+        await ctx.defer(ephemeral=True)
         async with db_session() as session:
-            tournament = await get_latest_completed_tournament(session, ctx.guild.id)
-            if tournament is None:
-                await ctx.followup.send("There is no completed tournament to pay out.", ephemeral=True)
-                return
+            if tournament_id is not None:
+                tournament = await session.get(Tournament, tournament_id)
+                if tournament is None or str(tournament.guild_id) != str(ctx.guild.id):
+                    await ctx.followup.send(f"No tournament #{tournament_id} in this server.", ephemeral=True)
+                    return
+                if tournament.status != "completed":
+                    await ctx.followup.send(
+                        f"**{tournament.name}** is {tournament.status}, not completed — only a "
+                        f"finished tournament can be paid out.", ephemeral=True)
+                    return
+            else:
+                tournament = await get_latest_completed_tournament(session, ctx.guild.id)
+                if tournament is None:
+                    await ctx.followup.send(
+                        "There is no completed tournament to pay out. Pass a `tournament_id` to target one.",
+                        ephemeral=True)
+                    return
             t_id, t_name = tournament.id, tournament.name
             fee = tournament.entry_fee or 0
             struct = structure or tournament.payout_structure or "winner_take_all"
@@ -615,7 +733,7 @@ class TournamentCog(commands.Cog):
             await ctx.followup.send(f"**{t_name}** had no entry fee — nothing to pay out.", ephemeral=True)
             return
         if await escrow.is_paid_out(t_id):
-            await ctx.followup.send(f"**{t_name}** has already been paid out.", ephemeral=True)
+            await ctx.followup.send(f"**{t_name}** (#{t_id}) has already been paid out.", ephemeral=True)
             return
         pool = await escrow.prize_pool(str(ctx.guild.id), t_id)
         if pool <= 0:
@@ -623,28 +741,21 @@ class TournamentCog(commands.Cog):
             return
         allocations = escrow.compute_allocations(pool, struct, ranked)
         if not allocations:
-            await ctx.followup.send("No eligible winners to pay.", ephemeral=True)
+            await ctx.followup.send("No eligible (paid) winners to pay.", ephemeral=True)
             return
 
-        res = await escrow.execute_payout(str(ctx.guild.id), t_id, allocations)
-        if not res.get("ok"):
-            await ctx.followup.send(f"❌ Payout failed: {res.get('error')}", ephemeral=True)
-            return
-        if res.get("already_paid"):
-            await ctx.followup.send(f"**{t_name}** was already paid out.", ephemeral=True)
-            return
-
-        medals = {1: "🥇", 2: "🥈", 3: "🥉"}
-        lines = "\n".join(
-            f"{medals.get(place, f'{place}.')} <@{cap}> (**{name}**) — **{amt} tix**"
-            for place, cap, name, amt in allocations
+        # Preview + require confirmation before disbursing real value.
+        embed = discord.Embed(
+            title=f"Confirm payout — {t_name} (#{t_id})",
+            description=(
+                f"Prize pool: **{pool} tix** · Split: **{escrow.describe_structure(struct)}**\n\n"
+                f"{_format_payout_lines(allocations)}\n\n"
+                f"This credits real tix to the winners' wallets and can't be undone."),
+            color=discord.Color.gold(),
         )
-        logger.info(f"Tournament {t_id} paid out {res['total']} tix in guild {ctx.guild.id} by {ctx.author.id}")
-        await ctx.followup.send(
-            f"🏦 **{t_name}** — prize pool of **{pool} tix** paid out "
-            f"(*{escrow.describe_structure(struct)}*):\n{lines}\n"
-            f"Winners can `/wallet withdraw` to MTGO or `/wallet pay` teammates."
-        )
+        view = PayoutConfirmView(
+            str(ctx.guild.id), t_id, t_name, pool, struct, allocations, ctx.author.id)
+        view.message = await ctx.followup.send(embed=embed, view=view, ephemeral=True)
 
     @tournament.command(name="next_round", description="Admin: pair the next Swiss round (all results must be in)")
     @has_bot_manager_role()

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -491,9 +491,17 @@ class TournamentCog(commands.Cog):
                     return
                 tournament_id = tournament.id
                 tournament_name = tournament.name
+                fee = tournament.entry_fee or 0
                 await start_tournament(session, tournament.id, random.Random())
+                # Reallocate held escrow into the prize wallet in the SAME transaction, so
+                # seeding and the pot move commit together (or neither does).
+                pot = 0
+                if fee > 0:
+                    pot = (await escrow.reallocate_to_prize(
+                        session, str(ctx.guild.id), tournament_id))["moved"]
             logger.info(f"Tournament {tournament_id} started in guild {ctx.guild.id} by {ctx.author.id}")
-            await ctx.followup.send(f"🏆 **{tournament_name}** has started!")
+            pot_line = f" 🏦 Prize pool: **{pot} tix**." if fee > 0 else ""
+            await ctx.followup.send(f"🏆 **{tournament_name}** has started!{pot_line}")
             await self._post_schedule(ctx, tournament_id)
             await self._post_standings(ctx, tournament_id)
         except ValueError as e:
@@ -738,6 +746,7 @@ class TournamentCog(commands.Cog):
             return
         await ctx.defer()
         registration = False
+        active_fee = 0
         async with db_session() as session:
             tournament = await get_active_tournament(session, ctx.guild.id)
             if tournament is None:
@@ -752,9 +761,14 @@ class TournamentCog(commands.Cog):
             else:
                 participants = await get_standings_data(session, tournament.id)
                 embed = create_standings_embed(tournament, participants)
+                active_fee = tournament.entry_fee or 0
+                active_id = tournament.id
         if registration:
             held = await escrow.total_escrowed(str(ctx.guild.id), t_id) if fee > 0 else 0
             embed = self._registration_embed(t_name, t_status, parts, fee, held)
+        elif active_fee > 0:
+            pool = await escrow.prize_pool(str(ctx.guild.id), active_id)
+            embed.add_field(name="🏦 Prize pool", value=f"{pool} tix", inline=False)
         await ctx.followup.send(embed=embed)
 
     def _registration_embed(self, name, status, parts, fee=0, held=0):

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -1,10 +1,11 @@
+import asyncio
 import random
 
 import discord
 from discord.ext import commands
 from loguru import logger
 
-from config import get_config, update_setting
+from config import get_config, update_setting, is_money_server
 from database.db_session import db_session
 from helpers.permissions import has_bot_manager_role
 from models.tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
@@ -20,10 +21,16 @@ from services.tournament_service import (
     get_standings_data,
     list_participants,
     register_team,
-    remove_team,
     set_result,
     start_tournament,
 )
+from models.mtgo_account import MtgoAccount
+from services.mtgo_tradebot_client import get_client, EVENT_TICKET
+from services import mtgo_resolution_service as resolution
+from services import tournament_escrow_service as escrow
+
+# Serve-side readiness wait (minutes) for a captain's escrow deposit before the job fails.
+ESCROW_WAIT_MINUTES = 10
 
 
 def tournament_enabled(guild_id):
@@ -172,6 +179,24 @@ class TournamentCog(commands.Cog):
         await ctx.respond("Tournaments are not enabled on this server.", ephemeral=True)
         return False
 
+    # ---- escrow helpers (entry-fee tournaments) ----
+    def _escrow_gate(self, ctx):
+        """What's required to collect a tix entry fee. Returns an error string, or None."""
+        if not is_money_server(str(ctx.guild.id)):
+            return "Entry fees need a money-enabled server."
+        if not get_client().enabled:
+            return ("The MTGO TradeBot integration isn't configured on this bot "
+                    "(set MTGO_TRADEBOT_URL and MTGO_TRADEBOT_TOKEN).")
+        return None
+
+    async def _linked_username(self, discord_id):
+        acct = await MtgoAccount.get_for_discord(discord_id)
+        return acct.mtgo_username if acct else None
+
+    async def _custodian(self):
+        health = await get_client().health()
+        return (health or {}).get("custodian") or "the custodian bot"
+
     @tournament.command(name="enable", description="Admin: enable tournament commands on this server")
     @has_bot_manager_role()
     async def enable(self, ctx):
@@ -200,6 +225,9 @@ class TournamentCog(commands.Cog):
             int, "Number of Swiss rounds (Swiss only)", min_value=1, max_value=20,
             required=False, default=None,
         ),
+        entry_fee: discord.Option(
+            int, "Per-team entry fee in tix (0 = free)", min_value=0, default=0
+        ),
     ):
         if not await self._check_enabled(ctx):
             return
@@ -207,18 +235,28 @@ class TournamentCog(commands.Cog):
         if format == "swiss" and rounds is None:
             await ctx.followup.send("❌ Swiss tournaments need a `rounds` count.", ephemeral=True)
             return
+        if entry_fee > 0:
+            gate = self._escrow_gate(ctx)
+            if gate:
+                await ctx.followup.send(f"❌ Can't charge an entry fee here: {gate}", ephemeral=True)
+                return
         # Round-robin/manual derive their round count from the schedule at start.
         total_rounds = rounds if format == "swiss" else 0
         try:
             async with db_session() as session:
                 tournament = await create_tournament(
-                    session, ctx.guild.id, name, total_rounds, format=format
+                    session, ctx.guild.id, name, total_rounds, format=format, entry_fee=entry_fee
                 )
             logger.info(f"Tournament '{name}' ({format}) created in guild {ctx.guild.id} by {ctx.author.id}")
             detail = f"{tournament.total_rounds} rounds" if format == "swiss" else format.replace("_", "-")
+            fee_line = (
+                f" Entry fee: **{entry_fee} {EVENT_TICKET}(s)** per team — a team is registered "
+                f"once its captain's escrow is received."
+                if entry_fee > 0 else ""
+            )
             await ctx.followup.send(
                 f"✅ Tournament **{tournament.name}** created ({detail}). "
-                f"Registration is open — captains can join with `/tournament register`.",
+                f"Registration is open — captains can join with `/tournament register`.{fee_line}",
                 ephemeral=True,
             )
         except ValueError as e:
@@ -233,32 +271,123 @@ class TournamentCog(commands.Cog):
         if not await self._check_enabled(ctx):
             return
         await ctx.defer()
+
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
+                return
+            t_id, t_name, fee = tournament.id, tournament.name, (tournament.entry_fee or 0)
+
+        guild_id = str(ctx.guild.id)
+        captain_id = str(ctx.author.id)
+
+        # A paid tournament needs the money stack + the captain's MTGO link BEFORE we create
+        # anything, so we never leave a pending row that can't be paid.
+        captain_user = None
+        if fee > 0:
+            gate = self._escrow_gate(ctx)
+            if gate:
+                await ctx.followup.send(f"❌ {gate}", ephemeral=True)
+                return
+            captain_user = await self._linked_username(ctx.author.id)
+            if not captain_user:
+                await ctx.followup.send(
+                    "Link your MTGO account first with `/link_mtgo <username>`, then register.",
+                    ephemeral=True)
+                return
+
+        # Create (or find) the participant.
         try:
             async with db_session() as session:
-                tournament = await get_active_tournament(session, ctx.guild.id)
-                if tournament is None:
-                    await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
-                    return
-                participant, created = await register_team(
-                    session, tournament.id, team, ctx.author.id
-                )
-            if created:
-                logger.info(
-                    f"Team '{participant.team_name}' registered for tournament {tournament.id} "
-                    f"by {ctx.author.id} in guild {ctx.guild.id}"
-                )
-                await ctx.followup.send(
-                    f"✅ **{participant.team_name}** is registered for **{tournament.name}** "
-                    f"with {ctx.author.mention} as captain."
-                )
-            else:
-                await ctx.followup.send(
-                    f"**{participant.team_name}** is already registered for **{tournament.name}** "
-                    f"(captain: <@{participant.captain_user_id}>).",
-                    ephemeral=True,
-                )
+                participant, created = await register_team(session, t_id, team, ctx.author.id)
+                p_id, p_name = participant.id, participant.team_name
+                p_status, p_captain = participant.status, participant.captain_user_id
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
+            return
+
+        # Free tournament: registration is complete on creation (existing behavior).
+        if fee == 0:
+            if created:
+                logger.info(f"Team '{p_name}' registered for tournament {t_id} by {ctx.author.id}")
+                await ctx.followup.send(
+                    f"✅ **{p_name}** is registered for **{t_name}** with {ctx.author.mention} as captain.")
+            else:
+                await ctx.followup.send(
+                    f"**{p_name}** is already registered for **{t_name}** (captain: <@{p_captain}>).",
+                    ephemeral=True)
+            return
+
+        # Paid tournament.
+        if p_status == "paid":
+            await ctx.followup.send(
+                f"**{p_name}** is already registered and paid for **{t_name}**.", ephemeral=True)
+            return
+        # Escrow is paid from the captain's wallet, so only the captain can complete it.
+        if captain_id != p_captain:
+            await ctx.followup.send(
+                f"**{p_name}** is registered (pending). Only its captain <@{p_captain}> can "
+                f"complete the **{fee}-tix** escrow.", ephemeral=True)
+            return
+
+        # Try to hold the fee from the captain's wallet right away.
+        res = await escrow.secure_from_wallet(guild_id, captain_id, p_id, t_id, fee, p_name)
+        if res.get("done"):
+            await ctx.followup.send(
+                f"✅ **{p_name}** is registered for **{t_name}** — **{fee} {EVENT_TICKET}(s)** held "
+                f"from your wallet. You're in.")
+            return
+        if not res.get("ok"):
+            await ctx.followup.send(
+                f"⚠️ **{p_name}** is registered but I couldn't hold the escrow: {res.get('error')}. "
+                f"Try `/tournament register` again.", ephemeral=True)
+            return
+
+        # Wallet short — deposit the difference, then hold the full fee (in the background).
+        deficit = res["deficit"]
+        started = await resolution.start_deposit(
+            captain_user, deficit, commit=True, wait_minutes=ESCROW_WAIT_MINUTES)
+        if not started.get("ok"):
+            await ctx.followup.send(
+                f"⚠️ **{p_name}** is registered (pending) but I couldn't start your deposit: "
+                f"{started.get('error')}. Try again once the vault is reachable.", ephemeral=True)
+            return
+
+        job_id = started["job_id"]
+        custodian = await self._custodian()
+        have = res.get("available", 0)
+        await ctx.followup.send(
+            f"**{p_name}** is registered (pending). To finish, deposit **{deficit} "
+            f"{EVENT_TICKET}(s)** to `{custodian}` in MTGO and accept the trade. "
+            f"(You have {have} in your wallet; the fee is {fee}.) I'll confirm here.\n"
+            f"_Job `{job_id}` — you have ~{ESCROW_WAIT_MINUTES} min._", ephemeral=True)
+
+        async def _finish():
+            try:
+                dep = await resolution.finish_deposit(job_id, guild_id, captain_id, deficit, captain_user)
+                if not dep.get("ok"):
+                    if dep.get("outcome") == "pending":
+                        msg = (f"⏳ Your deposit for **{p_name}** is still pending; registration will "
+                               f"complete once it lands.")
+                    else:
+                        msg = (f"❌ Deposit for **{p_name}** failed: {dep.get('error')}. Registration "
+                               f"not completed — run `/tournament register` to retry.")
+                    await ctx.followup.send(msg, ephemeral=True)
+                    return
+                res2 = await escrow.secure_from_wallet(guild_id, captain_id, p_id, t_id, fee, p_name)
+                if res2.get("done"):
+                    await ctx.followup.send(
+                        f"✅ Escrow received — **{p_name}** is fully registered for **{t_name}**. You're in.")
+                else:
+                    await ctx.followup.send(
+                        f"⚠️ Your deposit landed but the escrow couldn't be held "
+                        f"({res2.get('error') or 'insufficient funds'}). Run `/tournament register` again.",
+                        ephemeral=True)
+            except Exception as e:
+                logger.warning(f"tournament escrow follow-up failed: {e}")
+
+        asyncio.create_task(_finish())
 
     @tournament.command(name="add_team", description="Admin: register a team on a captain's behalf")
     @has_bot_manager_role()
@@ -278,13 +407,21 @@ class TournamentCog(commands.Cog):
                     await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
                     return
                 participant, created = await register_team(session, tournament.id, team, captain.id)
-            verb = "registered" if created else "already registered"
-            await ctx.followup.send(
-                f"✅ **{participant.team_name}** {verb} with {captain.mention} as captain.",
-                ephemeral=True,
-            )
+                # Admin add is a comp: mark it paid (no escrow) so it's seed-eligible even in
+                # a paid tournament. The captain isn't billed.
+                comped = participant.status != "paid"
+                if comped:
+                    participant.status = "paid"
+                p_name = participant.team_name
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
+            return
+        verb = "registered" if created else "already registered"
+        note = " (entry fee comped)" if comped else ""
+        await ctx.followup.send(
+            f"✅ **{p_name}** {verb} with {captain.mention} as captain{note}.",
+            ephemeral=True,
+        )
 
     @tournament.command(name="remove_team", description="Admin: remove a team during registration")
     @has_bot_manager_role()
@@ -296,16 +433,21 @@ class TournamentCog(commands.Cog):
         if not await self._check_enabled(ctx):
             return
         await ctx.defer(ephemeral=True)
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no active tournament.", ephemeral=True)
+                return
+            t_id = tournament.id
         try:
-            async with db_session() as session:
-                tournament = await get_active_tournament(session, ctx.guild.id)
-                if tournament is None:
-                    await ctx.followup.send("There is no active tournament.", ephemeral=True)
-                    return
-                participant = await remove_team(session, tournament.id, team)
-            await ctx.followup.send(f"✅ **{participant.team_name}** removed.", ephemeral=True)
+            # Atomic: delete the participant and release its escrow hold together.
+            res = await escrow.drop_with_refund(t_id, team)
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
+            return
+        refunded = res.get("refunded", 0)
+        note = f" Entry fee ({refunded} tix) refunded to the captain's wallet." if refunded else ""
+        await ctx.followup.send(f"✅ **{res['team_name']}** removed.{note}", ephemeral=True)
 
     @tournament.command(name="add_match", description="Admin: author a match for a manual-format tournament")
     @has_bot_manager_role()
@@ -595,6 +737,7 @@ class TournamentCog(commands.Cog):
         if not await self._check_enabled(ctx):
             return
         await ctx.defer()
+        registration = False
         async with db_session() as session:
             tournament = await get_active_tournament(session, ctx.guild.id)
             if tournament is None:
@@ -602,24 +745,35 @@ class TournamentCog(commands.Cog):
                 return
             if tournament.status == "registration":
                 participants = await list_participants(session, tournament.id)
-                embed = self._registration_embed(tournament, participants)
+                registration = True
+                t_id, t_name, t_status = tournament.id, tournament.name, tournament.status
+                fee = tournament.entry_fee or 0
+                parts = [(p.team_name, p.captain_user_id, p.status) for p in participants]
             else:
                 participants = await get_standings_data(session, tournament.id)
                 embed = create_standings_embed(tournament, participants)
+        if registration:
+            held = await escrow.total_escrowed(str(ctx.guild.id), t_id) if fee > 0 else 0
+            embed = self._registration_embed(t_name, t_status, parts, fee, held)
         await ctx.followup.send(embed=embed)
 
-    def _registration_embed(self, tournament, participants):
-        embed = discord.Embed(
-            title=f"🏆 {tournament.name}",
-            description=f"**Status:** {tournament.status.title()}",
-            color=discord.Color.gold(),
-        )
-        if participants:
+    def _registration_embed(self, name, status, parts, fee=0, held=0):
+        desc = f"**Status:** {status.title()}"
+        if fee > 0:
+            desc += f"\n**Entry fee:** {fee} tix/team · **Escrow held:** {held} tix"
+        embed = discord.Embed(title=f"🏆 {name}", description=desc, color=discord.Color.gold())
+        if parts:
             teams = "\n".join(
-                f"{i}. **{p.team_name}** — captain <@{p.captain_user_id}>"
-                for i, p in enumerate(participants, start=1)
+                f"{i}. {'✅' if st == 'paid' else '⏳'} **{tn}** — captain <@{cap}>"
+                + ("" if st == "paid" else " *(pending escrow)*")
+                for i, (tn, cap, st) in enumerate(parts, start=1)
             )
-            embed.add_field(name=f"Teams ({len(participants)})", value=teams, inline=False)
+            if fee > 0:
+                paid_n = sum(1 for _, _, st in parts if st == "paid")
+                label = f"Teams ({paid_n}/{len(parts)} paid)"
+            else:
+                label = f"Teams ({len(parts)})"
+            embed.add_field(name=label, value=teams, inline=False)
         else:
             embed.add_field(
                 name="Teams (0)",

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -18,6 +18,7 @@ from services.tournament_service import (
     finish_tournament,
     find_current_match,
     get_active_tournament,
+    get_latest_completed_tournament,
     get_standings_data,
     list_participants,
     register_team,
@@ -228,6 +229,10 @@ class TournamentCog(commands.Cog):
         entry_fee: discord.Option(
             int, "Per-team entry fee in tix (0 = free)", min_value=0, default=0
         ),
+        payout: discord.Option(
+            str, "Prize-pool split for entry-fee tournaments",
+            choices=["winner_take_all", "top2", "top3", "top4"], default="winner_take_all"
+        ),
     ):
         if not await self._check_enabled(ctx):
             return
@@ -245,13 +250,14 @@ class TournamentCog(commands.Cog):
         try:
             async with db_session() as session:
                 tournament = await create_tournament(
-                    session, ctx.guild.id, name, total_rounds, format=format, entry_fee=entry_fee
+                    session, ctx.guild.id, name, total_rounds, format=format,
+                    entry_fee=entry_fee, payout_structure=payout
                 )
             logger.info(f"Tournament '{name}' ({format}) created in guild {ctx.guild.id} by {ctx.author.id}")
             detail = f"{tournament.total_rounds} rounds" if format == "swiss" else format.replace("_", "-")
             fee_line = (
                 f" Entry fee: **{entry_fee} {EVENT_TICKET}(s)** per team — a team is registered "
-                f"once its captain's escrow is received."
+                f"once its captain's escrow is received. Payout: **{escrow.describe_structure(payout)}**."
                 if entry_fee > 0 else ""
             )
             await ctx.followup.send(
@@ -566,13 +572,79 @@ class TournamentCog(commands.Cog):
                     return
                 tournament_id = tournament.id
                 tournament_name = tournament.name
+                fee = tournament.entry_fee or 0
                 champion = await finish_tournament(session, tournament.id)
             champ_text = f"Champion: **{champion.team_name}** 🏆" if champion else "No teams competed."
             logger.info(f"Tournament {tournament_id} finished in guild {ctx.guild.id} by {ctx.author.id}")
-            await ctx.followup.send(f"🏁 **{tournament_name}** is complete! {champ_text}")
+            payout_hint = ""
+            if fee > 0:
+                pool = await escrow.prize_pool(str(ctx.guild.id), tournament_id)
+                if pool > 0 and not await escrow.is_paid_out(tournament_id):
+                    payout_hint = f"\n🏦 Prize pool: **{pool} tix** — run `/tournament payout` to distribute it."
+            await ctx.followup.send(f"🏁 **{tournament_name}** is complete! {champ_text}{payout_hint}")
             await update_standings_message(self.bot, tournament_id)
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
+
+    @tournament.command(name="payout", description="Admin: distribute the prize pool to the winners")
+    @has_bot_manager_role()
+    async def payout(
+        self,
+        ctx,
+        structure: discord.Option(
+            str, "Override the declared payout split",
+            choices=["winner_take_all", "top2", "top3", "top4"], required=False, default=None
+        ),
+    ):
+        if not await self._check_enabled(ctx):
+            return
+        await ctx.defer()
+        async with db_session() as session:
+            tournament = await get_latest_completed_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no completed tournament to pay out.", ephemeral=True)
+                return
+            t_id, t_name = tournament.id, tournament.name
+            fee = tournament.entry_fee or 0
+            struct = structure or tournament.payout_structure or "winner_take_all"
+            standings = await get_standings_data(session, tournament.id)
+            # Only teams that actually completed registration can win the pot.
+            ranked = [(p.captain_user_id, p.team_name) for p in standings if p.status == "paid"]
+
+        if fee <= 0:
+            await ctx.followup.send(f"**{t_name}** had no entry fee — nothing to pay out.", ephemeral=True)
+            return
+        if await escrow.is_paid_out(t_id):
+            await ctx.followup.send(f"**{t_name}** has already been paid out.", ephemeral=True)
+            return
+        pool = await escrow.prize_pool(str(ctx.guild.id), t_id)
+        if pool <= 0:
+            await ctx.followup.send(f"**{t_name}** has no prize pool to distribute.", ephemeral=True)
+            return
+        allocations = escrow.compute_allocations(pool, struct, ranked)
+        if not allocations:
+            await ctx.followup.send("No eligible winners to pay.", ephemeral=True)
+            return
+
+        res = await escrow.execute_payout(str(ctx.guild.id), t_id, allocations)
+        if not res.get("ok"):
+            await ctx.followup.send(f"❌ Payout failed: {res.get('error')}", ephemeral=True)
+            return
+        if res.get("already_paid"):
+            await ctx.followup.send(f"**{t_name}** was already paid out.", ephemeral=True)
+            return
+
+        medals = {1: "🥇", 2: "🥈", 3: "🥉"}
+        lines = "\n".join(
+            f"{medals.get(place, f'{place}.')} <@{cap}> (**{name}**) — **{amt} tix**"
+            for place, cap, name, amt in allocations
+        )
+        logger.info(f"Tournament {t_id} paid out {res['total']} tix in guild {ctx.guild.id} by {ctx.author.id}")
+        await ctx.followup.send(
+            f"🏦 **{t_name}** — prize pool of **{pool} tix** paid out "
+            f"(*{escrow.describe_structure(struct)}*):\n{lines}\n"
+            f"Winners can `/wallet withdraw` to MTGO or `/wallet pay` teammates."
+        )
 
     @tournament.command(name="next_round", description="Admin: pair the next Swiss round (all results must be in)")
     @has_bot_manager_role()
@@ -757,6 +829,7 @@ class TournamentCog(commands.Cog):
                 registration = True
                 t_id, t_name, t_status = tournament.id, tournament.name, tournament.status
                 fee = tournament.entry_fee or 0
+                payout_struct = tournament.payout_structure or "winner_take_all"
                 parts = [(p.team_name, p.captain_user_id, p.status) for p in participants]
             else:
                 participants = await get_standings_data(session, tournament.id)
@@ -765,16 +838,18 @@ class TournamentCog(commands.Cog):
                 active_id = tournament.id
         if registration:
             held = await escrow.total_escrowed(str(ctx.guild.id), t_id) if fee > 0 else 0
-            embed = self._registration_embed(t_name, t_status, parts, fee, held)
+            embed = self._registration_embed(t_name, t_status, parts, fee, held, payout_struct)
         elif active_fee > 0:
             pool = await escrow.prize_pool(str(ctx.guild.id), active_id)
             embed.add_field(name="🏦 Prize pool", value=f"{pool} tix", inline=False)
         await ctx.followup.send(embed=embed)
 
-    def _registration_embed(self, name, status, parts, fee=0, held=0):
+    def _registration_embed(self, name, status, parts, fee=0, held=0, payout_struct=None):
         desc = f"**Status:** {status.title()}"
         if fee > 0:
             desc += f"\n**Entry fee:** {fee} tix/team · **Escrow held:** {held} tix"
+            if payout_struct:
+                desc += f"\n**Payout:** {escrow.describe_structure(payout_struct)}"
         embed = discord.Embed(title=f"🏆 {name}", description=desc, color=discord.Color.gold())
         if parts:
             teams = "\n".join(

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -14,6 +14,7 @@ from services.tournament_formatter import create_standings_embed, update_standin
 from services.tournament_service import (
     advance_round,
     add_match,
+    count_unreported_matches,
     create_tournament,
     finish_tournament,
     find_current_match,
@@ -728,6 +729,8 @@ class TournamentCog(commands.Cog):
             standings = await get_standings_data(session, tournament.id)
             # Only teams that actually completed registration can win the pot.
             ranked = [(p.captain_user_id, p.team_name) for p in standings if p.status == "paid"]
+            # A tournament can be finished early with results still missing — warn before paying.
+            unreported = await count_unreported_matches(session, tournament.id)
 
         if fee <= 0:
             await ctx.followup.send(f"**{t_name}** had no entry fee — nothing to pay out.", ephemeral=True)
@@ -745,13 +748,19 @@ class TournamentCog(commands.Cog):
             return
 
         # Preview + require confirmation before disbursing real value.
+        warning = ""
+        if unreported > 0:
+            warning = (f"\n\n⚠️ **{unreported} match(es) still unreported** — these count as 0–0, so "
+                       f"standings may not be final. Report the results first unless you're finishing "
+                       f"intentionally.")
         embed = discord.Embed(
             title=f"Confirm payout — {t_name} (#{t_id})",
             description=(
                 f"Prize pool: **{pool} tix** · Split: **{escrow.describe_structure(struct)}**\n\n"
-                f"{_format_payout_lines(allocations)}\n\n"
+                f"{_format_payout_lines(allocations)}"
+                f"{warning}\n\n"
                 f"This credits real tix to the winners' wallets and can't be undone."),
-            color=discord.Color.gold(),
+            color=discord.Color.orange() if unreported > 0 else discord.Color.gold(),
         )
         view = PayoutConfirmView(
             str(ctx.guild.id), t_id, t_name, pool, struct, allocations, ctx.author.id)

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -32,6 +32,7 @@ from services.tournament_service import (
 from services.mtgo_tradebot_client import EVENT_TICKET
 from services import mtgo_resolution_service as resolution
 from services import tournament_escrow_service as escrow
+from services import wallet_service
 
 
 def tournament_enabled(guild_id):
@@ -435,9 +436,12 @@ class TournamentCog(commands.Cog):
             return
 
         # Wallet short — deposit the difference, then hold the full fee (in the background).
+        # The context tag lets the startup resumer re-secure this escrow if the bot
+        # restarts while the trade is still open.
         deficit = res["deficit"]
         started = await resolution.start_deposit(
-            captain_user, deficit, commit=True, wait_minutes=ESCROW_WAIT_MINUTES)
+            guild_id, captain_id, captain_user, deficit, commit=True,
+            wait_minutes=ESCROW_WAIT_MINUTES, context=f"tourney:{t_id}:{p_id}")
         if not started.get("ok"):
             await ctx.followup.send(
                 f"⚠️ **{p_name}** is registered (pending) but I couldn't start your deposit: "
@@ -497,14 +501,13 @@ class TournamentCog(commands.Cog):
                     await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
                     return
                 participant, created = await register_team(session, tournament.id, team, captain.id)
-                comped = participant.status != "paid"
+                # Admin add is a comp: paid with no escrow, so it's seed-eligible even in a
+                # paid tournament. Same transaction as the registration, so a crash can't
+                # leave the team registered-but-pending. The captain isn't billed.
+                comped = escrow.comp(participant)
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
             return
-        if comped:
-            # Admin add is a comp: paid with no escrow, so it's seed-eligible even in a
-            # paid tournament. The captain isn't billed (and the pot stays smaller).
-            await escrow.comp(participant.id)
         verb = "registered" if created else "already registered"
         note = " (entry fee comped)" if comped else ""
         await ctx.followup.send(
@@ -573,21 +576,29 @@ class TournamentCog(commands.Cog):
             return
         await ctx.defer()
         try:
-            async with db_session() as session:
-                tournament = await get_active_tournament(session, ctx.guild.id)
-                if tournament is None:
-                    await ctx.followup.send("There is no tournament to start.", ephemeral=True)
-                    return
-                tournament_id = tournament.id
-                tournament_name = tournament.name
-                fee = tournament.entry_fee or 0
-                await start_tournament(session, tournament.id, random.Random())
-                # Reallocate held escrow into the prize wallet in the SAME transaction, so
-                # seeding and the pot move commit together (or neither does).
-                pot = 0
-                if fee > 0:
-                    pot = (await escrow.reallocate_to_prize(
-                        session, str(ctx.guild.id), tournament_id))["moved"]
+            # MONEY_LOCK serializes concurrent starts: without it, two racing /tournament
+            # start calls could both reallocate escrow into the prize wallet (the unique
+            # transfer-leg index would catch the money, but the lock stops the race cold).
+            async with wallet_service.MONEY_LOCK:
+                async with db_session() as session:
+                    tournament = await get_active_tournament(session, ctx.guild.id)
+                    if tournament is None:
+                        await ctx.followup.send("There is no tournament to start.", ephemeral=True)
+                        return
+                    if tournament.status != "registration":
+                        await ctx.followup.send(
+                            f"**{tournament.name}** has already started.", ephemeral=True)
+                        return
+                    tournament_id = tournament.id
+                    tournament_name = tournament.name
+                    fee = tournament.entry_fee or 0
+                    await start_tournament(session, tournament.id, random.Random())
+                    # Reallocate held escrow into the prize wallet in the SAME transaction,
+                    # so seeding and the pot move commit together (or neither does).
+                    pot = 0
+                    if fee > 0:
+                        pot = (await escrow.reallocate_to_prize(
+                            session, str(ctx.guild.id), tournament_id))["moved"]
             logger.info(f"Tournament {tournament_id} started in guild {ctx.guild.id} by {ctx.author.id}")
             pot_line = f" 🏦 Prize pool: **{pot} tix**." if fee > 0 else ""
             await ctx.followup.send(f"🏆 **{tournament_name}** has started!{pot_line}")

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -27,12 +27,10 @@ from services.tournament_service import (
     list_participants,
     register_team,
     set_result,
-    start_tournament,
 )
 from services.mtgo_tradebot_client import EVENT_TICKET
 from services import mtgo_resolution_service as resolution
 from services import tournament_escrow_service as escrow
-from services import wallet_service
 
 
 def tournament_enabled(guild_id):
@@ -441,7 +439,7 @@ class TournamentCog(commands.Cog):
         deficit = res["deficit"]
         started = await resolution.start_deposit(
             guild_id, captain_id, captain_user, deficit, commit=True,
-            wait_minutes=ESCROW_WAIT_MINUTES, context=f"tourney:{t_id}:{p_id}")
+            wait_minutes=ESCROW_WAIT_MINUTES, context=escrow.escrow_source(t_id, p_id))
         if not started.get("ok"):
             await ctx.followup.send(
                 f"⚠️ **{p_name}** is registered (pending) but I couldn't start your deposit: "
@@ -471,10 +469,14 @@ class TournamentCog(commands.Cog):
                            f"not completed — run `/tournament register` to retry.")
                 await followup.send(msg, ephemeral=True)
                 return
-            res2 = await escrow.secure_from_wallet(guild_id, captain_id, p_id, t_id, fee, p_name)
+            res2 = await escrow.complete_entry_after_deposit(guild_id, captain_id, t_id, p_id)
             if res2.get("done"):
                 await followup.send(
                     f"✅ Escrow received — **{p_name}** is fully registered for **{t_name}**. You're in.")
+            elif res2.get("skipped"):
+                await followup.send(
+                    f"✅ Deposit received. **{p_name}** needed no further escrow action "
+                    f"(already paid, or the entry changed).", ephemeral=True)
             else:
                 await followup.send(
                     f"⚠️ Your deposit landed but the escrow couldn't be held "
@@ -576,32 +578,12 @@ class TournamentCog(commands.Cog):
             return
         await ctx.defer()
         try:
-            # MONEY_LOCK serializes concurrent starts: without it, two racing /tournament
-            # start calls could both reallocate escrow into the prize wallet (the unique
-            # transfer-leg index would catch the money, but the lock stops the race cold).
-            async with wallet_service.MONEY_LOCK:
-                async with db_session() as session:
-                    tournament = await get_active_tournament(session, ctx.guild.id)
-                    if tournament is None:
-                        await ctx.followup.send("There is no tournament to start.", ephemeral=True)
-                        return
-                    if tournament.status != "registration":
-                        await ctx.followup.send(
-                            f"**{tournament.name}** has already started.", ephemeral=True)
-                        return
-                    tournament_id = tournament.id
-                    tournament_name = tournament.name
-                    fee = tournament.entry_fee or 0
-                    await start_tournament(session, tournament.id, random.Random())
-                    # Reallocate held escrow into the prize wallet in the SAME transaction,
-                    # so seeding and the pot move commit together (or neither does).
-                    pot = 0
-                    if fee > 0:
-                        pot = (await escrow.reallocate_to_prize(
-                            session, str(ctx.guild.id), tournament_id))["moved"]
+            # start_and_fund owns the money lock + atomic seed-and-reallocate.
+            res = await escrow.start_and_fund(ctx.guild.id, random.Random())
+            tournament_id = res["tournament_id"]
             logger.info(f"Tournament {tournament_id} started in guild {ctx.guild.id} by {ctx.author.id}")
-            pot_line = f" 🏦 Prize pool: **{pot} tix**." if fee > 0 else ""
-            await ctx.followup.send(f"🏆 **{tournament_name}** has started!{pot_line}")
+            pot_line = f" 🏦 Prize pool: **{res['pot']} tix**." if res["fee"] > 0 else ""
+            await ctx.followup.send(f"🏆 **{res['name']}** has started!{pot_line}")
             await self._post_schedule(ctx, tournament_id)
             await self._post_standings(ctx, tournament_id)
         except ValueError as e:

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -1,12 +1,15 @@
-import asyncio
 import random
 
 import discord
 from discord.ext import commands
 from loguru import logger
 
-from config import get_config, update_setting, is_money_server
+from config import get_config, update_setting
 from database.db_session import db_session
+from helpers.money_gate import (
+    DEFAULT_WAIT_MINUTES as ESCROW_WAIT_MINUTES,
+    custodian_name, gate_serve, linked_username, spawn_followup,
+)
 from helpers.permissions import has_bot_manager_role
 from models.tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
 from sqlalchemy import or_, select
@@ -26,13 +29,9 @@ from services.tournament_service import (
     set_result,
     start_tournament,
 )
-from models.mtgo_account import MtgoAccount
-from services.mtgo_tradebot_client import get_client, EVENT_TICKET
+from services.mtgo_tradebot_client import EVENT_TICKET
 from services import mtgo_resolution_service as resolution
 from services import tournament_escrow_service as escrow
-
-# Serve-side readiness wait (minutes) for a captain's escrow deposit before the job fails.
-ESCROW_WAIT_MINUTES = 10
 
 
 def tournament_enabled(guild_id):
@@ -203,6 +202,19 @@ class PayoutConfirmView(discord.ui.View):
             return False
         return True
 
+    def _set_buttons(self, disabled: bool):
+        for item in self.children:
+            item.disabled = disabled
+
+    async def _fail(self, interaction, msg: str):
+        """Re-arm the view and surface the error so the admin can retry."""
+        self._processing = False
+        self._set_buttons(False)
+        try:
+            await interaction.edit_original_response(content=msg, view=self)
+        except Exception:
+            pass
+
     @discord.ui.button(label="Confirm payout", style=discord.ButtonStyle.success, emoji="🏦")
     async def confirm(self, button: discord.ui.Button, interaction: discord.Interaction):
         if self._processing:
@@ -210,44 +222,34 @@ class PayoutConfirmView(discord.ui.View):
             return
         self._processing = True
         await interaction.response.defer()
-        for item in self.children:
-            item.disabled = True
+        self._set_buttons(True)
         try:
             res = await escrow.execute_payout(self.guild_id, self.tournament_id, self.allocations)
-            if not res.get("ok"):
-                self._processing = False
-                for item in self.children:
-                    item.disabled = False
-                await interaction.edit_original_response(
-                    content=f"❌ Payout failed: {res.get('error')}", view=self)
-                return
-            if res.get("already_paid"):
-                await interaction.edit_original_response(
-                    content=f"**{self.t_name}** was already paid out.", embed=None, view=None)
-                self.stop()
-                return
-            await interaction.edit_original_response(
-                content=f"✅ Paid out **{res['total']} tix** for **{self.t_name}**.", embed=None, view=None)
-            announcement = (
-                f"🏦 **{self.t_name}** — prize pool of **{self.pool} tix** paid out "
-                f"(*{escrow.describe_structure(self.struct)}*):\n{_format_payout_lines(self.allocations)}\n"
-                f"Winners can `/wallet withdraw` to MTGO or `/wallet pay` teammates."
-            )
-            try:
-                await interaction.channel.send(announcement)
-            except Exception as e:
-                logger.warning(f"[PayoutConfirm] public announcement failed: {e}")
-            logger.info(f"Tournament {self.tournament_id} paid out {res['total']} tix by {interaction.user.id}")
-            self.stop()
         except Exception as e:
             logger.error(f"[PayoutConfirm] execute failed: {e}")
-            self._processing = False
-            for item in self.children:
-                item.disabled = False
-            try:
-                await interaction.edit_original_response(content=f"❌ Payout error: {e}", view=self)
-            except Exception:
-                pass
+            await self._fail(interaction, f"❌ Payout error: {e}")
+            return
+        if not res.get("ok"):
+            await self._fail(interaction, f"❌ Payout failed: {res.get('error')}")
+            return
+        if res.get("already_paid"):
+            await interaction.edit_original_response(
+                content=f"**{self.t_name}** was already paid out.", embed=None, view=None)
+            self.stop()
+            return
+        await interaction.edit_original_response(
+            content=f"✅ Paid out **{res['total']} tix** for **{self.t_name}**.", embed=None, view=None)
+        announcement = (
+            f"🏦 **{self.t_name}** — prize pool of **{self.pool} tix** paid out "
+            f"(*{escrow.describe_structure(self.struct)}*):\n{_format_payout_lines(self.allocations)}\n"
+            f"Winners can `/wallet withdraw` to MTGO or `/wallet pay` teammates."
+        )
+        try:
+            await interaction.channel.send(announcement)
+        except Exception as e:
+            logger.warning(f"[PayoutConfirm] public announcement failed: {e}")
+        logger.info(f"Tournament {self.tournament_id} paid out {res['total']} tix by {interaction.user.id}")
+        self.stop()
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
     async def cancel(self, button: discord.ui.Button, interaction: discord.Interaction):
@@ -258,8 +260,7 @@ class PayoutConfirmView(discord.ui.View):
         self.stop()
 
     async def on_timeout(self):
-        for item in self.children:
-            item.disabled = True
+        self._set_buttons(True)
         if self.message is not None:
             try:
                 await self.message.edit(content="Payout confirmation expired — run `/tournament payout` again.",
@@ -280,24 +281,6 @@ class TournamentCog(commands.Cog):
             return True
         await ctx.respond("Tournaments are not enabled on this server.", ephemeral=True)
         return False
-
-    # ---- escrow helpers (entry-fee tournaments) ----
-    def _escrow_gate(self, ctx):
-        """What's required to collect a tix entry fee. Returns an error string, or None."""
-        if not is_money_server(str(ctx.guild.id)):
-            return "Entry fees need a money-enabled server."
-        if not get_client().enabled:
-            return ("The MTGO TradeBot integration isn't configured on this bot "
-                    "(set MTGO_TRADEBOT_URL and MTGO_TRADEBOT_TOKEN).")
-        return None
-
-    async def _linked_username(self, discord_id):
-        acct = await MtgoAccount.get_for_discord(discord_id)
-        return acct.mtgo_username if acct else None
-
-    async def _custodian(self):
-        health = await get_client().health()
-        return (health or {}).get("custodian") or "the custodian bot"
 
     @tournament.command(name="enable", description="Admin: enable tournament commands on this server")
     @has_bot_manager_role()
@@ -332,7 +315,7 @@ class TournamentCog(commands.Cog):
         ),
         payout: discord.Option(
             str, "Prize-pool split for entry-fee tournaments",
-            choices=["winner_take_all", "top2", "top3", "top4"], default="winner_take_all"
+            choices=list(escrow.PAYOUT_STRUCTURES), default="winner_take_all"
         ),
     ):
         if not await self._check_enabled(ctx):
@@ -342,7 +325,7 @@ class TournamentCog(commands.Cog):
             await ctx.followup.send("❌ Swiss tournaments need a `rounds` count.", ephemeral=True)
             return
         if entry_fee > 0:
-            gate = self._escrow_gate(ctx)
+            gate = gate_serve(ctx)
             if gate:
                 await ctx.followup.send(f"❌ Can't charge an entry fee here: {gate}", ephemeral=True)
                 return
@@ -381,10 +364,10 @@ class TournamentCog(commands.Cog):
 
         async with db_session() as session:
             tournament = await get_active_tournament(session, ctx.guild.id)
-            if tournament is None:
-                await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
-                return
-            t_id, t_name, fee = tournament.id, tournament.name, (tournament.entry_fee or 0)
+        if tournament is None:
+            await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
+            return
+        t_id, t_name, fee = tournament.id, tournament.name, (tournament.entry_fee or 0)
 
         guild_id = str(ctx.guild.id)
         captain_id = str(ctx.author.id)
@@ -393,11 +376,11 @@ class TournamentCog(commands.Cog):
         # anything, so we never leave a pending row that can't be paid.
         captain_user = None
         if fee > 0:
-            gate = self._escrow_gate(ctx)
+            gate = gate_serve(ctx)
             if gate:
                 await ctx.followup.send(f"❌ {gate}", ephemeral=True)
                 return
-            captain_user = await self._linked_username(ctx.author.id)
+            captain_user = await linked_username(ctx.author.id)
             if not captain_user:
                 await ctx.followup.send(
                     "Link your MTGO account first with `/link_mtgo <username>`, then register.",
@@ -408,11 +391,10 @@ class TournamentCog(commands.Cog):
         try:
             async with db_session() as session:
                 participant, created = await register_team(session, t_id, team, ctx.author.id)
-                p_id, p_name = participant.id, participant.team_name
-                p_status, p_captain = participant.status, participant.captain_user_id
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
             return
+        p_id, p_name = participant.id, participant.team_name
 
         # Free tournament: registration is complete on creation (existing behavior).
         if fee == 0:
@@ -422,20 +404,21 @@ class TournamentCog(commands.Cog):
                     f"✅ **{p_name}** is registered for **{t_name}** with {ctx.author.mention} as captain.")
             else:
                 await ctx.followup.send(
-                    f"**{p_name}** is already registered for **{t_name}** (captain: <@{p_captain}>).",
-                    ephemeral=True)
+                    f"**{p_name}** is already registered for **{t_name}** "
+                    f"(captain: <@{participant.captain_user_id}>).", ephemeral=True)
             return
 
         # Paid tournament.
-        if p_status == "paid":
+        if participant.status == "paid":
             await ctx.followup.send(
                 f"**{p_name}** is already registered and paid for **{t_name}**.", ephemeral=True)
             return
         # Escrow is paid from the captain's wallet, so only the captain can complete it.
-        if captain_id != p_captain:
+        if captain_id != participant.captain_user_id:
             await ctx.followup.send(
-                f"**{p_name}** is registered (pending). Only its captain <@{p_captain}> can "
-                f"complete the **{fee}-tix** escrow.", ephemeral=True)
+                f"**{p_name}** is registered (pending). Only its captain "
+                f"<@{participant.captain_user_id}> can complete the **{fee}-tix** escrow.",
+                ephemeral=True)
             return
 
         # Try to hold the fee from the captain's wallet right away.
@@ -462,7 +445,7 @@ class TournamentCog(commands.Cog):
             return
 
         job_id = started["job_id"]
-        custodian = await self._custodian()
+        custodian = await custodian_name()
         have = res.get("available", 0)
         await ctx.followup.send(
             f"**{p_name}** is registered (pending). To finish, deposit **{deficit} "
@@ -470,31 +453,31 @@ class TournamentCog(commands.Cog):
             f"(You have {have} in your wallet; the fee is {fee}.) I'll confirm here.\n"
             f"_Job `{job_id}` — you have ~{ESCROW_WAIT_MINUTES} min._", ephemeral=True)
 
-        async def _finish():
-            try:
-                dep = await resolution.finish_deposit(job_id, guild_id, captain_id, deficit, captain_user)
-                if not dep.get("ok"):
-                    if dep.get("outcome") == "pending":
-                        msg = (f"⏳ Your deposit for **{p_name}** is still pending; registration will "
-                               f"complete once it lands.")
-                    else:
-                        msg = (f"❌ Deposit for **{p_name}** failed: {dep.get('error')}. Registration "
-                               f"not completed — run `/tournament register` to retry.")
-                    await ctx.followup.send(msg, ephemeral=True)
-                    return
-                res2 = await escrow.secure_from_wallet(guild_id, captain_id, p_id, t_id, fee, p_name)
-                if res2.get("done"):
-                    await ctx.followup.send(
-                        f"✅ Escrow received — **{p_name}** is fully registered for **{t_name}**. You're in.")
-                else:
-                    await ctx.followup.send(
-                        f"⚠️ Your deposit landed but the escrow couldn't be held "
-                        f"({res2.get('error') or 'insufficient funds'}). Run `/tournament register` again.",
-                        ephemeral=True)
-            except Exception as e:
-                logger.warning(f"tournament escrow follow-up failed: {e}")
+        # capture only what the poller needs (not ctx) — this task can live for ~14 min
+        followup = ctx.followup
 
-        asyncio.create_task(_finish())
+        async def _finish():
+            dep = await resolution.finish_deposit(job_id, guild_id, captain_id, deficit, captain_user)
+            if not dep.get("ok"):
+                if dep.get("outcome") == "pending":
+                    msg = (f"⏳ Your deposit for **{p_name}** is still pending; registration will "
+                           f"complete once it lands.")
+                else:
+                    msg = (f"❌ Deposit for **{p_name}** failed: {dep.get('error')}. Registration "
+                           f"not completed — run `/tournament register` to retry.")
+                await followup.send(msg, ephemeral=True)
+                return
+            res2 = await escrow.secure_from_wallet(guild_id, captain_id, p_id, t_id, fee, p_name)
+            if res2.get("done"):
+                await followup.send(
+                    f"✅ Escrow received — **{p_name}** is fully registered for **{t_name}**. You're in.")
+            else:
+                await followup.send(
+                    f"⚠️ Your deposit landed but the escrow couldn't be held "
+                    f"({res2.get('error') or 'insufficient funds'}). Run `/tournament register` again.",
+                    ephemeral=True)
+
+        spawn_followup("tournament escrow", _finish())
 
     @tournament.command(name="add_team", description="Admin: register a team on a captain's behalf")
     @has_bot_manager_role()
@@ -514,19 +497,18 @@ class TournamentCog(commands.Cog):
                     await ctx.followup.send("There is no tournament accepting registrations right now.", ephemeral=True)
                     return
                 participant, created = await register_team(session, tournament.id, team, captain.id)
-                # Admin add is a comp: mark it paid (no escrow) so it's seed-eligible even in
-                # a paid tournament. The captain isn't billed.
                 comped = participant.status != "paid"
-                if comped:
-                    participant.status = "paid"
-                p_name = participant.team_name
         except ValueError as e:
             await ctx.followup.send(f"❌ {e}", ephemeral=True)
             return
+        if comped:
+            # Admin add is a comp: paid with no escrow, so it's seed-eligible even in a
+            # paid tournament. The captain isn't billed (and the pot stays smaller).
+            await escrow.comp(participant.id)
         verb = "registered" if created else "already registered"
         note = " (entry fee comped)" if comped else ""
         await ctx.followup.send(
-            f"✅ **{p_name}** {verb} with {captain.mention} as captain{note}.",
+            f"✅ **{participant.team_name}** {verb} with {captain.mention} as captain{note}.",
             ephemeral=True,
         )
 
@@ -699,7 +681,7 @@ class TournamentCog(commands.Cog):
         ),
         structure: discord.Option(
             str, "Override the declared payout split",
-            choices=["winner_take_all", "top2", "top3", "top4"], required=False, default=None
+            choices=list(escrow.PAYOUT_STRUCTURES), required=False, default=None
         ),
     ):
         if not await self._check_enabled(ctx):
@@ -937,8 +919,7 @@ class TournamentCog(commands.Cog):
         if not await self._check_enabled(ctx):
             return
         await ctx.defer()
-        registration = False
-        active_fee = 0
+        # expire_on_commit=False lets the ORM objects be read after the session closes.
         async with db_session() as session:
             tournament = await get_active_tournament(session, ctx.guild.id)
             if tournament is None:
@@ -946,42 +927,38 @@ class TournamentCog(commands.Cog):
                 return
             if tournament.status == "registration":
                 participants = await list_participants(session, tournament.id)
-                registration = True
-                t_id, t_name, t_status = tournament.id, tournament.name, tournament.status
-                fee = tournament.entry_fee or 0
-                payout_struct = tournament.payout_structure or "winner_take_all"
-                parts = [(p.team_name, p.captain_user_id, p.status) for p in participants]
             else:
                 participants = await get_standings_data(session, tournament.id)
-                embed = create_standings_embed(tournament, participants)
-                active_fee = tournament.entry_fee or 0
-                active_id = tournament.id
-        if registration:
-            held = await escrow.total_escrowed(str(ctx.guild.id), t_id) if fee > 0 else 0
-            embed = self._registration_embed(t_name, t_status, parts, fee, held, payout_struct)
-        elif active_fee > 0:
-            pool = await escrow.prize_pool(str(ctx.guild.id), active_id)
-            embed.add_field(name="🏦 Prize pool", value=f"{pool} tix", inline=False)
+
+        fee = tournament.entry_fee or 0
+        if tournament.status == "registration":
+            held = await escrow.total_escrowed(str(ctx.guild.id), tournament.id) if fee > 0 else 0
+            embed = self._registration_embed(tournament, participants, held)
+        else:
+            embed = create_standings_embed(tournament, participants)
+            if fee > 0:
+                pool = await escrow.prize_pool(str(ctx.guild.id), tournament.id)
+                embed.add_field(name="🏦 Prize pool", value=f"{pool} tix", inline=False)
         await ctx.followup.send(embed=embed)
 
-    def _registration_embed(self, name, status, parts, fee=0, held=0, payout_struct=None):
-        desc = f"**Status:** {status.title()}"
+    def _registration_embed(self, tournament, participants, held=0):
+        fee = tournament.entry_fee or 0
+        desc = f"**Status:** {tournament.status.title()}"
         if fee > 0:
             desc += f"\n**Entry fee:** {fee} tix/team · **Escrow held:** {held} tix"
-            if payout_struct:
-                desc += f"\n**Payout:** {escrow.describe_structure(payout_struct)}"
-        embed = discord.Embed(title=f"🏆 {name}", description=desc, color=discord.Color.gold())
-        if parts:
+            desc += f"\n**Payout:** {escrow.describe_structure(tournament.payout_structure or 'winner_take_all')}"
+        embed = discord.Embed(title=f"🏆 {tournament.name}", description=desc, color=discord.Color.gold())
+        if participants:
             teams = "\n".join(
-                f"{i}. {'✅' if st == 'paid' else '⏳'} **{tn}** — captain <@{cap}>"
-                + ("" if st == "paid" else " *(pending escrow)*")
-                for i, (tn, cap, st) in enumerate(parts, start=1)
+                f"{i}. {'✅' if p.status == 'paid' else '⏳'} **{p.team_name}** — captain <@{p.captain_user_id}>"
+                + ("" if p.status == "paid" else " *(pending escrow)*")
+                for i, p in enumerate(participants, start=1)
             )
             if fee > 0:
-                paid_n = sum(1 for _, _, st in parts if st == "paid")
-                label = f"Teams ({paid_n}/{len(parts)} paid)"
+                paid_n = sum(1 for p in participants if p.status == "paid")
+                label = f"Teams ({paid_n}/{len(participants)} paid)"
             else:
-                label = f"Teams ({len(parts)})"
+                label = f"Teams ({len(participants)})"
             embed.add_field(name=label, value=teams, inline=False)
         else:
             embed.add_field(

--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -1,0 +1,265 @@
+"""
+Tix wallet slash commands — the player-facing face of the MTGO escrow/wallet system.
+
+Commands (all under /wallet):
+- /wallet [player]        show a wallet: balance / reserved / available + recent activity
+- /wallet deposit <n>     hand tix to the custodian (an MTGO trade) -> wallet +n
+- /wallet withdraw <n>    take tix out of the custodian (an MTGO trade) -> wallet -n
+- /wallet pay @player <n> send tix to another player's wallet (internal, no trade)
+- /wallet reconcile       (admin) audit: physical vault tix == SUM of all wallets
+
+Gating: enabled only on money servers with the TradeBot integration configured
+(MTGO_TRADEBOT_URL + _TOKEN). Deposits/withdraws require the caller to have linked their
+MTGO account (`/link_mtgo`); pay requires both parties linked so the tix stay usable.
+
+The serve runs deposits/withdraws as async jobs. A command enqueues, replies immediately
+with in-client instructions, then a background task polls the job to a terminal state and
+posts the outcome — the ledger is only ever written on a completed trade. The serve's own
+--commit arm state remains the master safety switch for whether a trade actually fires.
+"""
+import asyncio
+
+import discord
+from discord.ext import commands
+from discord.commands import SlashCommandGroup, option
+from loguru import logger
+
+from config import is_money_server
+from models.mtgo_account import MtgoAccount
+from services import wallet_service
+from services import mtgo_resolution_service as resolution
+from services.mtgo_tradebot_client import get_client, EVENT_TICKET
+from helpers.permissions import has_bot_manager_role
+
+# Serve-side readiness wait (minutes) for a deposit/withdraw trade before the job fails and
+# any reservation is released. Bounds how long a player has to accept the in-client trade.
+DEFAULT_WAIT_MINUTES = 10
+
+
+class WalletCommands(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        logger.info("Wallet commands cog loaded")
+
+    wallet = SlashCommandGroup("wallet", "Manage your MTGO tix wallet")
+
+    # ----- gating helpers -----
+    def _serve_enabled(self) -> bool:
+        return get_client().enabled
+
+    def _gate_read(self, ctx) -> str | None:
+        """Wallet must be a money server. Returns an error string, or None if allowed."""
+        if not ctx.guild:
+            return "Wallet commands can only be used in a server."
+        if not is_money_server(str(ctx.guild.id)):
+            return "The tix wallet is only available on money-enabled servers."
+        return None
+
+    def _gate_serve(self, ctx) -> str | None:
+        """Read gate + the TradeBot integration must be configured."""
+        err = self._gate_read(ctx)
+        if err:
+            return err
+        if not self._serve_enabled():
+            return ("The MTGO TradeBot integration isn't configured on this bot "
+                    "(set MTGO_TRADEBOT_URL and MTGO_TRADEBOT_TOKEN).")
+        return None
+
+    async def _linked_username(self, discord_id) -> str | None:
+        acct = await MtgoAccount.get_for_discord(discord_id)
+        return acct.mtgo_username if acct else None
+
+    async def _custodian(self) -> str:
+        health = await get_client().health()
+        return (health or {}).get("custodian") or "the custodian bot"
+
+    # ----- /wallet [player] -----
+    @wallet.command(name="show", description="Show a tix wallet balance and recent activity")
+    @option("player", discord.Member, description="Whose wallet to show (defaults to you)", required=False)
+    async def wallet_show(self, ctx: discord.ApplicationContext, player: discord.Member = None):
+        await ctx.defer(ephemeral=True)
+        err = self._gate_read(ctx)
+        if err:
+            return await ctx.followup.send(err, ephemeral=True)
+
+        guild_id = str(ctx.guild.id)
+        target = player or ctx.author
+        w = await wallet_service.get_wallet(guild_id, str(target.id))
+        history = await wallet_service.get_history(guild_id, str(target.id), limit=10)
+
+        embed = discord.Embed(
+            title=f"{target.display_name}'s Tix Wallet", color=discord.Color.gold())
+        embed.add_field(name="Balance", value=f"**{w.balance}** tix", inline=True)
+        if w.reserved:
+            embed.add_field(name="Reserved", value=f"{w.reserved} tix (withdraw in flight)", inline=True)
+            embed.add_field(name="Available", value=f"**{w.available}** tix", inline=True)
+
+        if history:
+            lines = []
+            for tx in history:
+                sign = "+" if tx.amount >= 0 else "−"
+                tag = f" ({tx.status})" if tx.status != "done" else ""
+                # counterparty is a Discord id (all-digits) for internal pay/receive; an MTGO
+                # username for deposit/withdraw — only mention the former.
+                who = f" ↔ <@{tx.counterparty_id}>" if tx.counterparty_id and tx.counterparty_id.isdigit() else ""
+                lines.append(f"`{sign}{abs(tx.amount)}` {tx.kind}{tag}{who}")
+            embed.add_field(name="Recent activity", value="\n".join(lines), inline=False)
+        else:
+            embed.set_footer(text="No wallet activity yet.")
+
+        await ctx.followup.send(embed=embed, ephemeral=True)
+
+    # ----- /wallet deposit <n> -----
+    @wallet.command(name="deposit", description="Deposit tix into your wallet (trade them to the custodian)")
+    @option("amount", int, description="How many tix to deposit", min_value=1)
+    async def wallet_deposit(self, ctx: discord.ApplicationContext, amount: int):
+        await ctx.defer(ephemeral=True)
+        err = self._gate_serve(ctx)
+        if err:
+            return await ctx.followup.send(err, ephemeral=True)
+        username = await self._linked_username(ctx.author.id)
+        if not username:
+            return await ctx.followup.send(
+                "Link your MTGO account first with `/link_mtgo <username>`.", ephemeral=True)
+
+        guild_id = str(ctx.guild.id)
+        player_id = str(ctx.author.id)
+        started = await resolution.start_deposit(
+            username, amount, commit=True, wait_minutes=DEFAULT_WAIT_MINUTES)
+        if not started.get("ok"):
+            return await ctx.followup.send(
+                f"Couldn't start the deposit: {started.get('error')}", ephemeral=True)
+
+        job_id = started["job_id"]
+        custodian = await self._custodian()
+        await ctx.followup.send(
+            f"**Deposit started.** In MTGO, trade **{amount} {EVENT_TICKET}(s)** to "
+            f"`{custodian}` and accept when the trade window pops. I'll confirm here once it "
+            f"lands.\n_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
+
+        async def _finish():
+            try:
+                res = await resolution.finish_deposit(job_id, guild_id, player_id, amount, username)
+                if res.get("ok"):
+                    bal = await wallet_service.get_balance(guild_id, player_id)
+                    drawn = await resolution.auto_draw(guild_id, player_id)
+                    msg = f"✅ Deposit confirmed: **+{amount} tix**. Balance: **{bal} tix**."
+                    if drawn:
+                        total = sum(d.get("amount", 0) for d in drawn)
+                        msg += f" Auto-applied **{total} tix** to {len(drawn)} debt(s)."
+                elif res.get("outcome") == "pending":
+                    msg = (f"⏳ Deposit `{job_id}` is still pending — it'll credit automatically "
+                           f"once the trade completes.")
+                else:
+                    msg = f"❌ Deposit `{job_id}` failed: {res.get('error')}"
+                await ctx.followup.send(msg, ephemeral=True)
+            except Exception as e:
+                logger.warning(f"wallet deposit follow-up failed: {e}")
+
+        asyncio.create_task(_finish())
+
+    # ----- /wallet withdraw <n> -----
+    @wallet.command(name="withdraw", description="Withdraw tix from your wallet (the custodian trades them to you)")
+    @option("amount", int, description="How many tix to withdraw", min_value=1)
+    async def wallet_withdraw(self, ctx: discord.ApplicationContext, amount: int):
+        await ctx.defer(ephemeral=True)
+        err = self._gate_serve(ctx)
+        if err:
+            return await ctx.followup.send(err, ephemeral=True)
+        username = await self._linked_username(ctx.author.id)
+        if not username:
+            return await ctx.followup.send(
+                "Link your MTGO account first with `/link_mtgo <username>`.", ephemeral=True)
+
+        guild_id = str(ctx.guild.id)
+        player_id = str(ctx.author.id)
+        started = await resolution.start_withdraw(
+            guild_id, player_id, username, amount, commit=True, wait_minutes=DEFAULT_WAIT_MINUTES)
+        if not started.get("ok"):
+            # covers insufficient funds and a serve that wouldn't accept the job
+            return await ctx.followup.send(
+                f"Couldn't start the withdraw: {started.get('error')}", ephemeral=True)
+
+        job_id = started["job_id"]
+        reserve_tx_id = started["reserve_tx_id"]
+        custodian = await self._custodian()
+        await ctx.followup.send(
+            f"**Withdraw started** — {amount} tix reserved. In MTGO, accept the trade from "
+            f"`{custodian}` when it pops. I'll confirm here once it completes.\n"
+            f"_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
+
+        async def _finish():
+            try:
+                res = await resolution.finish_withdraw(reserve_tx_id, job_id)
+                if res.get("ok"):
+                    bal = await wallet_service.get_balance(guild_id, player_id)
+                    msg = f"✅ Withdraw confirmed: **−{amount} tix**. Balance: **{bal} tix**."
+                elif res.get("outcome") == "pending":
+                    msg = (f"⏳ Withdraw `{job_id}` is still running; your {amount} tix stay "
+                           f"reserved until it resolves.")
+                else:
+                    msg = (f"❌ Withdraw `{job_id}` failed: {res.get('error')}. "
+                           f"Your {amount} tix have been released.")
+                await ctx.followup.send(msg, ephemeral=True)
+            except Exception as e:
+                logger.warning(f"wallet withdraw follow-up failed: {e}")
+
+        asyncio.create_task(_finish())
+
+    # ----- /wallet pay @player <n> -----
+    @wallet.command(name="pay", description="Send tix from your wallet to another player (no MTGO trade)")
+    @option("player", discord.Member, description="Who to pay")
+    @option("amount", int, description="How many tix to send", min_value=1)
+    async def wallet_pay(self, ctx: discord.ApplicationContext, player: discord.Member, amount: int):
+        await ctx.defer(ephemeral=True)
+        err = self._gate_read(ctx)
+        if err:
+            return await ctx.followup.send(err, ephemeral=True)
+        if player.id == ctx.author.id:
+            return await ctx.followup.send("You can't pay yourself.", ephemeral=True)
+        # both parties linked so the recipient can actually use the tix later
+        if not await self._linked_username(ctx.author.id):
+            return await ctx.followup.send(
+                "Link your MTGO account first with `/link_mtgo`.", ephemeral=True)
+        if not await self._linked_username(player.id):
+            return await ctx.followup.send(
+                f"{player.display_name} hasn't linked an MTGO account yet, so they can't "
+                f"receive tix. Ask them to run `/link_mtgo` first.", ephemeral=True)
+
+        guild_id = str(ctx.guild.id)
+        res = await resolution.pay(
+            guild_id, str(ctx.author.id), str(player.id), amount,
+            notes=f"pay to {player.display_name}")
+        if not res.get("ok"):
+            return await ctx.followup.send(f"Couldn't send tix: {res.get('error')}", ephemeral=True)
+
+        payer_bal = await wallet_service.get_balance(guild_id, str(ctx.author.id))
+        await ctx.followup.send(
+            f"Sent **{amount} tix** to <@{player.id}>. Your balance: **{payer_bal} tix**.",
+            ephemeral=True)
+
+    # ----- /wallet reconcile (admin) -----
+    @wallet.command(name="reconcile", description="(Admin) Audit: vault tix vs. total of all wallets")
+    @has_bot_manager_role()
+    async def wallet_reconcile(self, ctx: discord.ApplicationContext):
+        await ctx.defer(ephemeral=True)
+        err = self._gate_serve(ctx)
+        if err:
+            return await ctx.followup.send(err, ephemeral=True)
+
+        res = await resolution.reconcile()  # global: one vault across guilds
+        if "error" in res and not res.get("ok"):
+            return await ctx.followup.send(f"Couldn't reconcile: {res['error']}", ephemeral=True)
+
+        color = discord.Color.green() if res["ok"] else discord.Color.red()
+        embed = discord.Embed(title="Wallet Reconciliation", color=color)
+        embed.add_field(name="Vault tix (physical)", value=str(res["bot_tix"]), inline=True)
+        embed.add_field(name="Wallets total (claims)", value=str(res["wallet_total"]), inline=True)
+        embed.add_field(name="Difference", value=f"{res['diff']:+d}", inline=True)
+        embed.set_footer(text="✅ Balanced" if res["ok"]
+                         else "⚠️ MISMATCH — the vault and the ledger disagree.")
+        await ctx.followup.send(embed=embed, ephemeral=True)
+
+
+def setup(bot):
+    bot.add_cog(WalletCommands(bot))

--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -17,23 +17,20 @@ with in-client instructions, then a background task polls the job to a terminal 
 posts the outcome — the ledger is only ever written on a completed trade. The serve's own
 --commit arm state remains the master safety switch for whether a trade actually fires.
 """
-import asyncio
-
 import discord
 from discord.ext import commands
 from discord.commands import SlashCommandGroup, option
 from loguru import logger
 
-from config import is_money_server
 from models.mtgo_account import MtgoAccount
 from services import wallet_service
 from services import mtgo_resolution_service as resolution
-from services.mtgo_tradebot_client import get_client, EVENT_TICKET
+from services.mtgo_tradebot_client import EVENT_TICKET
+from helpers.money_gate import (
+    DEFAULT_WAIT_MINUTES, custodian_name, gate_read, gate_serve, linked_username,
+    spawn_followup,
+)
 from helpers.permissions import has_bot_manager_role
-
-# Serve-side readiness wait (minutes) for a deposit/withdraw trade before the job fails and
-# any reservation is released. Bounds how long a player has to accept the in-client trade.
-DEFAULT_WAIT_MINUTES = 10
 
 
 class WalletCommands(commands.Cog):
@@ -43,42 +40,12 @@ class WalletCommands(commands.Cog):
 
     wallet = SlashCommandGroup("wallet", "Manage your MTGO tix wallet")
 
-    # ----- gating helpers -----
-    def _serve_enabled(self) -> bool:
-        return get_client().enabled
-
-    def _gate_read(self, ctx) -> str | None:
-        """Wallet must be a money server. Returns an error string, or None if allowed."""
-        if not ctx.guild:
-            return "Wallet commands can only be used in a server."
-        if not is_money_server(str(ctx.guild.id)):
-            return "The tix wallet is only available on money-enabled servers."
-        return None
-
-    def _gate_serve(self, ctx) -> str | None:
-        """Read gate + the TradeBot integration must be configured."""
-        err = self._gate_read(ctx)
-        if err:
-            return err
-        if not self._serve_enabled():
-            return ("The MTGO TradeBot integration isn't configured on this bot "
-                    "(set MTGO_TRADEBOT_URL and MTGO_TRADEBOT_TOKEN).")
-        return None
-
-    async def _linked_username(self, discord_id) -> str | None:
-        acct = await MtgoAccount.get_for_discord(discord_id)
-        return acct.mtgo_username if acct else None
-
-    async def _custodian(self) -> str:
-        health = await get_client().health()
-        return (health or {}).get("custodian") or "the custodian bot"
-
     # ----- /wallet [player] -----
     @wallet.command(name="show", description="Show a tix wallet balance and recent activity")
     @option("player", discord.Member, description="Whose wallet to show (defaults to you)", required=False)
     async def wallet_show(self, ctx: discord.ApplicationContext, player: discord.Member = None):
         await ctx.defer(ephemeral=True)
-        err = self._gate_read(ctx)
+        err = gate_read(ctx)
         if err:
             return await ctx.followup.send(err, ephemeral=True)
 
@@ -114,10 +81,10 @@ class WalletCommands(commands.Cog):
     @option("amount", int, description="How many tix to deposit", min_value=1)
     async def wallet_deposit(self, ctx: discord.ApplicationContext, amount: int):
         await ctx.defer(ephemeral=True)
-        err = self._gate_serve(ctx)
+        err = gate_serve(ctx)
         if err:
             return await ctx.followup.send(err, ephemeral=True)
-        username = await self._linked_username(ctx.author.id)
+        username = await linked_username(ctx.author.id)
         if not username:
             return await ctx.followup.send(
                 "Link your MTGO account first with `/link_mtgo <username>`.", ephemeral=True)
@@ -131,42 +98,42 @@ class WalletCommands(commands.Cog):
                 f"Couldn't start the deposit: {started.get('error')}", ephemeral=True)
 
         job_id = started["job_id"]
-        custodian = await self._custodian()
+        custodian = await custodian_name()
         await ctx.followup.send(
             f"**Deposit started.** In MTGO, trade **{amount} {EVENT_TICKET}(s)** to "
             f"`{custodian}` and accept when the trade window pops. I'll confirm here once it "
             f"lands.\n_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
 
-        async def _finish():
-            try:
-                res = await resolution.finish_deposit(job_id, guild_id, player_id, amount, username)
-                if res.get("ok"):
-                    bal = await wallet_service.get_balance(guild_id, player_id)
-                    drawn = await resolution.auto_draw(guild_id, player_id)
-                    msg = f"✅ Deposit confirmed: **+{amount} tix**. Balance: **{bal} tix**."
-                    if drawn:
-                        total = sum(d.get("amount", 0) for d in drawn)
-                        msg += f" Auto-applied **{total} tix** to {len(drawn)} debt(s)."
-                elif res.get("outcome") == "pending":
-                    msg = (f"⏳ Deposit `{job_id}` is still pending — it'll credit automatically "
-                           f"once the trade completes.")
-                else:
-                    msg = f"❌ Deposit `{job_id}` failed: {res.get('error')}"
-                await ctx.followup.send(msg, ephemeral=True)
-            except Exception as e:
-                logger.warning(f"wallet deposit follow-up failed: {e}")
+        # capture only what the poller needs (not ctx) — this task can live for ~14 min
+        followup = ctx.followup
 
-        asyncio.create_task(_finish())
+        async def _finish():
+            res = await resolution.finish_deposit(job_id, guild_id, player_id, amount, username)
+            if res.get("ok"):
+                bal = await wallet_service.get_balance(guild_id, player_id)
+                drawn = await resolution.auto_draw(guild_id, player_id)
+                msg = f"✅ Deposit confirmed: **+{amount} tix**. Balance: **{bal} tix**."
+                if drawn:
+                    total = sum(d.get("amount", 0) for d in drawn)
+                    msg += f" Auto-applied **{total} tix** to {len(drawn)} debt(s)."
+            elif res.get("outcome") == "pending":
+                msg = (f"⏳ Deposit `{job_id}` is still pending — it'll credit automatically "
+                       f"once the trade completes.")
+            else:
+                msg = f"❌ Deposit `{job_id}` failed: {res.get('error')}"
+            await followup.send(msg, ephemeral=True)
+
+        spawn_followup("wallet deposit", _finish())
 
     # ----- /wallet withdraw <n> -----
     @wallet.command(name="withdraw", description="Withdraw tix from your wallet (the custodian trades them to you)")
     @option("amount", int, description="How many tix to withdraw", min_value=1)
     async def wallet_withdraw(self, ctx: discord.ApplicationContext, amount: int):
         await ctx.defer(ephemeral=True)
-        err = self._gate_serve(ctx)
+        err = gate_serve(ctx)
         if err:
             return await ctx.followup.send(err, ephemeral=True)
-        username = await self._linked_username(ctx.author.id)
+        username = await linked_username(ctx.author.id)
         if not username:
             return await ctx.followup.send(
                 "Link your MTGO account first with `/link_mtgo <username>`.", ephemeral=True)
@@ -182,29 +149,28 @@ class WalletCommands(commands.Cog):
 
         job_id = started["job_id"]
         reserve_tx_id = started["reserve_tx_id"]
-        custodian = await self._custodian()
+        custodian = await custodian_name()
         await ctx.followup.send(
             f"**Withdraw started** — {amount} tix reserved. In MTGO, accept the trade from "
             f"`{custodian}` when it pops. I'll confirm here once it completes.\n"
             f"_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
 
-        async def _finish():
-            try:
-                res = await resolution.finish_withdraw(reserve_tx_id, job_id)
-                if res.get("ok"):
-                    bal = await wallet_service.get_balance(guild_id, player_id)
-                    msg = f"✅ Withdraw confirmed: **−{amount} tix**. Balance: **{bal} tix**."
-                elif res.get("outcome") == "pending":
-                    msg = (f"⏳ Withdraw `{job_id}` is still running; your {amount} tix stay "
-                           f"reserved until it resolves.")
-                else:
-                    msg = (f"❌ Withdraw `{job_id}` failed: {res.get('error')}. "
-                           f"Your {amount} tix have been released.")
-                await ctx.followup.send(msg, ephemeral=True)
-            except Exception as e:
-                logger.warning(f"wallet withdraw follow-up failed: {e}")
+        followup = ctx.followup
 
-        asyncio.create_task(_finish())
+        async def _finish():
+            res = await resolution.finish_withdraw(reserve_tx_id, job_id)
+            if res.get("ok"):
+                bal = await wallet_service.get_balance(guild_id, player_id)
+                msg = f"✅ Withdraw confirmed: **−{amount} tix**. Balance: **{bal} tix**."
+            elif res.get("outcome") == "pending":
+                msg = (f"⏳ Withdraw `{job_id}` is still running; your {amount} tix stay "
+                       f"reserved until it resolves.")
+            else:
+                msg = (f"❌ Withdraw `{job_id}` failed: {res.get('error')}. "
+                       f"Your {amount} tix have been released.")
+            await followup.send(msg, ephemeral=True)
+
+        spawn_followup("wallet withdraw", _finish())
 
     # ----- /wallet pay @player <n> -----
     @wallet.command(name="pay", description="Send tix from your wallet to another player (no MTGO trade)")
@@ -212,16 +178,17 @@ class WalletCommands(commands.Cog):
     @option("amount", int, description="How many tix to send", min_value=1)
     async def wallet_pay(self, ctx: discord.ApplicationContext, player: discord.Member, amount: int):
         await ctx.defer(ephemeral=True)
-        err = self._gate_read(ctx)
+        err = gate_read(ctx)
         if err:
             return await ctx.followup.send(err, ephemeral=True)
         if player.id == ctx.author.id:
             return await ctx.followup.send("You can't pay yourself.", ephemeral=True)
-        # both parties linked so the recipient can actually use the tix later
-        if not await self._linked_username(ctx.author.id):
+        # both parties linked so the recipient can actually use the tix later (one batch query)
+        linked = await MtgoAccount.usernames_for_discord_ids([ctx.author.id, player.id])
+        if str(ctx.author.id) not in linked:
             return await ctx.followup.send(
                 "Link your MTGO account first with `/link_mtgo`.", ephemeral=True)
-        if not await self._linked_username(player.id):
+        if str(player.id) not in linked:
             return await ctx.followup.send(
                 f"{player.display_name} hasn't linked an MTGO account yet, so they can't "
                 f"receive tix. Ask them to run `/link_mtgo` first.", ephemeral=True)
@@ -243,12 +210,12 @@ class WalletCommands(commands.Cog):
     @has_bot_manager_role()
     async def wallet_reconcile(self, ctx: discord.ApplicationContext):
         await ctx.defer(ephemeral=True)
-        err = self._gate_serve(ctx)
+        err = gate_serve(ctx)
         if err:
             return await ctx.followup.send(err, ephemeral=True)
 
         res = await resolution.reconcile()  # global: one vault across guilds
-        if "error" in res and not res.get("ok"):
+        if res.get("error"):
             return await ctx.followup.send(f"Couldn't reconcile: {res['error']}", ephemeral=True)
 
         color = discord.Color.green() if res["ok"] else discord.Color.red()

--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -92,7 +92,7 @@ class WalletCommands(commands.Cog):
         guild_id = str(ctx.guild.id)
         player_id = str(ctx.author.id)
         started = await resolution.start_deposit(
-            username, amount, commit=True, wait_minutes=DEFAULT_WAIT_MINUTES)
+            guild_id, player_id, username, amount, commit=True, wait_minutes=DEFAULT_WAIT_MINUTES)
         if not started.get("ok"):
             return await ctx.followup.send(
                 f"Couldn't start the deposit: {started.get('error')}", ephemeral=True)

--- a/database/retry.py
+++ b/database/retry.py
@@ -1,0 +1,30 @@
+"""Shared retry-with-backoff for transient SQLite write-lock errors.
+
+One home for the "database is locked" backoff loop that money-path services need
+around their transactions (wallet, resolution, escrow). 3 attempts, 1s initial
+delay, doubling.
+"""
+import asyncio
+
+from loguru import logger
+from sqlalchemy.exc import OperationalError
+
+_MAX_RETRIES = 3
+_INITIAL_DELAY_S = 1.0
+
+
+async def with_db_retry(thunk):
+    """Run an async thunk, retrying on transient 'database is locked' with backoff."""
+    delay = _INITIAL_DELAY_S
+    for attempt in range(_MAX_RETRIES):
+        try:
+            return await thunk()
+        except OperationalError as e:
+            if "database is locked" in str(e) and attempt < _MAX_RETRIES - 1:
+                logger.warning(
+                    f"DB locked on attempt {attempt + 1}/{_MAX_RETRIES}, retrying in {delay}s..."
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+            else:
+                raise

--- a/helpers/money_gate.py
+++ b/helpers/money_gate.py
@@ -1,0 +1,84 @@
+"""
+Shared gating/identity helpers for the money stack (wallet + tournament escrow cogs).
+
+One home for the checks every money-touching command runs, so the rules and their
+user-facing wording can't drift between cogs:
+  * gate_read  — the guild must be money-enabled (wallet views, internal pays).
+  * gate_serve — read gate + the TradeBot serve must be configured (trades).
+  * linked_username — the caller's /link_mtgo identity, required to trade.
+  * custodian_name — the vault account's display name (cached; it only changes
+    when the serve is re-attached to a different MTGO login, i.e. on a restart
+    of the serve — and a bot restart clears the cache).
+
+Also the shared background-followup spawner: deposit/withdraw/escrow commands
+reply immediately and poll the MTGO job in a fire-and-forget task; spawn_followup
+gives that task the never-crash-silently wrapper (and keeps a strong reference so
+it can't be garbage-collected mid-poll).
+"""
+import asyncio
+
+from loguru import logger
+
+from config import is_money_server
+from models.mtgo_account import MtgoAccount
+from services.mtgo_tradebot_client import get_client
+
+# Serve-side readiness wait (minutes) for a deposit/withdraw trade before the job
+# fails and any reservation is released. Bounds how long a player has to accept
+# the in-client trade.
+DEFAULT_WAIT_MINUTES = 10
+
+_custodian_cache: str | None = None
+_background_tasks: set = set()
+
+
+def gate_read(ctx) -> str | None:
+    """Wallet must be used in a money server. Returns an error string, or None."""
+    if not ctx.guild:
+        return "Wallet commands can only be used in a server."
+    if not is_money_server(str(ctx.guild.id)):
+        return "The tix wallet is only available on money-enabled servers."
+    return None
+
+
+def gate_serve(ctx) -> str | None:
+    """Read gate + the TradeBot integration must be configured."""
+    err = gate_read(ctx)
+    if err:
+        return err
+    if not get_client().enabled:
+        return ("The MTGO TradeBot integration isn't configured on this bot "
+                "(set MTGO_TRADEBOT_URL and MTGO_TRADEBOT_TOKEN).")
+    return None
+
+
+async def linked_username(discord_id) -> str | None:
+    acct = await MtgoAccount.get_for_discord(discord_id)
+    return acct.mtgo_username if acct else None
+
+
+async def custodian_name() -> str:
+    """The vault account's display name, from the serve's /health (cached on success)."""
+    global _custodian_cache
+    if _custodian_cache:
+        return _custodian_cache
+    health = await get_client().health()
+    name = (health or {}).get("custodian")
+    if name:
+        _custodian_cache = name
+        return name
+    return "the custodian bot"
+
+
+def spawn_followup(label: str, coro) -> asyncio.Task:
+    """Run a background follow-up coroutine that logs (never raises) on failure."""
+    async def _guarded():
+        try:
+            await coro
+        except Exception as e:
+            logger.warning(f"{label} follow-up failed: {e}")
+
+    task = asyncio.create_task(_guarded())
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -22,6 +22,7 @@ from .debt_summary_message import DebtSummaryMessage
 from .tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
 from .trophy_quiz_session import TrophyQuizSession
 from .trophy_quiz_submission import TrophyQuizSubmission
+from .mtgo_account import MtgoAccount
 
 # Export all models
 __all__ = [
@@ -61,4 +62,5 @@ __all__ = [
     'TournamentMatch',
     'TrophyQuizSession',
     'TrophyQuizSubmission',
+    'MtgoAccount',
 ]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -23,6 +23,7 @@ from .tournament import Tournament, TournamentMatch, TournamentParticipant, Tour
 from .trophy_quiz_session import TrophyQuizSession
 from .trophy_quiz_submission import TrophyQuizSubmission
 from .mtgo_account import MtgoAccount
+from .wallet_tx import WalletTx
 
 # Export all models
 __all__ = [
@@ -63,4 +64,5 @@ __all__ = [
     'TrophyQuizSession',
     'TrophyQuizSubmission',
     'MtgoAccount',
+    'WalletTx',
 ]

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -23,6 +23,7 @@ from .tournament import Tournament, TournamentMatch, TournamentParticipant, Tour
 from .trophy_quiz_session import TrophyQuizSession
 from .trophy_quiz_submission import TrophyQuizSubmission
 from .mtgo_account import MtgoAccount
+from .mtgo_job import MtgoJob
 from .wallet_tx import WalletTx
 
 # Export all models
@@ -64,5 +65,6 @@ __all__ = [
     'TrophyQuizSession',
     'TrophyQuizSubmission',
     'MtgoAccount',
+    'MtgoJob',
     'WalletTx',
 ]

--- a/models/mtgo_account.py
+++ b/models/mtgo_account.py
@@ -1,0 +1,114 @@
+"""
+MTGO account link — maps a Discord user to their MTGO username.
+
+Why a dedicated table (not a column on player_stats):
+  * The load-bearing lookup is the REVERSE direction, mtgo_username -> discord_user_id,
+    used when auto-reporting a spectated MTGO match result back to DraftBot. That needs
+    a UNIQUE key on the (normalized) handle, which a plain column can't give.
+  * An MTGO account belongs to a PERSON, so it's keyed by the global Discord id — unlike
+    player_stats, whose PK is (player_id, guild_id).
+  * player_stats rows are created lazily (only after a player has stats); a link must be
+    able to exist before that.
+
+MTGO handles are effectively case-insensitive, so we store the original casing for
+display plus a normalized lower form carrying the UNIQUE constraint for lookups.
+"""
+from datetime import datetime
+
+from sqlalchemy import Column, String, Boolean, DateTime, select
+
+from database.models_base import Base
+from database.db_session import db_session
+
+
+def normalize_mtgo(name: str) -> str:
+    """Canonical form for matching + uniqueness: trimmed and lowercased."""
+    return (name or "").strip().lower()
+
+
+class MtgoAccount(Base):
+    __tablename__ = 'mtgo_accounts'
+
+    discord_user_id = Column(String(64), primary_key=True)                 # global per-person key
+    mtgo_username = Column(String(128), nullable=False)                    # original casing (display)
+    mtgo_username_lower = Column(String(128), nullable=False,
+                                 unique=True, index=True)                  # reverse-lookup key
+    verified = Column(Boolean, default=False)                             # reserved for a future verify step
+    linked_at = Column(DateTime, default=datetime.now)
+    guild_id = Column(String(64), nullable=True)                          # where first linked (metadata only)
+
+    def __repr__(self):
+        return f"<MtgoAccount(discord={self.discord_user_id}, mtgo={self.mtgo_username})>"
+
+    @classmethod
+    async def link(cls, discord_user_id, mtgo_username, guild_id=None):
+        """
+        Create or update the caller's MTGO link. One MTGO handle maps to exactly one
+        Discord user. Returns (status, detail):
+          ("ok", mtgo_username)            link created/updated
+          ("conflict", other_discord_id)   that handle is already linked to someone else
+          ("empty", None)                  blank username supplied
+        """
+        cleaned = (mtgo_username or "").strip()
+        lower = normalize_mtgo(cleaned)
+        if not lower:
+            return ("empty", None)
+        did = str(discord_user_id)
+        async with db_session() as session:
+            existing = (await session.execute(
+                select(cls).where(cls.mtgo_username_lower == lower))).scalar_one_or_none()
+            if existing is not None and existing.discord_user_id != did:
+                return ("conflict", existing.discord_user_id)
+            row = await session.get(cls, did)
+            if row is None:
+                session.add(cls(
+                    discord_user_id=did, mtgo_username=cleaned, mtgo_username_lower=lower,
+                    guild_id=(str(guild_id) if guild_id else None)))
+            else:
+                row.mtgo_username = cleaned
+                row.mtgo_username_lower = lower
+                if guild_id and not row.guild_id:
+                    row.guild_id = str(guild_id)
+            return ("ok", cleaned)
+
+    @classmethod
+    async def discord_for_mtgo(cls, mtgo_username):
+        """Reverse lookup: MTGO username -> Discord user id (or None). Used by the API/worker."""
+        lower = normalize_mtgo(mtgo_username)
+        if not lower:
+            return None
+        async with db_session() as session:
+            row = (await session.execute(
+                select(cls).where(cls.mtgo_username_lower == lower))).scalar_one_or_none()
+            return row.discord_user_id if row else None
+
+    @classmethod
+    async def get_for_discord(cls, discord_user_id):
+        """Forward lookup: Discord user id -> MtgoAccount row (or None)."""
+        async with db_session() as session:
+            return await session.get(cls, str(discord_user_id))
+
+    @classmethod
+    async def usernames_for_discord_ids(cls, discord_user_ids):
+        """Batch forward lookup: {discord_user_id -> mtgo_username} for the linked ones.
+
+        Unlinked ids are simply absent from the result. One query instead of N — used
+        when resolving a whole pairing list for the worker.
+        """
+        ids = [str(d) for d in discord_user_ids if d is not None]
+        if not ids:
+            return {}
+        async with db_session() as session:
+            rows = (await session.execute(
+                select(cls).where(cls.discord_user_id.in_(ids)))).scalars().all()
+            return {r.discord_user_id: r.mtgo_username for r in rows}
+
+    @classmethod
+    async def unlink(cls, discord_user_id):
+        """Remove a link. Returns True if a row was deleted."""
+        async with db_session() as session:
+            row = await session.get(cls, str(discord_user_id))
+            if row is None:
+                return False
+            await session.delete(row)
+            return True

--- a/models/mtgo_account.py
+++ b/models/mtgo_account.py
@@ -15,7 +15,7 @@ display plus a normalized lower form carrying the UNIQUE constraint for lookups.
 """
 from datetime import datetime
 
-from sqlalchemy import Column, String, Boolean, DateTime, select
+from sqlalchemy import Column, String, DateTime, select
 
 from database.models_base import Base
 from database.db_session import db_session
@@ -33,7 +33,6 @@ class MtgoAccount(Base):
     mtgo_username = Column(String(128), nullable=False)                    # original casing (display)
     mtgo_username_lower = Column(String(128), nullable=False,
                                  unique=True, index=True)                  # reverse-lookup key
-    verified = Column(Boolean, default=False)                             # reserved for a future verify step
     linked_at = Column(DateTime, default=datetime.now)
     guild_id = Column(String(64), nullable=True)                          # where first linked (metadata only)
 
@@ -70,17 +69,6 @@ class MtgoAccount(Base):
                 if guild_id and not row.guild_id:
                     row.guild_id = str(guild_id)
             return ("ok", cleaned)
-
-    @classmethod
-    async def discord_for_mtgo(cls, mtgo_username):
-        """Reverse lookup: MTGO username -> Discord user id (or None). Used by the API/worker."""
-        lower = normalize_mtgo(mtgo_username)
-        if not lower:
-            return None
-        async with db_session() as session:
-            row = (await session.execute(
-                select(cls).where(cls.mtgo_username_lower == lower))).scalar_one_or_none()
-            return row.discord_user_id if row else None
 
     @classmethod
     async def get_for_discord(cls, discord_user_id):

--- a/models/mtgo_job.py
+++ b/models/mtgo_job.py
@@ -1,0 +1,40 @@
+"""
+Durable record of an in-flight MTGO serve job (deposit/withdraw trade).
+
+Why a table: the cogs poll a job in a fire-and-forget background task. If the
+poll times out, or the bot restarts mid-trade, that task is gone — but the MTGO
+trade can still complete, moving real tix into or out of the vault with nothing
+left to book the ledger side. Persisting every started job lets a startup
+resumer (mtgo_resolution_service.resume_pending_jobs) pick up whatever is still
+'pending' and poll it to a terminal state, so a completed trade is always booked
+eventually. Booking itself stays idempotent by job_id, so a resumed poll racing
+a still-alive original poller cannot double-credit.
+
+``context`` carries what to do after a deposit lands beyond crediting the wallet
+(currently 'tourney:<tid>:<pid>' -> re-secure that tournament escrow).
+"""
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime
+
+from database.models_base import Base
+
+
+class MtgoJob(Base):
+    __tablename__ = 'mtgo_jobs'
+
+    job_id = Column(String(64), primary_key=True)          # the serve's job id
+    kind = Column(String(16), nullable=False)              # deposit | withdraw
+    guild_id = Column(String(64), nullable=False)
+    player_id = Column(String(64), nullable=False)
+    mtgo_user = Column(String(128), nullable=False)
+    amount = Column(Integer, nullable=False)
+    reserve_tx_id = Column(Integer, nullable=True)         # withdraws: the pending WalletTx hold
+    context = Column(String(64), nullable=True)            # post-completion hook tag
+    status = Column(String(16), nullable=False, default='pending')  # pending | done | failed
+    created_at = Column(DateTime, default=datetime.now)
+    resolved_at = Column(DateTime, nullable=True)
+
+    def __repr__(self):
+        return (f"<MtgoJob(job={self.job_id}, kind={self.kind}, player={self.player_id}, "
+                f"amount={self.amount}, status={self.status})>")

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -31,6 +31,10 @@ class Tournament(Base):
     # registering captain must have the fee held in their wallet before the team counts
     # as registered (see services/tournament_escrow_service.py).
     entry_fee = Column(Integer, nullable=False, default=0, server_default=text('0'))
+    # How the prize pool is split at payout, declared up front so entrants know it before
+    # they pay: 'winner_take_all' | 'top2' | 'top3' | 'top4' (see PAYOUT_STRUCTURES).
+    payout_structure = Column(String(32), nullable=False, default='winner_take_all',
+                              server_default=text("'winner_take_all'"))
     created_at = Column(DateTime, default=datetime.now)
     # Where the auto-updating standings message lives (edited in place on every result)
     standings_channel_id = Column(String(64), nullable=True)

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -27,6 +27,10 @@ class Tournament(Base):
     # 'swiss' (re-pair each round) | 'round_robin' | 'manual' (schedule fixed upfront)
     format = Column(String(16), nullable=False, default='swiss',
                     server_default=text("'swiss'"))
+    # Escrow entry fee in tix (0 = free, the default = today's behavior). When > 0, a
+    # registering captain must have the fee held in their wallet before the team counts
+    # as registered (see services/tournament_escrow_service.py).
+    entry_fee = Column(Integer, nullable=False, default=0, server_default=text('0'))
     created_at = Column(DateTime, default=datetime.now)
     # Where the auto-updating standings message lives (edited in place on every result)
     standings_channel_id = Column(String(64), nullable=True)
@@ -45,6 +49,15 @@ class TournamentParticipant(Base):
     team_id = Column(Integer, nullable=False)
     team_name = Column(String(128), nullable=False)
     captain_user_id = Column(String(64), nullable=False)
+
+    # Escrow gate. 'paid' = entry fee is held (or it's a free tournament, or a row that
+    # predates escrow — server_default grandfathers those); 'pending' = registered but the
+    # escrow isn't secured yet. Only 'paid' participants are seeded when the tournament starts.
+    status = Column(String(16), nullable=False, default='paid', server_default=text("'paid'"))
+    # The captain's WalletTx reserve holding the fee — cancelled to refund (drop before
+    # start), retained as the pot after start. Null for free/grandfathered participants.
+    escrow_tx_id = Column(Integer, nullable=True)
+    paid_at = Column(DateTime, nullable=True)
 
     # This tournament's standings (never written onto the global Team record)
     match_wins = Column(Integer, nullable=False, default=0, server_default=text('0'))

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -55,7 +55,8 @@ class TournamentParticipant(Base):
     # escrow isn't secured yet. Only 'paid' participants are seeded when the tournament starts.
     status = Column(String(16), nullable=False, default='paid', server_default=text("'paid'"))
     # The captain's WalletTx reserve holding the fee — cancelled to refund (drop before
-    # start), retained as the pot after start. Null for free/grandfathered participants.
+    # start), or settled into the tournament's prize wallet when it starts. Null for
+    # free / grandfathered / comped participants.
     escrow_tx_id = Column(Integer, nullable=True)
     paid_at = Column(DateTime, nullable=True)
 

--- a/models/wallet_tx.py
+++ b/models/wallet_tx.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Column, Integer, String, DateTime, Index
+from datetime import datetime
+from database.models_base import Base
+
+
+class WalletTx(Base):
+    """
+    Append-only audit log for the tix wallet — the *obligation* / claim ledger.
+
+    One row per movement of tix through the custodian vault. There is deliberately
+    NO materialized balance column: a player's balance is always SUM(amount) over
+    their 'done' rows, exactly like ``DebtLedger``. The log is the single source of
+    truth, so a balance can never drift out of sync with its own history — the right
+    trade-off when the ledger stands in for real value. (The plan sketched a separate
+    ``TixWallet(balance)`` table; a computed balance is strictly safer and a
+    materialized cache can be layered on later if reads ever get hot.)
+
+    ``amount`` is SIGNED from the player's perspective:
+      + credit  — deposit into the vault, or receiving an internal payment
+      - debit   — withdraw out of the vault, or paying another player
+
+    ``status``:
+      'done'      settled; counts toward the balance.
+      'pending'   a withdraw whose MTGO trade is still running. It RESERVES the tix
+                  (counts against ``available``) so they can't be double-spent, but
+                  does NOT count toward the settled balance until the job completes.
+                  Credits are only ever written as 'done' (never on enqueue).
+      'cancelled' a reservation released because its job failed. Ignored by every sum.
+
+    Reconciliation invariant: bot's on-MTGO tix == SUM(amount WHERE status='done').
+
+    ``job_id`` links a row to its MTGO serve job (deposit/withdraw) and is the
+    idempotency key, so a replayed job poll can't double-book. NULL for internal pays.
+    ``source`` doubles as the idempotency key for internal pays (a settlement uuid or
+    'debt:<id>'), mirroring ``DebtLedger.source_id``.
+    """
+    __tablename__ = 'wallet_tx'
+
+    id = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
+    guild_id = Column(String(64), nullable=False, index=True)
+    player_id = Column(String(64), nullable=False, index=True)
+
+    kind = Column(String(32), nullable=False)   # deposit | withdraw | pay | receive | adjust
+    amount = Column(Integer, nullable=False)     # + credit, - debit (player's perspective)
+    status = Column(String(16), nullable=False, default='done')  # done | pending | cancelled
+
+    counterparty_id = Column(String(64), nullable=True)  # other player (pay/receive); MTGO user for deposit/withdraw
+    job_id = Column(String(64), nullable=True, index=True)  # serve job id; idempotency key
+    source = Column(String(64), nullable=True)   # 'serve' | 'internal' | 'debt:<id>' | settlement uuid
+    notes = Column(String(256), nullable=True)
+
+    created_at = Column(DateTime, default=datetime.now)
+
+    __table_args__ = (
+        Index('ix_wallet_tx_balance_lookup', 'guild_id', 'player_id', 'status'),
+    )
+
+    def __repr__(self):
+        return (f"<WalletTx(player={self.player_id}, kind={self.kind}, "
+                f"amount={self.amount:+d}, status={self.status}, job={self.job_id})>")

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -239,6 +239,25 @@ async def resume_pending_jobs() -> int:
     return len(pending)
 
 
+_RESCAN_INTERVAL_S = 10 * 60
+
+
+async def pending_jobs_watchdog():
+    """Run resume_pending_jobs forever, every ``_RESCAN_INTERVAL_S``.
+
+    A single startup pass isn't enough: each poll gives up after ~14 minutes
+    ('pending' outcome), but a serve job can complete later than that (a stalled
+    serve that recovers, live case: 28 minutes). The rescan keeps re-polling
+    every still-pending job until it reaches a terminal state — booking stays
+    idempotent by job_id, so overlapping pollers are harmless."""
+    while True:
+        try:
+            await resume_pending_jobs()
+        except Exception as e:
+            logger.warning(f"pending_jobs_watchdog: rescan failed: {e}")
+        await asyncio.sleep(_RESCAN_INTERVAL_S)
+
+
 # ---------------------------------------------------------------------------
 # internal pay (no trade)
 # ---------------------------------------------------------------------------

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -21,16 +21,20 @@ import asyncio
 import uuid
 from loguru import logger
 from sqlalchemy import select, func
-from sqlalchemy.exc import OperationalError
 
 from database.db_session import db_session
+from database.retry import with_db_retry
 from models.wallet_tx import WalletTx
 from models.debt_ledger import DebtLedger
 from services.mtgo_tradebot_client import get_client
 from services import wallet_service
 from services import debt_service
 
+# Poll fast at first (a serve rejection surfaces in seconds), then back off — the human
+# step (accepting an MTGO trade) takes minutes, so terminal-detection latency is cheap.
 _POLL_INTERVAL_S = 3.0
+_POLL_INTERVAL_MAX_S = 15.0
+_POLL_BACKOFF = 1.5
 # Keep the inline poll inside Discord's 15-minute interaction/followup window.
 _DEFAULT_POLL_TIMEOUT_S = 14 * 60
 
@@ -43,6 +47,7 @@ async def _poll_job(job_id: str, timeout_s: float):
     'done' | 'failed' | 'pending' ('pending' = still running when the timeout hit)."""
     client = get_client()
     waited = 0.0
+    interval = _POLL_INTERVAL_S
     last = None
     while waited < timeout_s:
         job = await client.get_job(job_id)
@@ -53,8 +58,9 @@ async def _poll_job(job_id: str, timeout_s: float):
                 return "done", job
             if state == "failed":
                 return "failed", job
-        await asyncio.sleep(_POLL_INTERVAL_S)
-        waited += _POLL_INTERVAL_S
+        await asyncio.sleep(interval)
+        waited += interval
+        interval = min(interval * _POLL_BACKOFF, _POLL_INTERVAL_MAX_S)
     return "pending", (last or {"id": job_id, "state": "pending"})
 
 
@@ -144,25 +150,6 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
 # ---------------------------------------------------------------------------
 # debt settlement from wallet — wallet move + debt clear in ONE transaction
 # ---------------------------------------------------------------------------
-async def _with_retry(thunk):
-    delay = 1.0
-    for attempt in range(3):
-        try:
-            return await thunk()
-        except OperationalError as e:
-            if "database is locked" in str(e) and attempt < 2:
-                logger.warning(f"resolution DB locked (attempt {attempt + 1}/3), retrying in {delay}s...")
-                await asyncio.sleep(delay)
-                delay *= 2
-            else:
-                raise
-
-
-async def _sum(session, column, *conditions) -> int:
-    result = await session.execute(select(func.coalesce(func.sum(column), 0)).where(*conditions))
-    return int(result.scalar() or 0)
-
-
 async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str, amount: int,
                                   *, link_id: str = None) -> dict:
     """Settle a tix debt from the payer's wallet: move the claim (payer −N, creditor +N)
@@ -187,22 +174,20 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
             if seen.scalar():
                 return {"ok": True, "amount": amount, "id": link_id, "idempotent": True}
 
-            # payer must have the funds (settled minus reserved)
-            done = await _sum(session, WalletTx.amount,
-                              WalletTx.guild_id == guild_id, WalletTx.player_id == payer_id,
-                              WalletTx.status == "done")
-            pending = await _sum(session, WalletTx.amount,
-                                 WalletTx.guild_id == guild_id, WalletTx.player_id == payer_id,
-                                 WalletTx.status == "pending")
-            available = done + pending  # pending debits are negative
+            # payer must have the funds (settled minus reserved) — the same availability
+            # formula every wallet op uses
+            balance, reserved = await wallet_service._balances(session, guild_id, payer_id)
+            available = balance - reserved
             if amount > available:
                 return {"ok": False, "error": f"insufficient wallet funds (available {available})"}
 
             # payer must actually owe the creditor at least this much
-            debt_balance = await _sum(session, DebtLedger.amount,
-                                      DebtLedger.guild_id == guild_id,
-                                      DebtLedger.player_id == payer_id,
-                                      DebtLedger.counterparty_id == creditor_id)
+            debt_balance = int((await session.execute(
+                select(func.coalesce(func.sum(DebtLedger.amount), 0)).where(
+                    DebtLedger.guild_id == guild_id,
+                    DebtLedger.player_id == payer_id,
+                    DebtLedger.counterparty_id == creditor_id,
+                ))).scalar() or 0)
             if debt_balance >= 0:
                 return {"ok": False, "error": "no outstanding debt to this creditor"}
             owed = -debt_balance
@@ -226,7 +211,7 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
             logger.info(f"settle_debt_from_wallet: {payer_id} -> {creditor_id} {amount} tix (link {link_id})")
             return {"ok": True, "amount": amount, "payer": payer_id, "creditor": creditor_id, "id": link_id}
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
@@ -244,12 +229,15 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
     if not owed:
         return []
 
-    # order creditors by the age of the oldest still-active debt entry (oldest first)
-    ordered = []
-    for cp in owed:
-        entries = await debt_service.get_active_debt_entries(guild_id, player_id, cp)
-        oldest_ts = entries[-1].created_at if entries else None  # entries are newest-first
-        ordered.append((oldest_ts, cp))
+    # order creditors by the age of the oldest still-active debt entry (oldest first);
+    # the per-creditor lookups are independent reads, so run them concurrently
+    creditors = list(owed)
+    entry_lists = await asyncio.gather(*(
+        debt_service.get_active_debt_entries(guild_id, player_id, cp) for cp in creditors))
+    ordered = [
+        (entries[-1].created_at if entries else None, cp)  # entries are newest-first
+        for cp, entries in zip(creditors, entry_lists)
+    ]
     ordered.sort(key=lambda t: (t[0] is None, t[0]))
 
     settlements = []
@@ -273,10 +261,10 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 # reconciliation passthrough (physical vault tix == SUM settled wallets)
 # ---------------------------------------------------------------------------
-async def reconcile(guild_id: str = None) -> dict:
+async def reconcile() -> dict:
     """Pull the vault's live tix from the serve and compare to the wallet claim total."""
     client = get_client()
     bot_tix = await client.bot_tix()
     if bot_tix is None:
         return {"ok": False, "error": "could not read vault tix from serve"}
-    return await wallet_service.reconcile(bot_tix, guild_id)
+    return await wallet_service.reconcile(bot_tix)

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -1,0 +1,282 @@
+"""
+Resolution engine — the bridge between the two ledgers.
+
+  * Physical ledger = the MTGO TradeBot serve (real vault contents; trades).
+  * Claim ledger    = wallet_service / WalletTx (who is owed what).
+
+A trade fires ONLY when value crosses the vault boundary:
+  - deposit  (bot receives tix)  -> credit the wallet once the job is 'done'.
+  - withdraw (bot gives tix)     -> reserve the wallet, then settle/cancel on the job.
+Everything internal (pay, debt settlement, auto-draw) is a claim move with NO trade.
+
+Job discipline (matches the plan): each serve op is an async job with a lowercase
+``state`` ∈ queued|running|done|failed. The ``start_*`` calls enqueue and return fast
+(the reserve is the only immediate ledger effect, for withdraws); the ``finish_*`` calls
+poll to a terminal state and write the ledger — credits are booked ONLY on 'done', never
+on enqueue, and idempotently by ``job_id`` so a re-poll can't double-book. Split this way
+so a cog can enqueue synchronously, defer the interaction, and run ``finish_*`` as a
+background task within Discord's interaction window.
+"""
+import asyncio
+import uuid
+from loguru import logger
+from sqlalchemy import select, func
+from sqlalchemy.exc import OperationalError
+
+from database.db_session import db_session
+from models.wallet_tx import WalletTx
+from models.debt_ledger import DebtLedger
+from services.mtgo_tradebot_client import get_client
+from services import wallet_service
+from services import debt_service
+
+_POLL_INTERVAL_S = 3.0
+# Keep the inline poll inside Discord's 15-minute interaction/followup window.
+_DEFAULT_POLL_TIMEOUT_S = 14 * 60
+
+
+# ---------------------------------------------------------------------------
+# job polling
+# ---------------------------------------------------------------------------
+async def _poll_job(job_id: str, timeout_s: float):
+    """Poll GET /jobs/{id} until terminal. Returns (outcome, job) where outcome is
+    'done' | 'failed' | 'pending' ('pending' = still running when the timeout hit)."""
+    client = get_client()
+    waited = 0.0
+    last = None
+    while waited < timeout_s:
+        job = await client.get_job(job_id)
+        if job is not None:
+            last = job
+            state = (job.get("state") or "").lower()
+            if state == "done":
+                return "done", job
+            if state == "failed":
+                return "failed", job
+        await asyncio.sleep(_POLL_INTERVAL_S)
+        waited += _POLL_INTERVAL_S
+    return "pending", (last or {"id": job_id, "state": "pending"})
+
+
+# ---------------------------------------------------------------------------
+# deposit (bot receives tix) — credit only on 'done'
+# ---------------------------------------------------------------------------
+async def start_deposit(mtgo_user: str, n: int, *, commit: bool = True, wait_minutes: int = 0) -> dict:
+    """Enqueue a deposit (bot receives ``n`` tix from ``mtgo_user``). No ledger effect yet."""
+    if n <= 0:
+        return {"ok": False, "error": "amount must be positive"}
+    client = get_client()
+    if not client.enabled:
+        return {"ok": False, "error": "MTGO TradeBot integration is disabled"}
+    resp = await client.deposit_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
+    if not resp or not resp.get("id"):
+        return {"ok": False, "error": "serve did not accept the deposit (unreachable or rejected)"}
+    return {"ok": True, "job_id": resp["id"], "job": resp}
+
+
+async def finish_deposit(job_id: str, guild_id: str, player_id: str, n: int, mtgo_user: str,
+                         timeout_s: float = _DEFAULT_POLL_TIMEOUT_S) -> dict:
+    """Poll the deposit job; on 'done' credit the wallet (idempotent by job_id)."""
+    outcome, job = await _poll_job(job_id, timeout_s)
+    if outcome == "done":
+        tx = await wallet_service.credit_done(
+            guild_id, player_id, n, kind="deposit",
+            job_id=job_id, counterparty_id=mtgo_user, source="serve", notes=f"deposit {n} tix")
+        return {"ok": True, "outcome": "done", "credited": n, "tx_id": tx.id, "job": job}
+    if outcome == "failed":
+        return {"ok": False, "outcome": "failed", "error": job.get("detail") or "trade failed", "job": job}
+    return {"ok": False, "outcome": "pending", "job_id": job_id, "job": job}
+
+
+# ---------------------------------------------------------------------------
+# withdraw (bot gives tix) — reserve up front, settle/cancel on terminal
+# ---------------------------------------------------------------------------
+async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, *,
+                         commit: bool = True, wait_minutes: int = 0) -> dict:
+    """Reserve ``n`` tix in the player's wallet (atomic funds check), then enqueue the give.
+    If the serve rejects it, the reservation is released."""
+    if n <= 0:
+        return {"ok": False, "error": "amount must be positive"}
+    client = get_client()
+    if not client.enabled:
+        return {"ok": False, "error": "MTGO TradeBot integration is disabled"}
+    try:
+        reserve = await wallet_service.reserve_debit(
+            guild_id, player_id, n, counterparty_id=mtgo_user, source="serve",
+            notes=f"withdraw {n} tix")
+    except ValueError as e:
+        return {"ok": False, "error": str(e)}
+
+    resp = await client.withdraw_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
+    if not resp or not resp.get("id"):
+        await wallet_service.cancel_reserve(reserve.id)  # release the hold
+        return {"ok": False, "error": "serve did not accept the withdraw (unreachable or rejected)"}
+    await wallet_service.attach_job(reserve.id, resp["id"])
+    return {"ok": True, "job_id": resp["id"], "reserve_tx_id": reserve.id, "job": resp}
+
+
+async def finish_withdraw(reserve_tx_id: int, job_id: str,
+                          timeout_s: float = _DEFAULT_POLL_TIMEOUT_S) -> dict:
+    """Poll the withdraw job; confirm the reservation on 'done', release it on 'failed'.
+    On timeout the reservation stays in place (funds remain held) — resolvable later."""
+    outcome, job = await _poll_job(job_id, timeout_s)
+    if outcome == "done":
+        await wallet_service.settle_reserve(reserve_tx_id)
+        return {"ok": True, "outcome": "done", "job": job}
+    if outcome == "failed":
+        await wallet_service.cancel_reserve(reserve_tx_id)
+        return {"ok": False, "outcome": "failed", "error": job.get("detail") or "trade failed", "job": job}
+    return {"ok": False, "outcome": "pending", "job_id": job_id, "reserve_tx_id": reserve_tx_id, "job": job}
+
+
+# ---------------------------------------------------------------------------
+# internal pay (no trade)
+# ---------------------------------------------------------------------------
+async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, notes: str = None) -> dict:
+    """Move tix between two wallets with no MTGO trade (a plain claim transfer)."""
+    try:
+        debit, credit = await wallet_service.pay(guild_id, from_player, to_player, amount, notes=notes)
+        return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
+    except ValueError as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# debt settlement from wallet — wallet move + debt clear in ONE transaction
+# ---------------------------------------------------------------------------
+async def _with_retry(thunk):
+    delay = 1.0
+    for attempt in range(3):
+        try:
+            return await thunk()
+        except OperationalError as e:
+            if "database is locked" in str(e) and attempt < 2:
+                logger.warning(f"resolution DB locked (attempt {attempt + 1}/3), retrying in {delay}s...")
+                await asyncio.sleep(delay)
+                delay *= 2
+            else:
+                raise
+
+
+async def _sum(session, column, *conditions) -> int:
+    result = await session.execute(select(func.coalesce(func.sum(column), 0)).where(*conditions))
+    return int(result.scalar() or 0)
+
+
+async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str, amount: int,
+                                  *, link_id: str = None) -> dict:
+    """Settle a tix debt from the payer's wallet: move the claim (payer −N, creditor +N)
+    AND clear the debt ledger, atomically in one transaction. No MTGO trade — the tix
+    never leave the vault; only the claim on them changes hands.
+
+    Validates funds AND the outstanding debt inside the transaction, and is idempotent by
+    ``link_id`` (which tags both the WalletTx pair and the DebtLedger settlement pair)."""
+    if amount <= 0:
+        return {"ok": False, "error": "amount must be positive"}
+    if payer_id == creditor_id:
+        return {"ok": False, "error": "cannot settle a debt with yourself"}
+    if link_id is None:
+        link_id = str(uuid.uuid4())
+    wallet_source = f"debt:{link_id}"
+
+    async def _do():
+        async with db_session() as session:
+            # idempotency: this settlement already applied?
+            seen = await session.execute(
+                select(WalletTx.id).where(WalletTx.source == wallet_source).limit(1))
+            if seen.scalar():
+                return {"ok": True, "amount": amount, "id": link_id, "idempotent": True}
+
+            # payer must have the funds (settled minus reserved)
+            done = await _sum(session, WalletTx.amount,
+                              WalletTx.guild_id == guild_id, WalletTx.player_id == payer_id,
+                              WalletTx.status == "done")
+            pending = await _sum(session, WalletTx.amount,
+                                 WalletTx.guild_id == guild_id, WalletTx.player_id == payer_id,
+                                 WalletTx.status == "pending")
+            available = done + pending  # pending debits are negative
+            if amount > available:
+                return {"ok": False, "error": f"insufficient wallet funds (available {available})"}
+
+            # payer must actually owe the creditor at least this much
+            debt_balance = await _sum(session, DebtLedger.amount,
+                                      DebtLedger.guild_id == guild_id,
+                                      DebtLedger.player_id == payer_id,
+                                      DebtLedger.counterparty_id == creditor_id)
+            if debt_balance >= 0:
+                return {"ok": False, "error": "no outstanding debt to this creditor"}
+            owed = -debt_balance
+            if amount > owed:
+                return {"ok": False, "error": f"amount ({amount}) exceeds debt ({owed})"}
+
+            note = f"Wallet debt settlement: {amount} tix"
+            # 1) wallet claim move (payer -> creditor)
+            session.add(WalletTx(guild_id=guild_id, player_id=payer_id, kind="pay", amount=-amount,
+                                 status="done", counterparty_id=creditor_id, source=wallet_source, notes=note))
+            session.add(WalletTx(guild_id=guild_id, player_id=creditor_id, kind="receive", amount=amount,
+                                 status="done", counterparty_id=payer_id, source=wallet_source, notes=note))
+            # 2) debt ledger settlement (payer +amount reduces debt; creditor -amount reduces credit)
+            session.add(DebtLedger(guild_id=guild_id, player_id=payer_id, counterparty_id=creditor_id,
+                                   amount=amount, source_type="settlement", source_id=link_id,
+                                   notes=note, created_by=payer_id))
+            session.add(DebtLedger(guild_id=guild_id, player_id=creditor_id, counterparty_id=payer_id,
+                                   amount=-amount, source_type="settlement", source_id=link_id,
+                                   notes=note, created_by=payer_id))
+            # single commit on exit -> wallet + debt move together or not at all
+            logger.info(f"settle_debt_from_wallet: {payer_id} -> {creditor_id} {amount} tix (link {link_id})")
+            return {"ok": True, "amount": amount, "payer": payer_id, "creditor": creditor_id, "id": link_id}
+
+    return await _with_retry(_do)
+
+
+async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
+    """Apply a player's wallet balance to their outstanding debts, oldest debt first,
+    until the wallet is exhausted or the debts are cleared. Returns the settlements made.
+
+    Called after a deposit (fresh funds) or after a debt is booked (funds already there).
+    Each settlement is atomic and re-checks the live debt, so a concurrent or repeated run
+    simply draws against whatever remains — it converges, never over-pays."""
+    available = await wallet_service.get_available(guild_id, player_id)
+    if available <= 0:
+        return []
+    balances = await debt_service.get_all_balances_for(guild_id, player_id)
+    owed = {cp: -bal for cp, bal in balances.items() if bal < 0}  # positive amounts owed
+    if not owed:
+        return []
+
+    # order creditors by the age of the oldest still-active debt entry (oldest first)
+    ordered = []
+    for cp in owed:
+        entries = await debt_service.get_active_debt_entries(guild_id, player_id, cp)
+        oldest_ts = entries[-1].created_at if entries else None  # entries are newest-first
+        ordered.append((oldest_ts, cp))
+    ordered.sort(key=lambda t: (t[0] is None, t[0]))
+
+    settlements = []
+    for _, cp in ordered:
+        if available <= 0:
+            break
+        pay_amt = min(available, owed[cp])
+        if pay_amt <= 0:
+            continue
+        res = await settle_debt_from_wallet(guild_id, player_id, cp, pay_amt)
+        if res.get("ok"):
+            available -= pay_amt
+            settlements.append(res)
+        else:
+            logger.warning(f"auto_draw: settle {player_id}->{cp} {pay_amt} skipped: {res.get('error')}")
+    if settlements:
+        logger.info(f"auto_draw: {player_id} settled {len(settlements)} debt(s) from wallet")
+    return settlements
+
+
+# ---------------------------------------------------------------------------
+# reconciliation passthrough (physical vault tix == SUM settled wallets)
+# ---------------------------------------------------------------------------
+async def reconcile(guild_id: str = None) -> dict:
+    """Pull the vault's live tix from the serve and compare to the wallet claim total."""
+    client = get_client()
+    bot_tix = await client.bot_tix()
+    if bot_tix is None:
+        return {"ok": False, "error": "could not read vault tix from serve"}
+    return await wallet_service.reconcile(bot_tix, guild_id)

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -94,9 +94,13 @@ async def _resolve_job(job_id: str, status: str):
     await with_db_retry(_do)
 
 
-async def _recover_lost_job(job_type: str, mtgo_user: str, n: int):
-    """After an ambiguous POST failure, look for the job on the serve (the POST may have
-    landed even though we never saw the 202). One retry covers a brief flap."""
+async def _recover_lost_job(resp, job_type: str, mtgo_user: str, n: int):
+    """Recovery for a failed job POST. Runs the /jobs adoption scan ONLY when the client
+    flagged the failure as ambiguous (delivered-but-response-lost is possible); a definite
+    rejection or never-connected error returns None immediately — no job can exist, and
+    the caller may fail fast. One retry covers a brief flap."""
+    if not (resp and resp.get("_ambiguous")):
+        return None
     client = get_client()
     job = await client.find_recent_job(job_type, mtgo_user, n)
     if job is None:
@@ -120,9 +124,10 @@ async def start_deposit(guild_id: str, player_id: str, mtgo_user: str, n: int, *
         return {"ok": False, "error": "MTGO TradeBot integration is disabled"}
     resp = await client.deposit_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
     if not resp or not resp.get("id"):
-        # Ambiguous: the POST may have reached the serve and only the response was lost —
-        # in that case the trade can still fire, so adopt the job rather than orphan it.
-        resp = await _recover_lost_job("deposit", mtgo_user, n)
+        # If the POST may have reached the serve with only the response lost, the trade
+        # can still fire — adopt the job rather than orphan it. Definite failures skip
+        # the scan and fail fast.
+        resp = await _recover_lost_job(resp, "deposit", mtgo_user, n)
         if not resp or not resp.get("id"):
             return {"ok": False, "error": "serve did not accept the deposit (unreachable or rejected)"}
         logger.warning(f"start_deposit: adopted job {resp['id']} after lost POST response")
@@ -169,10 +174,10 @@ async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, 
 
     resp = await client.withdraw_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
     if not resp or not resp.get("id"):
-        resp = await _recover_lost_job("request", mtgo_user, n)
+        resp = await _recover_lost_job(resp, "request", mtgo_user, n)
         if not resp or not resp.get("id"):
-            # The serve's job list shows no such job (or the serve is entirely down, in
-            # which case no trade can have been opened either) — safe to release the hold.
+            # Definite rejection, or an ambiguous failure whose job-list scan shows no
+            # job — either way no trade can have been opened; safe to release the hold.
             await wallet_service.cancel_reserve(reserve.id)
             return {"ok": False, "error": "serve did not accept the withdraw (unreachable or rejected)"}
         logger.warning(f"start_withdraw: adopted job {resp['id']} after lost POST response")
@@ -200,46 +205,48 @@ async def finish_withdraw(reserve_tx_id: int, job_id: str,
 
 
 # ---------------------------------------------------------------------------
-# startup resumer — finish booking any job whose poller died (timeout/restart)
+# pending-jobs watchdog — finish booking any job whose poller died
+# (poll timeout / bot restart / gateway reconnect)
 # ---------------------------------------------------------------------------
-async def resume_pending_jobs() -> int:
-    """Re-poll every 'pending' MtgoJob to a terminal state and book its ledger side.
-    Booking is idempotent (job_id unique index), so racing a still-live poller is safe.
-    Returns the number of jobs picked up; the polls run as background tasks."""
-    from helpers.money_gate import spawn_followup
+_RESCAN_INTERVAL_S = 10 * 60
+_watchdog_running = False   # on_ready refires on gateway reconnects; start one loop only
+_polling_jobs: set = set()  # job_ids with a live resumed poller — rescans skip them
 
+
+async def resume_pending_jobs() -> int:
+    """Spawn a poller for every 'pending' MtgoJob that doesn't already have one, booking
+    its ledger side when the job reaches a terminal state. Booking is idempotent
+    (job_id unique index), so racing a still-live command poller is safe. Returns the
+    number of jobs picked up."""
     async with db_session() as session:
         pending = (await session.execute(
             select(MtgoJob).where(MtgoJob.status == "pending"))).scalars().all()
+    pending = [j for j in pending if j.job_id not in _polling_jobs]
     if not pending:
         return 0
 
-    async def _resume_deposit(job: MtgoJob):
-        res = await finish_deposit(job.job_id, job.guild_id, job.player_id,
-                                   job.amount, job.mtgo_user)
-        if res.get("ok") and job.context and job.context.startswith("tourney:"):
-            # deposit was for a tournament entry — re-secure the escrow now the funds landed
-            from services import tournament_escrow_service as escrow
-            from models.tournament import Tournament, TournamentParticipant
-            _, tid, pid = job.context.split(":")
-            async with db_session() as session:
-                t = await session.get(Tournament, int(tid))
-                p = await session.get(TournamentParticipant, int(pid))
-            if t and p and p.status != "paid" and (t.entry_fee or 0) > 0:
-                await escrow.secure_from_wallet(
-                    job.guild_id, job.player_id, p.id, t.id, t.entry_fee, p.team_name)
+    async def _resume(job: MtgoJob):
+        try:
+            if job.kind == "deposit":
+                res = await finish_deposit(job.job_id, job.guild_id, job.player_id,
+                                           job.amount, job.mtgo_user)
+                if res.get("ok") and job.context:
+                    # the deposit had a continuation (e.g. a tournament entry) — the
+                    # escrow service owns the context format and what to do with it
+                    from services import tournament_escrow_service as escrow
+                    await escrow.resume_entry_from_context(
+                        job.guild_id, job.player_id, job.context)
+            elif job.kind == "withdraw" and job.reserve_tx_id:
+                await finish_withdraw(job.reserve_tx_id, job.job_id)
+        finally:
+            _polling_jobs.discard(job.job_id)
 
+    from helpers.money_gate import spawn_followup
     for job in pending:
-        if job.kind == "deposit":
-            spawn_followup(f"resume deposit {job.job_id}", _resume_deposit(job))
-        elif job.kind == "withdraw" and job.reserve_tx_id:
-            spawn_followup(f"resume withdraw {job.job_id}",
-                           finish_withdraw(job.reserve_tx_id, job.job_id))
+        _polling_jobs.add(job.job_id)
+        spawn_followup(f"resume {job.kind} {job.job_id}", _resume(job))
     logger.info(f"resume_pending_jobs: picked up {len(pending)} unresolved MTGO job(s)")
     return len(pending)
-
-
-_RESCAN_INTERVAL_S = 10 * 60
 
 
 async def pending_jobs_watchdog():
@@ -247,9 +254,14 @@ async def pending_jobs_watchdog():
 
     A single startup pass isn't enough: each poll gives up after ~14 minutes
     ('pending' outcome), but a serve job can complete later than that (a stalled
-    serve that recovers, live case: 28 minutes). The rescan keeps re-polling
-    every still-pending job until it reaches a terminal state — booking stays
-    idempotent by job_id, so overlapping pollers are harmless."""
+    serve that recovers, live case: 28 minutes). The rescan re-polls every
+    still-pending job — skipping ones whose poller is still live — until it
+    reaches a terminal state. Guarded so on_ready refiring on gateway reconnects
+    can't stack duplicate loops (same pattern as run_log_reconciler)."""
+    global _watchdog_running
+    if _watchdog_running:
+        return
+    _watchdog_running = True
     while True:
         try:
             await resume_pending_jobs()

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -19,11 +19,14 @@ background task within Discord's interaction window.
 """
 import asyncio
 import uuid
+from datetime import datetime
+
 from loguru import logger
 from sqlalchemy import select, func
 
 from database.db_session import db_session
 from database.retry import with_db_retry
+from models.mtgo_job import MtgoJob
 from models.wallet_tx import WalletTx
 from models.debt_ledger import DebtLedger
 from services.mtgo_tradebot_client import get_client
@@ -65,10 +68,51 @@ async def _poll_job(job_id: str, timeout_s: float):
 
 
 # ---------------------------------------------------------------------------
+# durable job records — every started serve job is persisted so a startup
+# resumer can finish booking trades that outlive their in-memory poller
+# ---------------------------------------------------------------------------
+async def _record_job(job_id: str, kind: str, guild_id: str, player_id: str, mtgo_user: str,
+                      amount: int, *, reserve_tx_id: int = None, context: str = None):
+    async def _do():
+        async with db_session() as session:
+            if await session.get(MtgoJob, job_id):
+                return
+            session.add(MtgoJob(
+                job_id=job_id, kind=kind, guild_id=guild_id, player_id=player_id,
+                mtgo_user=mtgo_user, amount=amount, reserve_tx_id=reserve_tx_id,
+                context=context, status="pending"))
+    await with_db_retry(_do)
+
+
+async def _resolve_job(job_id: str, status: str):
+    async def _do():
+        async with db_session() as session:
+            job = await session.get(MtgoJob, job_id)
+            if job is not None and job.status == "pending":
+                job.status = status
+                job.resolved_at = datetime.now()
+    await with_db_retry(_do)
+
+
+async def _recover_lost_job(job_type: str, mtgo_user: str, n: int):
+    """After an ambiguous POST failure, look for the job on the serve (the POST may have
+    landed even though we never saw the 202). One retry covers a brief flap."""
+    client = get_client()
+    job = await client.find_recent_job(job_type, mtgo_user, n)
+    if job is None:
+        await asyncio.sleep(2)
+        job = await client.find_recent_job(job_type, mtgo_user, n)
+    return job
+
+
+# ---------------------------------------------------------------------------
 # deposit (bot receives tix) — credit only on 'done'
 # ---------------------------------------------------------------------------
-async def start_deposit(mtgo_user: str, n: int, *, commit: bool = True, wait_minutes: int = 0) -> dict:
-    """Enqueue a deposit (bot receives ``n`` tix from ``mtgo_user``). No ledger effect yet."""
+async def start_deposit(guild_id: str, player_id: str, mtgo_user: str, n: int, *,
+                        commit: bool = True, wait_minutes: int = 0, context: str = None) -> dict:
+    """Enqueue a deposit (bot receives ``n`` tix from ``mtgo_user``). No wallet effect yet,
+    but the job is durably recorded so it can't be stranded by a restart. ``context`` tags
+    what to do beyond crediting when the trade lands (see resume_pending_jobs)."""
     if n <= 0:
         return {"ok": False, "error": "amount must be positive"}
     client = get_client()
@@ -76,7 +120,13 @@ async def start_deposit(mtgo_user: str, n: int, *, commit: bool = True, wait_min
         return {"ok": False, "error": "MTGO TradeBot integration is disabled"}
     resp = await client.deposit_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
     if not resp or not resp.get("id"):
-        return {"ok": False, "error": "serve did not accept the deposit (unreachable or rejected)"}
+        # Ambiguous: the POST may have reached the serve and only the response was lost —
+        # in that case the trade can still fire, so adopt the job rather than orphan it.
+        resp = await _recover_lost_job("deposit", mtgo_user, n)
+        if not resp or not resp.get("id"):
+            return {"ok": False, "error": "serve did not accept the deposit (unreachable or rejected)"}
+        logger.warning(f"start_deposit: adopted job {resp['id']} after lost POST response")
+    await _record_job(resp["id"], "deposit", guild_id, player_id, mtgo_user, n, context=context)
     return {"ok": True, "job_id": resp["id"], "job": resp}
 
 
@@ -88,8 +138,10 @@ async def finish_deposit(job_id: str, guild_id: str, player_id: str, n: int, mtg
         tx = await wallet_service.credit_done(
             guild_id, player_id, n, kind="deposit",
             job_id=job_id, counterparty_id=mtgo_user, source="serve", notes=f"deposit {n} tix")
+        await _resolve_job(job_id, "done")
         return {"ok": True, "outcome": "done", "credited": n, "tx_id": tx.id, "job": job}
     if outcome == "failed":
+        await _resolve_job(job_id, "failed")
         return {"ok": False, "outcome": "failed", "error": job.get("detail") or "trade failed", "job": job}
     return {"ok": False, "outcome": "pending", "job_id": job_id, "job": job}
 
@@ -100,7 +152,9 @@ async def finish_deposit(job_id: str, guild_id: str, player_id: str, n: int, mtg
 async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, *,
                          commit: bool = True, wait_minutes: int = 0) -> dict:
     """Reserve ``n`` tix in the player's wallet (atomic funds check), then enqueue the give.
-    If the serve rejects it, the reservation is released."""
+    The reservation is released ONLY when we're sure the serve never created the job —
+    an ambiguous POST failure keeps the hold (the trade may still fire) and adopts the
+    job from the serve's list when it can."""
     if n <= 0:
         return {"ok": False, "error": "amount must be positive"}
     client = get_client()
@@ -115,24 +169,74 @@ async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, 
 
     resp = await client.withdraw_tix(mtgo_user, n, commit=commit, wait_minutes=wait_minutes)
     if not resp or not resp.get("id"):
-        await wallet_service.cancel_reserve(reserve.id)  # release the hold
-        return {"ok": False, "error": "serve did not accept the withdraw (unreachable or rejected)"}
+        resp = await _recover_lost_job("request", mtgo_user, n)
+        if not resp or not resp.get("id"):
+            # The serve's job list shows no such job (or the serve is entirely down, in
+            # which case no trade can have been opened either) — safe to release the hold.
+            await wallet_service.cancel_reserve(reserve.id)
+            return {"ok": False, "error": "serve did not accept the withdraw (unreachable or rejected)"}
+        logger.warning(f"start_withdraw: adopted job {resp['id']} after lost POST response")
     await wallet_service.attach_job(reserve.id, resp["id"])
+    await _record_job(resp["id"], "withdraw", guild_id, player_id, mtgo_user, n,
+                      reserve_tx_id=reserve.id)
     return {"ok": True, "job_id": resp["id"], "reserve_tx_id": reserve.id, "job": resp}
 
 
 async def finish_withdraw(reserve_tx_id: int, job_id: str,
                           timeout_s: float = _DEFAULT_POLL_TIMEOUT_S) -> dict:
     """Poll the withdraw job; confirm the reservation on 'done', release it on 'failed'.
-    On timeout the reservation stays in place (funds remain held) — resolvable later."""
+    On timeout the reservation stays in place (funds remain held) — the startup resumer
+    or a later poll resolves it."""
     outcome, job = await _poll_job(job_id, timeout_s)
     if outcome == "done":
         await wallet_service.settle_reserve(reserve_tx_id)
+        await _resolve_job(job_id, "done")
         return {"ok": True, "outcome": "done", "job": job}
     if outcome == "failed":
         await wallet_service.cancel_reserve(reserve_tx_id)
+        await _resolve_job(job_id, "failed")
         return {"ok": False, "outcome": "failed", "error": job.get("detail") or "trade failed", "job": job}
     return {"ok": False, "outcome": "pending", "job_id": job_id, "reserve_tx_id": reserve_tx_id, "job": job}
+
+
+# ---------------------------------------------------------------------------
+# startup resumer — finish booking any job whose poller died (timeout/restart)
+# ---------------------------------------------------------------------------
+async def resume_pending_jobs() -> int:
+    """Re-poll every 'pending' MtgoJob to a terminal state and book its ledger side.
+    Booking is idempotent (job_id unique index), so racing a still-live poller is safe.
+    Returns the number of jobs picked up; the polls run as background tasks."""
+    from helpers.money_gate import spawn_followup
+
+    async with db_session() as session:
+        pending = (await session.execute(
+            select(MtgoJob).where(MtgoJob.status == "pending"))).scalars().all()
+    if not pending:
+        return 0
+
+    async def _resume_deposit(job: MtgoJob):
+        res = await finish_deposit(job.job_id, job.guild_id, job.player_id,
+                                   job.amount, job.mtgo_user)
+        if res.get("ok") and job.context and job.context.startswith("tourney:"):
+            # deposit was for a tournament entry — re-secure the escrow now the funds landed
+            from services import tournament_escrow_service as escrow
+            from models.tournament import Tournament, TournamentParticipant
+            _, tid, pid = job.context.split(":")
+            async with db_session() as session:
+                t = await session.get(Tournament, int(tid))
+                p = await session.get(TournamentParticipant, int(pid))
+            if t and p and p.status != "paid" and (t.entry_fee or 0) > 0:
+                await escrow.secure_from_wallet(
+                    job.guild_id, job.player_id, p.id, t.id, t.entry_fee, p.team_name)
+
+    for job in pending:
+        if job.kind == "deposit":
+            spawn_followup(f"resume deposit {job.job_id}", _resume_deposit(job))
+        elif job.kind == "withdraw" and job.reserve_tx_id:
+            spawn_followup(f"resume withdraw {job.job_id}",
+                           finish_withdraw(job.reserve_tx_id, job.job_id))
+    logger.info(f"resume_pending_jobs: picked up {len(pending)} unresolved MTGO job(s)")
+    return len(pending)
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +315,8 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
             logger.info(f"settle_debt_from_wallet: {payer_id} -> {creditor_id} {amount} tix (link {link_id})")
             return {"ok": True, "amount": amount, "payer": payer_id, "creditor": creditor_id, "id": link_id}
 
-    return await with_db_retry(_do)
+    async with wallet_service.MONEY_LOCK:
+        return await with_db_retry(_do)
 
 
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:

--- a/services/mtgo_tradebot_client.py
+++ b/services/mtgo_tradebot_client.py
@@ -1,0 +1,121 @@
+"""
+Async HTTP client for the MTGO TradeBot ``serve`` API — the *physical ledger* / trade executor.
+
+The serve is a token-protected internal service (bearer auth, loopback / Tailscale) that owns the
+bot's real MTGO collection and executes trades. DraftBot is just another authed client: it POSTs
+deposit / withdraw / trade jobs and polls ``/jobs/{id}`` to a terminal state, then applies the result
+to its own (obligation) ledger.
+
+Config via env ``MTGO_TRADEBOT_URL`` + ``MTGO_TRADEBOT_TOKEN``. The client stays **disabled** — every
+method returns ``None`` — unless *both* are set, so nothing breaks on servers without the integration
+(mirrors the "stay disabled unless the token is set" guard in services/mtgo_result_api.py).
+
+Mirrors the aiohttp idiom in helpers/magicprotools_helper.py, plus a Bearer header + a timeout.
+"""
+import logging
+import os
+from typing import List, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# On MTGO, event tickets are the currency. Depositing/withdrawing tix is just trading this "card".
+EVENT_TICKET = "Event Ticket"
+
+
+class MtgoTradeBotClient:
+    """Thin async wrapper over the serve API. All methods return the parsed JSON dict on success,
+    or ``None`` on any failure / when disabled (they never raise to the caller)."""
+
+    def __init__(self, url: Optional[str] = None, token: Optional[str] = None, timeout: float = 20.0):
+        self.url = (url or os.getenv("MTGO_TRADEBOT_URL") or "").rstrip("/")
+        self.token = token or os.getenv("MTGO_TRADEBOT_TOKEN") or ""
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.url and self.token)
+
+    async def _call(self, method: str, path: str, *, json=None, params=None):
+        if not self.enabled:
+            logger.warning("MtgoTradeBotClient disabled (MTGO_TRADEBOT_URL / MTGO_TRADEBOT_TOKEN not set)")
+            return None
+        headers = {"Authorization": f"Bearer {self.token}"}
+        full = f"{self.url}{path}"
+        try:
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.request(method, full, headers=headers, json=json, params=params) as resp:
+                    text = await resp.text()
+                    if resp.status < 200 or resp.status >= 300:
+                        logger.warning("TradeBot %s %s -> HTTP %s: %s", method, path, resp.status, text[:200])
+                        return None
+                    if not text:
+                        return {}
+                    try:
+                        return await resp.json()
+                    except Exception:
+                        return {"raw": text}
+        except Exception as e:  # network / timeout / dns
+            logger.error("TradeBot %s %s failed: %s", method, path, e)
+            return None
+
+    # ---- reads ----
+    async def health(self):
+        """{ok, custodian, commit, reconnecting, queued, jobs} — connectivity + arm state."""
+        return await self._call("GET", "/health")
+
+    async def vault(self):
+        """{available, custodian, tix, distinct, top[]} — used to reconcile physical == Σ wallets."""
+        return await self._call("GET", "/vault")
+
+    async def holdings(self):
+        """{holdings[]} — the custody accounting (card, owner, borrower, status)."""
+        return await self._call("GET", "/holdings")
+
+    async def get_job(self, job_id: str):
+        """One job's projection incl. its terminal ``state`` (queued|running|done|failed) + ``detail``."""
+        return await self._call("GET", f"/jobs/{job_id}")
+
+    # ---- jobs (each returns the 202 job dict, whose ``id`` you then poll) ----
+    async def deposit(self, user: str, card: str, qty: int = 1, commit: bool = True, wait_minutes: int = 0):
+        """Bot RECEIVES qty of a card FROM the user (a deposit into custody)."""
+        return await self._call("POST", "/deposit", json={
+            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes})
+
+    async def give(self, user: str, card: str, qty: int = 1, commit: bool = True, wait_minutes: int = 0):
+        """Bot GIVES qty of a card TO the user (a withdrawal, or a lend)."""
+        return await self._call("POST", "/request", json={
+            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes})
+
+    async def trade(self, partner: str, give: Optional[List[dict]] = None, receive: Optional[List[dict]] = None,
+                    commit: bool = True, wait_minutes: int = 0):
+        """General trade. ``give``/``receive`` are lists of {name, qty, catId?} (catId pins the printing)."""
+        return await self._call("POST", "/trade", json={
+            "partner": partner, "give": give or [], "receive": receive or [],
+            "commit": commit, "waitMinutes": wait_minutes})
+
+    # ---- tix convenience (currency == Event Ticket) ----
+    async def deposit_tix(self, user: str, n: int, commit: bool = True, wait_minutes: int = 0):
+        return await self.deposit(user, EVENT_TICKET, n, commit=commit, wait_minutes=wait_minutes)
+
+    async def withdraw_tix(self, user: str, n: int, commit: bool = True, wait_minutes: int = 0):
+        return await self.give(user, EVENT_TICKET, n, commit=commit, wait_minutes=wait_minutes)
+
+    async def bot_tix(self) -> Optional[int]:
+        """Physical tix the bot currently holds (for the reconciliation audit). None if unavailable."""
+        v = await self.vault()
+        if not v or not v.get("available"):
+            return None
+        return v.get("tix")
+
+
+# Lazy module-level singleton (env is loaded by bot.py's load_dotenv() before cogs import).
+_client: Optional[MtgoTradeBotClient] = None
+
+
+def get_client() -> MtgoTradeBotClient:
+    global _client
+    if _client is None:
+        _client = MtgoTradeBotClient()
+    return _client

--- a/services/mtgo_tradebot_client.py
+++ b/services/mtgo_tradebot_client.py
@@ -13,6 +13,7 @@ method returns ``None`` — unless *both* are set, so nothing breaks on servers 
 Mirrors the aiohttp idiom in helpers/magicprotools_helper.py, plus a Bearer header + a timeout.
 """
 import os
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import aiohttp
@@ -48,7 +49,15 @@ class MtgoTradeBotClient:
         if self._session is not None and not self._session.closed:
             await self._session.close()
 
-    async def _call(self, method: str, path: str, *, json=None, params=None):
+    async def _call(self, method: str, path: str, *, json=None, params=None,
+                    mark_ambiguous: bool = False):
+        """One HTTP call. Returns the parsed body, or None on any DEFINITE failure
+        (disabled, HTTP error status, connection never established).
+
+        ``mark_ambiguous``: for POSTs whose delivery matters (they create serve jobs) —
+        a timeout/reset AFTER the connection was made may mean the request landed and
+        only the response was lost, so those return ``{"_ambiguous": True}`` instead of
+        None, letting the caller run job-adoption recovery only when it's warranted."""
         if not self.enabled:
             logger.warning("MtgoTradeBotClient disabled (MTGO_TRADEBOT_URL / MTGO_TRADEBOT_TOKEN not set)")
             return None
@@ -67,9 +76,12 @@ class MtgoTradeBotClient:
                     return await resp.json()
                 except Exception:
                     return {"raw": text}
-        except Exception as e:  # network / timeout / dns
-            logger.error(f"TradeBot {method} {path} failed: {e}")
+        except aiohttp.ClientConnectorError as e:  # connection refused / DNS — never delivered
+            logger.error(f"TradeBot {method} {path} unreachable: {e}")
             return None
+        except Exception as e:  # timeout / reset mid-flight — delivery unknown
+            logger.error(f"TradeBot {method} {path} failed ambiguously: {e}")
+            return {"_ambiguous": True} if mark_ambiguous else None
 
     # ---- reads ----
     async def health(self):
@@ -90,7 +102,6 @@ class MtgoTradeBotClient:
         listing = await self._call("GET", "/jobs")
         if not listing:
             return None
-        from datetime import datetime, timedelta, timezone
         now = datetime.now(timezone.utc)
         for job in listing.get("jobs", []):  # serve lists newest first
             if job.get("type") != job_type or job.get("state") == "failed":
@@ -100,15 +111,8 @@ class MtgoTradeBotClient:
             items = job.get("receive") if job_type == "deposit" else job.get("give")
             if not items or items[0].get("name") != EVENT_TICKET or items[0].get("qty") != qty:
                 continue
-            created = job.get("createdAt") or ""
             try:
-                # serve timestamps: ISO-8601 UTC with 7-digit fractions, e.g.
-                # 2026-08-11T09:00:10.2460618Z — trim to microseconds for fromisoformat
-                trimmed = created.rstrip("Z")
-                if "." in trimmed:
-                    head, frac = trimmed.split(".", 1)
-                    trimmed = f"{head}.{frac[:6]}"
-                ts = datetime.fromisoformat(trimmed).replace(tzinfo=timezone.utc)
+                ts = datetime.fromisoformat(job.get("createdAt") or "")
                 if now - ts > timedelta(seconds=max_age_s):
                     continue
             except ValueError:
@@ -124,12 +128,14 @@ class MtgoTradeBotClient:
     async def deposit(self, user: str, card: str, qty: int = 1, commit: bool = True, wait_minutes: int = 0):
         """Bot RECEIVES qty of a card FROM the user (a deposit into custody)."""
         return await self._call("POST", "/deposit", json={
-            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes})
+            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes},
+            mark_ambiguous=True)
 
     async def give(self, user: str, card: str, qty: int = 1, commit: bool = True, wait_minutes: int = 0):
         """Bot GIVES qty of a card TO the user (a withdrawal, or a lend)."""
         return await self._call("POST", "/request", json={
-            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes})
+            "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes},
+            mark_ambiguous=True)
 
     # ---- tix convenience (currency == Event Ticket) ----
     async def deposit_tix(self, user: str, n: int, commit: bool = True, wait_minutes: int = 0):

--- a/services/mtgo_tradebot_client.py
+++ b/services/mtgo_tradebot_client.py
@@ -12,13 +12,11 @@ method returns ``None`` — unless *both* are set, so nothing breaks on servers 
 
 Mirrors the aiohttp idiom in helpers/magicprotools_helper.py, plus a Bearer header + a timeout.
 """
-import logging
 import os
-from typing import List, Optional
+from typing import Optional
 
 import aiohttp
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 # On MTGO, event tickets are the currency. Depositing/withdrawing tix is just trading this "card".
 EVENT_TICKET = "Event Ticket"
@@ -32,10 +30,23 @@ class MtgoTradeBotClient:
         self.url = (url or os.getenv("MTGO_TRADEBOT_URL") or "").rstrip("/")
         self.token = token or os.getenv("MTGO_TRADEBOT_TOKEN") or ""
         self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session: Optional[aiohttp.ClientSession] = None
 
     @property
     def enabled(self) -> bool:
         return bool(self.url and self.token)
+
+    def _get_session(self) -> aiohttp.ClientSession:
+        """One shared session for connection reuse — job polling hits the serve every few
+        seconds for minutes at a time, so per-call sessions would pay a fresh TCP handshake
+        each poll. Lives for the process; aiohttp reclaims idle connections itself."""
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self.timeout)
+        return self._session
+
+    async def close(self):
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
 
     async def _call(self, method: str, path: str, *, json=None, params=None):
         if not self.enabled:
@@ -44,20 +55,20 @@ class MtgoTradeBotClient:
         headers = {"Authorization": f"Bearer {self.token}"}
         full = f"{self.url}{path}"
         try:
-            async with aiohttp.ClientSession(timeout=self.timeout) as session:
-                async with session.request(method, full, headers=headers, json=json, params=params) as resp:
-                    text = await resp.text()
-                    if resp.status < 200 or resp.status >= 300:
-                        logger.warning("TradeBot %s %s -> HTTP %s: %s", method, path, resp.status, text[:200])
-                        return None
-                    if not text:
-                        return {}
-                    try:
-                        return await resp.json()
-                    except Exception:
-                        return {"raw": text}
+            session = self._get_session()
+            async with session.request(method, full, headers=headers, json=json, params=params) as resp:
+                text = await resp.text()
+                if resp.status < 200 or resp.status >= 300:
+                    logger.warning(f"TradeBot {method} {path} -> HTTP {resp.status}: {text[:200]}")
+                    return None
+                if not text:
+                    return {}
+                try:
+                    return await resp.json()
+                except Exception:
+                    return {"raw": text}
         except Exception as e:  # network / timeout / dns
-            logger.error("TradeBot %s %s failed: %s", method, path, e)
+            logger.error(f"TradeBot {method} {path} failed: {e}")
             return None
 
     # ---- reads ----
@@ -68,10 +79,6 @@ class MtgoTradeBotClient:
     async def vault(self):
         """{available, custodian, tix, distinct, top[]} — used to reconcile physical == Σ wallets."""
         return await self._call("GET", "/vault")
-
-    async def holdings(self):
-        """{holdings[]} — the custody accounting (card, owner, borrower, status)."""
-        return await self._call("GET", "/holdings")
 
     async def get_job(self, job_id: str):
         """One job's projection incl. its terminal ``state`` (queued|running|done|failed) + ``detail``."""
@@ -87,13 +94,6 @@ class MtgoTradeBotClient:
         """Bot GIVES qty of a card TO the user (a withdrawal, or a lend)."""
         return await self._call("POST", "/request", json={
             "user": user, "cards": [card], "qty": qty, "commit": commit, "waitMinutes": wait_minutes})
-
-    async def trade(self, partner: str, give: Optional[List[dict]] = None, receive: Optional[List[dict]] = None,
-                    commit: bool = True, wait_minutes: int = 0):
-        """General trade. ``give``/``receive`` are lists of {name, qty, catId?} (catId pins the printing)."""
-        return await self._call("POST", "/trade", json={
-            "partner": partner, "give": give or [], "receive": receive or [],
-            "commit": commit, "waitMinutes": wait_minutes})
 
     # ---- tix convenience (currency == Event Ticket) ----
     async def deposit_tix(self, user: str, n: int, commit: bool = True, wait_minutes: int = 0):

--- a/services/mtgo_tradebot_client.py
+++ b/services/mtgo_tradebot_client.py
@@ -80,6 +80,42 @@ class MtgoTradeBotClient:
         """{available, custodian, tix, distinct, top[]} — used to reconcile physical == Σ wallets."""
         return await self._call("GET", "/vault")
 
+    async def find_recent_job(self, job_type: str, mtgo_user: str, qty: int,
+                              max_age_s: float = 120.0):
+        """Recover a job whose POST response was lost: scan GET /jobs for the newest
+        non-failed job of this type/user/qty created within ``max_age_s``. A POST that
+        actually reached the serve created a job even if we never saw the 202 — adopting
+        it here keeps the ledger attached to a trade that may still complete. Returns the
+        job dict or None."""
+        listing = await self._call("GET", "/jobs")
+        if not listing:
+            return None
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        for job in listing.get("jobs", []):  # serve lists newest first
+            if job.get("type") != job_type or job.get("state") == "failed":
+                continue
+            if (job.get("user") or "").lower() != mtgo_user.lower():
+                continue
+            items = job.get("receive") if job_type == "deposit" else job.get("give")
+            if not items or items[0].get("name") != EVENT_TICKET or items[0].get("qty") != qty:
+                continue
+            created = job.get("createdAt") or ""
+            try:
+                # serve timestamps: ISO-8601 UTC with 7-digit fractions, e.g.
+                # 2026-08-11T09:00:10.2460618Z — trim to microseconds for fromisoformat
+                trimmed = created.rstrip("Z")
+                if "." in trimmed:
+                    head, frac = trimmed.split(".", 1)
+                    trimmed = f"{head}.{frac[:6]}"
+                ts = datetime.fromisoformat(trimmed).replace(tzinfo=timezone.utc)
+                if now - ts > timedelta(seconds=max_age_s):
+                    continue
+            except ValueError:
+                pass  # unparseable timestamp: still adopt (better than stranding a live trade)
+            return job
+        return None
+
     async def get_job(self, job_id: str):
         """One job's projection incl. its terminal ``state`` (queued|running|done|failed) + ``detail``."""
         return await self._call("GET", f"/jobs/{job_id}")

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -8,10 +8,14 @@ with a per-participant ``source`` so it's idempotent and refundable:
               flip the participant to 'paid'. Reusing an existing reserve makes it safe to
               retry after a crash between reserving and marking paid.
   * refund  — cancel the reserve (drop before start); the tix become spendable again.
-  * on start — nothing moves: the reserve simply stays (now non-refundable). It is never
-              *settled*, because settling would remove tix from the captain's wallet with no
-              holder to receive them, breaking the vault == SUM(wallets) audit. The held
-              reserves ARE the pot; a future payout phase settles + redistributes them.
+  * on start — reallocate: each held reserve moves into the tournament's PRIZE WALLET
+              (settle the captain's reserve to 'done' AND credit the prize wallet the same
+              amount, in one transaction). That's an internal transfer, so vault ==
+              SUM(wallets) is preserved; the prize wallet now holds the pot, and a future
+              payout phase pays it out to the winners.
+
+The prize wallet is an ordinary wallet holder with a synthetic id (``prize:tourney:<id>``), so
+it's counted by the reconciliation audit and can later ``pay`` out to winners like any wallet.
 """
 from datetime import datetime
 
@@ -27,6 +31,11 @@ from services import wallet_service
 def escrow_source(tournament_id, participant_id) -> str:
     """Stable per-participant tag on the reserve (idempotency + refund handle + pot sum)."""
     return f"tourney:{tournament_id}:{participant_id}"
+
+
+def prize_wallet_id(tournament_id) -> str:
+    """Synthetic wallet holder for a tournament's prize pool (an ordinary WalletTx player_id)."""
+    return f"prize:tourney:{tournament_id}"
 
 
 async def mark_paid(participant_id: int, reserve_tx_id: int) -> bool:
@@ -134,3 +143,53 @@ async def total_escrowed(guild_id: str, tournament_id: int) -> int:
             )
         )
         return int(-(result.scalar() or 0))  # reserves are negative; report positive held
+
+
+async def reallocate_to_prize(session, guild_id: str, tournament_id: int) -> dict:
+    """Move every held escrow reserve into the tournament's prize wallet — run INSIDE the
+    caller's session so it commits atomically with ``start_tournament`` (seed + reallocate
+    together, or neither).
+
+    For each paid participant still holding a pending 'escrow' reserve: settle that reserve to
+    'done' (the captain's tix leave their wallet) AND credit the prize wallet the same amount
+    ('done'). Because it's an internal transfer, SUM(done) — and thus the vault==wallets audit —
+    is unchanged. Idempotent: a reserve that's already settled/cancelled is skipped, so a
+    re-run moves nothing. Returns {moved, count, prize_id}."""
+    prize_id = prize_wallet_id(tournament_id)
+    parts = (await session.execute(
+        select(TournamentParticipant).where(
+            TournamentParticipant.tournament_id == tournament_id,
+            TournamentParticipant.status == "paid",
+            TournamentParticipant.escrow_tx_id.isnot(None),
+        ))).scalars().all()
+
+    moved = 0
+    count = 0
+    for p in parts:
+        tx = await session.get(WalletTx, p.escrow_tx_id)
+        if tx is None or tx.status != "pending":
+            continue  # comped (no reserve), already reallocated, or refunded
+        fee = -tx.amount  # the reserve is a negative debit
+        tx.status = "done"  # settle the captain's debit
+        session.add(WalletTx(
+            guild_id=guild_id, player_id=prize_id, kind="receive", amount=fee, status="done",
+            counterparty_id=p.captain_user_id, source=f"prize:{tournament_id}:{p.id}",
+            notes=f"entry fee to prize pool: {p.team_name}"))
+        moved += fee
+        count += 1
+    await session.flush()
+    logger.info(f"prize reallocation: tournament {tournament_id} moved {moved} tix "
+                f"from {count} team(s) into {prize_id}")
+    return {"moved": moved, "count": count, "prize_id": prize_id}
+
+
+async def prize_pool(guild_id: str, tournament_id: int) -> int:
+    """The tournament's prize wallet balance (settled tix available to pay out)."""
+    async with db_session() as session:
+        result = await session.execute(
+            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
+                WalletTx.guild_id == guild_id,
+                WalletTx.player_id == prize_wallet_id(tournament_id),
+                WalletTx.status == "done",
+            ))
+        return int(result.scalar() or 0)

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -38,6 +38,48 @@ def prize_wallet_id(tournament_id) -> str:
     return f"prize:tourney:{tournament_id}"
 
 
+# Prize-pool split presets (top-heavy, per MTG convention). Ratios need not sum to 100 —
+# compute_allocations normalizes by the sum of the places actually paid.
+PAYOUT_STRUCTURES = {
+    "winner_take_all": [100],
+    "top2": [65, 35],
+    "top3": [50, 30, 20],
+    "top4": [40, 30, 20, 10],
+}
+
+
+def describe_structure(name: str) -> str:
+    ratios = PAYOUT_STRUCTURES.get(name)
+    if not ratios:
+        return name
+    if name == "winner_take_all":
+        return "winner-take-all"
+    return f"top {len(ratios)} ({'/'.join(str(r) for r in ratios)})"
+
+
+def compute_allocations(pool: int, structure: str, ranked: list) -> list:
+    """Split ``pool`` tix over the ranked teams by the named structure.
+
+    ``ranked`` is [(captain_id, team_name)] in finish order (1st first). Returns
+    [(place, captain_id, team_name, amount)] for amounts > 0. Integer tix; the whole pool is
+    always distributed — normalized to the places actually paid (so fewer teams than the
+    structure names just concentrates the split), with the rounding remainder going to 1st."""
+    ratios = PAYOUT_STRUCTURES.get(structure) or PAYOUT_STRUCTURES["winner_take_all"]
+    n = min(len(ratios), len(ranked))
+    if n == 0 or pool <= 0:
+        return []
+    ratios = ratios[:n]
+    total_ratio = sum(ratios)
+    amounts = [pool * r // total_ratio for r in ratios]  # floor
+    amounts[0] += pool - sum(amounts)  # remainder (and any truncated tail) -> 1st
+    out = []
+    for i in range(n):
+        if amounts[i] > 0:
+            captain_id, team_name = ranked[i]
+            out.append((i + 1, captain_id, team_name, amounts[i]))
+    return out
+
+
 async def mark_paid(participant_id: int, reserve_tx_id: int) -> bool:
     """Flip a participant to 'paid', recording the reserve that backs its escrow."""
     async with db_session() as session:
@@ -193,3 +235,54 @@ async def prize_pool(guild_id: str, tournament_id: int) -> int:
                 WalletTx.status == "done",
             ))
         return int(result.scalar() or 0)
+
+
+def _payout_like(tournament_id) -> str:
+    return f"payout:{tournament_id}:%"
+
+
+async def is_paid_out(tournament_id: int) -> bool:
+    """True once any payout has been booked for this tournament (idempotency guard)."""
+    async with db_session() as session:
+        r = await session.execute(
+            select(WalletTx.id).where(WalletTx.source.like(_payout_like(tournament_id))).limit(1))
+        return r.scalar() is not None
+
+
+async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -> dict:
+    """Disburse the prize pool to the winners' captains, atomically in one transaction.
+
+    ``allocations`` is [(place, captain_id, team_name, amount)]. For each, debits the prize
+    wallet and credits the captain (an internal transfer, so vault==SUM(wallets) holds).
+    Idempotent by source ``payout:<tid>:<place>`` — a re-run books nothing. Refuses to pay
+    more than the pool holds. Returns {ok, already_paid?, paid, total, pool} or {ok:False,error}."""
+    prize_id = prize_wallet_id(tournament_id)
+    async with db_session() as session:
+        already = await session.execute(
+            select(WalletTx.id).where(WalletTx.source.like(_payout_like(tournament_id))).limit(1))
+        if already.scalar():
+            return {"ok": True, "already_paid": True}
+
+        pool = int((await session.execute(
+            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
+                WalletTx.guild_id == guild_id, WalletTx.player_id == prize_id,
+                WalletTx.status == "done"))).scalar() or 0)
+        total = sum(amount for _, _, _, amount in allocations)
+        if total > pool:
+            return {"ok": False, "error": f"allocations ({total}) exceed the prize pool ({pool})"}
+
+        for place, captain_id, team_name, amount in allocations:
+            if amount <= 0:
+                continue
+            source = f"payout:{tournament_id}:{place}"
+            note = f"tournament prize (place {place}): {team_name}"
+            session.add(WalletTx(
+                guild_id=guild_id, player_id=prize_id, kind="pay", amount=-amount, status="done",
+                counterparty_id=captain_id, source=source, notes=note))
+            session.add(WalletTx(
+                guild_id=guild_id, player_id=captain_id, kind="receive", amount=amount, status="done",
+                counterparty_id=prize_id, source=source, notes=note))
+        await session.flush()
+        logger.info(f"payout: tournament {tournament_id} distributed {total} tix to "
+                    f"{len(allocations)} team(s)")
+        return {"ok": True, "paid": allocations, "total": total, "pool": pool}

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -19,7 +19,7 @@ from loguru import logger
 from sqlalchemy import func, select
 
 from database.db_session import db_session
-from models.tournament import TournamentParticipant
+from models.tournament import Tournament, TournamentParticipant
 from models.wallet_tx import WalletTx
 from services import wallet_service
 
@@ -78,6 +78,38 @@ async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int
 
     await mark_paid(participant_id, reserve.id)
     return {"ok": True, "done": True, "reserved": fee}
+
+
+async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
+    """Remove a team AND release its escrow hold, atomically in one transaction (so the
+    participant delete and the reserve cancel can never half-apply — a team can't end up
+    seeded-but-unpaid, nor deleted-but-still-holding tix). Registration phase only.
+
+    Returns {team_name, refunded}. Raises ValueError like tournament_service.remove_team."""
+    async with db_session() as session:
+        tournament = await session.get(Tournament, tournament_id)
+        if tournament is None:
+            raise ValueError("Tournament not found.")
+        if tournament.status != "registration":
+            raise ValueError(f"Teams cannot be removed once '{tournament.name}' has started.")
+        stmt = select(TournamentParticipant).where(
+            TournamentParticipant.tournament_id == tournament_id,
+            func.lower(TournamentParticipant.team_name) == team_name.strip().lower(),
+        )
+        p = (await session.execute(stmt)).scalars().first()
+        if p is None:
+            raise ValueError(f"'{team_name}' is not registered for this tournament.")
+        refunded = 0
+        if p.escrow_tx_id:
+            tx = await session.get(WalletTx, p.escrow_tx_id)
+            if tx is not None and tx.status == "pending":
+                tx.status = "cancelled"
+                refunded = -tx.amount
+        name = p.team_name
+        await session.delete(p)
+        await session.flush()
+        logger.info(f"escrow: dropped '{name}' from tournament {tournament_id} (refunded {refunded})")
+        return {"team_name": name, "refunded": refunded}
 
 
 async def refund_reserve(escrow_tx_id: int) -> bool:

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -20,12 +20,14 @@ it's counted by the reconciliation audit and can later ``pay`` out to winners li
 from datetime import datetime
 
 from loguru import logger
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 from database.db_session import db_session
-from models.tournament import Tournament, TournamentParticipant
+from database.retry import with_db_retry
+from models.tournament import TournamentParticipant
 from models.wallet_tx import WalletTx
 from services import wallet_service
+from services.tournament_service import remove_team
 
 
 def escrow_source(tournament_id, participant_id) -> str:
@@ -80,55 +82,79 @@ def compute_allocations(pool: int, structure: str, ranked: list) -> list:
     return out
 
 
-async def mark_paid(participant_id: int, reserve_tx_id: int) -> bool:
-    """Flip a participant to 'paid', recording the reserve that backs its escrow."""
+def _mark_paid(p: TournamentParticipant, reserve_tx_id: int | None):
+    """Stamp a participant paid inside the caller's session."""
+    p.status = "paid"
+    p.escrow_tx_id = reserve_tx_id
+    p.paid_at = datetime.now()
+
+
+async def comp(participant_id: int) -> bool:
+    """Admin comp: mark a participant paid with NO escrow (seed-eligible, captain unbilled).
+    Stamps paid_at so a comped row is distinguishable from a pre-escrow legacy one; the
+    NULL escrow_tx_id records that no tix back this entry (it dilutes the pot on purpose)."""
     async with db_session() as session:
         p = await session.get(TournamentParticipant, participant_id)
         if p is None:
-            logger.warning(f"escrow mark_paid: participant {participant_id} not found")
+            logger.warning(f"escrow comp: participant {participant_id} not found")
             return False
-        p.status = "paid"
-        p.escrow_tx_id = reserve_tx_id
-        p.paid_at = datetime.now()
+        if p.status == "paid":
+            return True
+        _mark_paid(p, None)
         await session.flush()
-        logger.info(f"escrow: participant {participant_id} paid (reserve tx {reserve_tx_id})")
+        logger.info(f"escrow: participant {participant_id} comped (no escrow)")
         return True
 
 
 async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int,
                              tournament_id: int, fee: int, team_name: str) -> dict:
-    """Try to hold ``fee`` tix in the captain's wallet for this participant.
+    """Try to hold ``fee`` tix in the captain's wallet for this participant — reserve and
+    participant flip commit atomically in ONE transaction (a crash can't leave a paid team
+    with no hold, or a hold on a pending team).
 
     Returns one of:
       {ok: True, done: True, reserved: n}    — escrow held, participant now paid.
       {ok: True, done: False, deficit: n}    — wallet short by ``deficit``; caller must
                                                deposit that much, then call again.
-      {ok: False, error: str}                — the reserve failed (e.g. a race lost the funds).
+      {ok: False, error: str}                — participant vanished mid-flight.
     Idempotent: an existing reserve for this participant is reused, not stacked."""
     if fee <= 0:
-        # Free / nothing to hold — treat as already complete.
-        await mark_paid(participant_id, None)
-        return {"ok": True, "done": True, "reserved": 0}
+        raise ValueError("secure_from_wallet needs a positive fee (free entries never escrow)")
 
     source = escrow_source(tournament_id, participant_id)
-    existing = await wallet_service.get_pending_reserve(guild_id, captain_id, source)
-    if existing:
-        await mark_paid(participant_id, existing.id)
-        return {"ok": True, "done": True, "reserved": -existing.amount, "reused": True}
 
-    available = await wallet_service.get_available(guild_id, captain_id)
-    if available < fee:
-        return {"ok": True, "done": False, "deficit": fee - available, "available": available}
+    async def _do():
+        async with db_session() as session:
+            p = await session.get(TournamentParticipant, participant_id)
+            if p is None:
+                return {"ok": False, "error": "team no longer registered"}
 
-    try:
-        reserve = await wallet_service.reserve_debit(
-            guild_id, captain_id, fee, kind="escrow", source=source,
-            notes=f"tournament entry: {team_name}")
-    except ValueError as e:  # lost a race for the funds since the check above
-        return {"ok": False, "error": str(e)}
+            existing = (await session.execute(
+                select(WalletTx).where(
+                    WalletTx.guild_id == guild_id,
+                    WalletTx.player_id == captain_id,
+                    WalletTx.source == source,
+                    WalletTx.status == "pending",
+                ).order_by(WalletTx.id).limit(1))).scalars().first()
+            if existing:
+                _mark_paid(p, existing.id)
+                return {"ok": True, "done": True, "reserved": -existing.amount, "reused": True}
 
-    await mark_paid(participant_id, reserve.id)
-    return {"ok": True, "done": True, "reserved": fee}
+            balance, reserved = await wallet_service._balances(session, guild_id, captain_id)
+            available = balance - reserved
+            if available < fee:
+                return {"ok": True, "done": False, "deficit": fee - available, "available": available}
+
+            reserve = WalletTx(
+                guild_id=guild_id, player_id=captain_id, kind="escrow", amount=-fee,
+                status="pending", source=source, notes=f"tournament entry: {team_name}")
+            session.add(reserve)
+            await session.flush()
+            _mark_paid(p, reserve.id)
+            logger.info(f"escrow: participant {participant_id} paid (reserve tx {reserve.id})")
+            return {"ok": True, "done": True, "reserved": fee}
+
+    return await with_db_retry(_do)
 
 
 async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
@@ -136,55 +162,33 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
     participant delete and the reserve cancel can never half-apply — a team can't end up
     seeded-but-unpaid, nor deleted-but-still-holding tix). Registration phase only.
 
-    Returns {team_name, refunded}. Raises ValueError like tournament_service.remove_team."""
+    Returns {team_name, refunded}. Raises ValueError like tournament_service.remove_team
+    (which owns the removal rules; this only adds the refund)."""
     async with db_session() as session:
-        tournament = await session.get(Tournament, tournament_id)
-        if tournament is None:
-            raise ValueError("Tournament not found.")
-        if tournament.status != "registration":
-            raise ValueError(f"Teams cannot be removed once '{tournament.name}' has started.")
-        stmt = select(TournamentParticipant).where(
-            TournamentParticipant.tournament_id == tournament_id,
-            func.lower(TournamentParticipant.team_name) == team_name.strip().lower(),
-        )
-        p = (await session.execute(stmt)).scalars().first()
-        if p is None:
-            raise ValueError(f"'{team_name}' is not registered for this tournament.")
+        p = await remove_team(session, tournament_id, team_name)
         refunded = 0
         if p.escrow_tx_id:
             tx = await session.get(WalletTx, p.escrow_tx_id)
             if tx is not None and tx.status == "pending":
                 tx.status = "cancelled"
                 refunded = -tx.amount
-        name = p.team_name
-        await session.delete(p)
         await session.flush()
-        logger.info(f"escrow: dropped '{name}' from tournament {tournament_id} (refunded {refunded})")
-        return {"team_name": name, "refunded": refunded}
-
-
-async def refund_reserve(escrow_tx_id: int) -> bool:
-    """Release a held escrow (drop before start). Idempotent — a non-pending reserve is a
-    no-op. Returns False when there's nothing to refund."""
-    if not escrow_tx_id:
-        return False
-    await wallet_service.cancel_reserve(escrow_tx_id)
-    logger.info(f"escrow: refunded reserve tx {escrow_tx_id}")
-    return True
+        logger.info(f"escrow: dropped '{p.team_name}' from tournament {tournament_id} "
+                    f"(refunded {refunded})")
+        return {"team_name": p.team_name, "refunded": refunded}
 
 
 async def total_escrowed(guild_id: str, tournament_id: int) -> int:
     """Total tix currently held across a tournament's participants (the pot so far)."""
     prefix = escrow_source(tournament_id, "")  # 'tourney:<id>:'
     async with db_session() as session:
-        result = await session.execute(
-            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
-                WalletTx.guild_id == guild_id,
-                WalletTx.status == "pending",
-                WalletTx.source.like(prefix + "%"),
-            )
+        held = await wallet_service._sum_amount(
+            session,
+            WalletTx.guild_id == guild_id,
+            WalletTx.status == "pending",
+            WalletTx.source.like(prefix + "%"),
         )
-        return int(-(result.scalar() or 0))  # reserves are negative; report positive held
+        return -held  # reserves are negative; report positive held
 
 
 async def reallocate_to_prize(session, guild_id: str, tournament_id: int) -> dict:
@@ -225,28 +229,34 @@ async def reallocate_to_prize(session, guild_id: str, tournament_id: int) -> dic
     return {"moved": moved, "count": count, "prize_id": prize_id}
 
 
+async def _pool(session, guild_id: str, tournament_id: int) -> int:
+    """Prize wallet balance inside an existing session (the one 'what counts as the pool'
+    predicate — the preview and the payout cap must agree)."""
+    return await wallet_service._sum_amount(
+        session,
+        WalletTx.guild_id == guild_id,
+        WalletTx.player_id == prize_wallet_id(tournament_id),
+        WalletTx.status == "done",
+    )
+
+
+async def _already_paid(session, tournament_id: int) -> bool:
+    r = await session.execute(
+        select(WalletTx.id).where(
+            WalletTx.source.like(f"payout:{tournament_id}:%")).limit(1))
+    return r.scalar() is not None
+
+
 async def prize_pool(guild_id: str, tournament_id: int) -> int:
     """The tournament's prize wallet balance (settled tix available to pay out)."""
     async with db_session() as session:
-        result = await session.execute(
-            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
-                WalletTx.guild_id == guild_id,
-                WalletTx.player_id == prize_wallet_id(tournament_id),
-                WalletTx.status == "done",
-            ))
-        return int(result.scalar() or 0)
-
-
-def _payout_like(tournament_id) -> str:
-    return f"payout:{tournament_id}:%"
+        return await _pool(session, guild_id, tournament_id)
 
 
 async def is_paid_out(tournament_id: int) -> bool:
     """True once any payout has been booked for this tournament (idempotency guard)."""
     async with db_session() as session:
-        r = await session.execute(
-            select(WalletTx.id).where(WalletTx.source.like(_payout_like(tournament_id))).limit(1))
-        return r.scalar() is not None
+        return await _already_paid(session, tournament_id)
 
 
 async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -> dict:
@@ -258,15 +268,10 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     more than the pool holds. Returns {ok, already_paid?, paid, total, pool} or {ok:False,error}."""
     prize_id = prize_wallet_id(tournament_id)
     async with db_session() as session:
-        already = await session.execute(
-            select(WalletTx.id).where(WalletTx.source.like(_payout_like(tournament_id))).limit(1))
-        if already.scalar():
+        if await _already_paid(session, tournament_id):
             return {"ok": True, "already_paid": True}
 
-        pool = int((await session.execute(
-            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
-                WalletTx.guild_id == guild_id, WalletTx.player_id == prize_id,
-                WalletTx.status == "done"))).scalar() or 0)
+        pool = await _pool(session, guild_id, tournament_id)
         total = sum(amount for _, _, _, amount in allocations)
         if total > pool:
             return {"ok": False, "error": f"allocations ({total}) exceed the prize pool ({pool})"}

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -1,0 +1,104 @@
+"""
+Tournament escrow — holds a team's entry fee in the captain's wallet until the tournament
+starts, bridging tournament_service (the participant row) and wallet_service (the reserve).
+
+The entry fee is held as a **pending wallet reserve** on the captain (kind='escrow'), tagged
+with a per-participant ``source`` so it's idempotent and refundable:
+  * secure  — reserve the fee (wallet-first; the caller deposits any shortfall first) and
+              flip the participant to 'paid'. Reusing an existing reserve makes it safe to
+              retry after a crash between reserving and marking paid.
+  * refund  — cancel the reserve (drop before start); the tix become spendable again.
+  * on start — nothing moves: the reserve simply stays (now non-refundable). It is never
+              *settled*, because settling would remove tix from the captain's wallet with no
+              holder to receive them, breaking the vault == SUM(wallets) audit. The held
+              reserves ARE the pot; a future payout phase settles + redistributes them.
+"""
+from datetime import datetime
+
+from loguru import logger
+from sqlalchemy import func, select
+
+from database.db_session import db_session
+from models.tournament import TournamentParticipant
+from models.wallet_tx import WalletTx
+from services import wallet_service
+
+
+def escrow_source(tournament_id, participant_id) -> str:
+    """Stable per-participant tag on the reserve (idempotency + refund handle + pot sum)."""
+    return f"tourney:{tournament_id}:{participant_id}"
+
+
+async def mark_paid(participant_id: int, reserve_tx_id: int) -> bool:
+    """Flip a participant to 'paid', recording the reserve that backs its escrow."""
+    async with db_session() as session:
+        p = await session.get(TournamentParticipant, participant_id)
+        if p is None:
+            logger.warning(f"escrow mark_paid: participant {participant_id} not found")
+            return False
+        p.status = "paid"
+        p.escrow_tx_id = reserve_tx_id
+        p.paid_at = datetime.now()
+        await session.flush()
+        logger.info(f"escrow: participant {participant_id} paid (reserve tx {reserve_tx_id})")
+        return True
+
+
+async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int,
+                             tournament_id: int, fee: int, team_name: str) -> dict:
+    """Try to hold ``fee`` tix in the captain's wallet for this participant.
+
+    Returns one of:
+      {ok: True, done: True, reserved: n}    — escrow held, participant now paid.
+      {ok: True, done: False, deficit: n}    — wallet short by ``deficit``; caller must
+                                               deposit that much, then call again.
+      {ok: False, error: str}                — the reserve failed (e.g. a race lost the funds).
+    Idempotent: an existing reserve for this participant is reused, not stacked."""
+    if fee <= 0:
+        # Free / nothing to hold — treat as already complete.
+        await mark_paid(participant_id, None)
+        return {"ok": True, "done": True, "reserved": 0}
+
+    source = escrow_source(tournament_id, participant_id)
+    existing = await wallet_service.get_pending_reserve(guild_id, captain_id, source)
+    if existing:
+        await mark_paid(participant_id, existing.id)
+        return {"ok": True, "done": True, "reserved": -existing.amount, "reused": True}
+
+    available = await wallet_service.get_available(guild_id, captain_id)
+    if available < fee:
+        return {"ok": True, "done": False, "deficit": fee - available, "available": available}
+
+    try:
+        reserve = await wallet_service.reserve_debit(
+            guild_id, captain_id, fee, kind="escrow", source=source,
+            notes=f"tournament entry: {team_name}")
+    except ValueError as e:  # lost a race for the funds since the check above
+        return {"ok": False, "error": str(e)}
+
+    await mark_paid(participant_id, reserve.id)
+    return {"ok": True, "done": True, "reserved": fee}
+
+
+async def refund_reserve(escrow_tx_id: int) -> bool:
+    """Release a held escrow (drop before start). Idempotent — a non-pending reserve is a
+    no-op. Returns False when there's nothing to refund."""
+    if not escrow_tx_id:
+        return False
+    await wallet_service.cancel_reserve(escrow_tx_id)
+    logger.info(f"escrow: refunded reserve tx {escrow_tx_id}")
+    return True
+
+
+async def total_escrowed(guild_id: str, tournament_id: int) -> int:
+    """Total tix currently held across a tournament's participants (the pot so far)."""
+    prefix = escrow_source(tournament_id, "")  # 'tourney:<id>:'
+    async with db_session() as session:
+        result = await session.execute(
+            select(func.coalesce(func.sum(WalletTx.amount), 0)).where(
+                WalletTx.guild_id == guild_id,
+                WalletTx.status == "pending",
+                WalletTx.source.like(prefix + "%"),
+            )
+        )
+        return int(-(result.scalar() or 0))  # reserves are negative; report positive held

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -25,15 +25,28 @@ from sqlalchemy.exc import IntegrityError
 
 from database.db_session import db_session
 from database.retry import with_db_retry
-from models.tournament import TournamentParticipant
+from models.tournament import Tournament, TournamentParticipant
 from models.wallet_tx import WalletTx
 from services import wallet_service
-from services.tournament_service import remove_team
+from services.tournament_service import get_active_tournament, remove_team, start_tournament
 
 
 def escrow_source(tournament_id, participant_id) -> str:
-    """Stable per-participant tag on the reserve (idempotency + refund handle + pot sum)."""
+    """Stable per-participant tag on the reserve (idempotency + refund handle + pot sum).
+    Also used as the MtgoJob deposit ``context`` for entry-fee deposits — this module is
+    the single owner of the format (parse with parse_escrow_source)."""
     return f"tourney:{tournament_id}:{participant_id}"
+
+
+def parse_escrow_source(source: str):
+    """Inverse of escrow_source: (tournament_id, participant_id), or None if not ours."""
+    if not source or not source.startswith("tourney:"):
+        return None
+    try:
+        _, tid, pid = source.split(":")
+        return int(tid), int(pid)
+    except ValueError:
+        return None
 
 
 def prize_wallet_id(tournament_id) -> str:
@@ -125,13 +138,7 @@ async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int
             if p is None:
                 return {"ok": False, "error": "team no longer registered"}
 
-            existing = (await session.execute(
-                select(WalletTx).where(
-                    WalletTx.guild_id == guild_id,
-                    WalletTx.player_id == captain_id,
-                    WalletTx.source == source,
-                    WalletTx.status == "pending",
-                ).order_by(WalletTx.id).limit(1))).scalars().first()
+            existing = await wallet_service._pending_reserve(session, guild_id, captain_id, source)
             if existing:
                 _mark_paid(p, existing.id)
                 return {"ok": True, "done": True, "reserved": -existing.amount, "reused": True}
@@ -158,6 +165,57 @@ async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int
         # rerun (unlocked read path finds and reuses the existing hold).
         logger.info(f"secure_from_wallet: concurrent reserve for {source}, reusing")
         return await _do()
+
+
+async def complete_entry_after_deposit(guild_id: str, captain_id: str,
+                                       tournament_id: int, participant_id: int) -> dict:
+    """The 'entry-fee deposit landed → secure the escrow' continuation, shared by the
+    register command's background follow-up and the pending-jobs resumer (one copy of
+    the guards, one behavior). Returns secure_from_wallet's dict plus team/tournament
+    names for messaging, or {ok: False, skipped: True} when there's nothing to do
+    (team gone, already paid, or fee dropped to zero)."""
+    async with db_session() as session:
+        t = await session.get(Tournament, tournament_id)
+        p = await session.get(TournamentParticipant, participant_id)
+    if not t or not p or p.status == "paid" or (t.entry_fee or 0) <= 0:
+        return {"ok": False, "skipped": True}
+    res = await secure_from_wallet(guild_id, captain_id, p.id, t.id, t.entry_fee, p.team_name)
+    res.update({"team_name": p.team_name, "tournament_name": t.name, "fee": t.entry_fee})
+    return res
+
+
+async def resume_entry_from_context(guild_id: str, captain_id: str, context: str):
+    """Resumer hook: if ``context`` is one of ours (escrow_source format), finish the
+    entry. Unknown contexts are ignored — this module owns the format."""
+    parsed = parse_escrow_source(context)
+    if parsed is None:
+        return
+    tournament_id, participant_id = parsed
+    res = await complete_entry_after_deposit(guild_id, captain_id, tournament_id, participant_id)
+    if res.get("done"):
+        logger.info(f"resumed escrow: participant {participant_id} paid after recovered deposit")
+
+
+async def start_and_fund(guild_id, rng) -> dict:
+    """Close registration, seed the schedule, and move held escrow into the prize wallet —
+    one transaction under MONEY_LOCK, so concurrent /tournament start calls serialize and
+    seeding + the pot move commit together (or neither does). Owns the lock so no cog
+    touches MONEY_LOCK directly. Returns {tournament_id, name, fee, pot}; raises
+    ValueError with a user-facing message when there's nothing to start."""
+    async with wallet_service.MONEY_LOCK:
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, guild_id)
+            if tournament is None:
+                raise ValueError("There is no tournament to start.")
+            if tournament.status != "registration":
+                raise ValueError(f"**{tournament.name}** has already started.")
+            fee = tournament.entry_fee or 0
+            await start_tournament(session, tournament.id, rng)
+            pot = 0
+            if fee > 0:
+                pot = (await reallocate_to_prize(session, str(guild_id), tournament.id))["moved"]
+            return {"tournament_id": tournament.id, "name": tournament.name,
+                    "fee": fee, "pot": pot}
 
 
 async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
@@ -301,6 +359,7 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
         async with wallet_service.MONEY_LOCK:
             return await with_db_retry(_do)
     except IntegrityError:
-        # uq_wallet_tx_transfer_legs: a concurrent payout booked first — idempotent no-op.
+        # uq_wallet_tx_transfer_legs: a concurrent payout booked first — re-run;
+        # _do's _already_paid branch reports it.
         logger.info(f"execute_payout: tournament {tournament_id} paid out concurrently")
-        return {"ok": True, "already_paid": True}
+        return await _do()

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -21,6 +21,7 @@ from datetime import datetime
 
 from loguru import logger
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from database.db_session import db_session
 from database.retry import with_db_retry
@@ -89,21 +90,16 @@ def _mark_paid(p: TournamentParticipant, reserve_tx_id: int | None):
     p.paid_at = datetime.now()
 
 
-async def comp(participant_id: int) -> bool:
+def comp(participant: TournamentParticipant) -> bool:
     """Admin comp: mark a participant paid with NO escrow (seed-eligible, captain unbilled).
-    Stamps paid_at so a comped row is distinguishable from a pre-escrow legacy one; the
-    NULL escrow_tx_id records that no tix back this entry (it dilutes the pot on purpose)."""
-    async with db_session() as session:
-        p = await session.get(TournamentParticipant, participant_id)
-        if p is None:
-            logger.warning(f"escrow comp: participant {participant_id} not found")
-            return False
-        if p.status == "paid":
-            return True
-        _mark_paid(p, None)
-        await session.flush()
-        logger.info(f"escrow: participant {participant_id} comped (no escrow)")
-        return True
+    Runs inside the CALLER's session so registration + comp commit atomically. Stamps
+    paid_at so a comped row is distinguishable from a pre-escrow legacy one; the NULL
+    escrow_tx_id records that no tix back this entry (it dilutes the pot on purpose)."""
+    if participant.status == "paid":
+        return False
+    _mark_paid(participant, None)
+    logger.info(f"escrow: participant {participant.id} comped (no escrow)")
+    return True
 
 
 async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int,
@@ -154,7 +150,14 @@ async def secure_from_wallet(guild_id: str, captain_id: str, participant_id: int
             logger.info(f"escrow: participant {participant_id} paid (reserve tx {reserve.id})")
             return {"ok": True, "done": True, "reserved": fee}
 
-    return await with_db_retry(_do)
+    try:
+        async with wallet_service.MONEY_LOCK:
+            return await with_db_retry(_do)
+    except IntegrityError:
+        # uq_wallet_tx_live_escrow: a concurrent register reserved this entry first —
+        # rerun (unlocked read path finds and reuses the existing hold).
+        logger.info(f"secure_from_wallet: concurrent reserve for {source}, reusing")
+        return await _do()
 
 
 async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
@@ -267,27 +270,37 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     Idempotent by source ``payout:<tid>:<place>`` — a re-run books nothing. Refuses to pay
     more than the pool holds. Returns {ok, already_paid?, paid, total, pool} or {ok:False,error}."""
     prize_id = prize_wallet_id(tournament_id)
-    async with db_session() as session:
-        if await _already_paid(session, tournament_id):
-            return {"ok": True, "already_paid": True}
 
-        pool = await _pool(session, guild_id, tournament_id)
-        total = sum(amount for _, _, _, amount in allocations)
-        if total > pool:
-            return {"ok": False, "error": f"allocations ({total}) exceed the prize pool ({pool})"}
+    async def _do():
+        async with db_session() as session:
+            if await _already_paid(session, tournament_id):
+                return {"ok": True, "already_paid": True}
 
-        for place, captain_id, team_name, amount in allocations:
-            if amount <= 0:
-                continue
-            source = f"payout:{tournament_id}:{place}"
-            note = f"tournament prize (place {place}): {team_name}"
-            session.add(WalletTx(
-                guild_id=guild_id, player_id=prize_id, kind="pay", amount=-amount, status="done",
-                counterparty_id=captain_id, source=source, notes=note))
-            session.add(WalletTx(
-                guild_id=guild_id, player_id=captain_id, kind="receive", amount=amount, status="done",
-                counterparty_id=prize_id, source=source, notes=note))
-        await session.flush()
-        logger.info(f"payout: tournament {tournament_id} distributed {total} tix to "
-                    f"{len(allocations)} team(s)")
-        return {"ok": True, "paid": allocations, "total": total, "pool": pool}
+            pool = await _pool(session, guild_id, tournament_id)
+            total = sum(amount for _, _, _, amount in allocations)
+            if total > pool:
+                return {"ok": False, "error": f"allocations ({total}) exceed the prize pool ({pool})"}
+
+            for place, captain_id, team_name, amount in allocations:
+                if amount <= 0:
+                    continue
+                source = f"payout:{tournament_id}:{place}"
+                note = f"tournament prize (place {place}): {team_name}"
+                session.add(WalletTx(
+                    guild_id=guild_id, player_id=prize_id, kind="pay", amount=-amount, status="done",
+                    counterparty_id=captain_id, source=source, notes=note))
+                session.add(WalletTx(
+                    guild_id=guild_id, player_id=captain_id, kind="receive", amount=amount, status="done",
+                    counterparty_id=prize_id, source=source, notes=note))
+            await session.flush()
+            logger.info(f"payout: tournament {tournament_id} distributed {total} tix to "
+                        f"{len(allocations)} team(s)")
+            return {"ok": True, "paid": allocations, "total": total, "pool": pool}
+
+    try:
+        async with wallet_service.MONEY_LOCK:
+            return await with_db_retry(_do)
+    except IntegrityError:
+        # uq_wallet_tx_transfer_legs: a concurrent payout booked first — idempotent no-op.
+        logger.info(f"execute_payout: tournament {tournament_id} paid out concurrently")
+        return {"ok": True, "already_paid": True}

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -46,14 +46,27 @@ async def _participant_by_name(session, tournament_id, team_name):
     return (await session.execute(stmt)).scalars().first()
 
 
-async def create_tournament(session, guild_id, name, total_rounds, format="swiss", entry_fee=0):
+async def get_latest_completed_tournament(session, guild_id):
+    """The guild's most recently completed tournament, or None. Used by payout, since
+    get_active_tournament only returns registration/active ones."""
+    stmt = (
+        select(Tournament)
+        .where(Tournament.guild_id == str(guild_id), Tournament.status == "completed")
+        .order_by(Tournament.id.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def create_tournament(session, guild_id, name, total_rounds, format="swiss", entry_fee=0,
+                            payout_structure="winner_take_all"):
     """Create a tournament in registration status.
 
     ``format`` is 'swiss', 'round_robin', or 'manual'. For the all-open formats
     total_rounds is set at start (derived from the schedule), so callers may
-    pass 0. ``entry_fee`` is the per-team escrow in tix (0 = free). Raises
-    ValueError if the guild already has a registration/active tournament (one
-    active per guild keeps other commands argument-free).
+    pass 0. ``entry_fee`` is the per-team escrow in tix (0 = free); ``payout_structure``
+    is how the pool splits at payout. Raises ValueError if the guild already has a
+    registration/active tournament (one active per guild keeps other commands argument-free).
     """
     if format not in ("swiss",) + ALL_OPEN_FORMATS:
         raise ValueError(f"Unknown tournament format: {format}")
@@ -65,7 +78,7 @@ async def create_tournament(session, guild_id, name, total_rounds, format="swiss
         )
     tournament = Tournament(
         guild_id=str(guild_id), name=name, total_rounds=total_rounds, format=format,
-        entry_fee=max(0, int(entry_fee or 0)),
+        entry_fee=max(0, int(entry_fee or 0)), payout_structure=payout_structure,
     )
     session.add(tournament)
     await session.flush()

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -109,6 +109,9 @@ async def register_team(session, tournament_id, team_name, captain_user_id):
         team_id=team.TeamID,
         team_name=team.TeamName,
         captain_user_id=str(captain_user_id),
+        # A paid tournament starts a new team as 'pending' until escrow is secured;
+        # a free tournament (entry_fee 0) leaves it 'paid' (the column default).
+        status="pending" if (tournament.entry_fee or 0) > 0 else "paid",
     )
     session.add(participant)
     await session.flush()
@@ -225,17 +228,22 @@ async def start_tournament(session, tournament_id, rng):
     if tournament.status != "registration":
         raise ValueError(f"'{tournament.name}' is already {tournament.status}.")
     participants = await list_participants(session, tournament_id)
-    if len(participants) < 2:
-        raise ValueError("At least 2 teams must be registered to start.")
+    # Only teams that completed registration (escrow paid) are seeded. Free
+    # tournaments mark everyone 'paid', so this is a no-op there.
+    paid = [p for p in participants if p.status == "paid"]
+    if len(paid) < 2:
+        raise ValueError(
+            "At least 2 teams must have completed registration (entry fee paid) to start."
+        )
 
     tournament.status = "active"
     if tournament.format == "round_robin":
-        return await _build_round_robin(session, tournament, participants, rng)
+        return await _build_round_robin(session, tournament, paid, rng)
     if tournament.format == "manual":
         return await _open_manual_schedule(session, tournament)
 
     _, matches = await _create_round_with_pairings(
-        session, tournament, participants, set(), rng
+        session, tournament, paid, set(), rng
     )
     return matches
 
@@ -262,6 +270,11 @@ async def add_match(session, tournament_id, team_a_name, team_b_name):
         raise ValueError(f"'{missing}' is not registered for this tournament.")
     if a.id == b.id:
         raise ValueError("A team can't be scheduled against itself.")
+    unpaid = [p.team_name for p in (a, b) if p.status != "paid"]
+    if unpaid:
+        raise ValueError(
+            f"{' and '.join(unpaid)} hasn't completed registration (entry fee unpaid)."
+        )
 
     rounds = (await session.execute(
         select(TournamentRound)

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -46,13 +46,14 @@ async def _participant_by_name(session, tournament_id, team_name):
     return (await session.execute(stmt)).scalars().first()
 
 
-async def create_tournament(session, guild_id, name, total_rounds, format="swiss"):
+async def create_tournament(session, guild_id, name, total_rounds, format="swiss", entry_fee=0):
     """Create a tournament in registration status.
 
     ``format`` is 'swiss', 'round_robin', or 'manual'. For the all-open formats
     total_rounds is set at start (derived from the schedule), so callers may
-    pass 0. Raises ValueError if the guild already has a registration/active
-    tournament (one active per guild keeps other commands argument-free).
+    pass 0. ``entry_fee`` is the per-team escrow in tix (0 = free). Raises
+    ValueError if the guild already has a registration/active tournament (one
+    active per guild keeps other commands argument-free).
     """
     if format not in ("swiss",) + ALL_OPEN_FORMATS:
         raise ValueError(f"Unknown tournament format: {format}")
@@ -63,7 +64,8 @@ async def create_tournament(session, guild_id, name, total_rounds, format="swiss
             "Finish it before creating a new tournament."
         )
     tournament = Tournament(
-        guild_id=str(guild_id), name=name, total_rounds=total_rounds, format=format
+        guild_id=str(guild_id), name=name, total_rounds=total_rounds, format=format,
+        entry_fee=max(0, int(entry_fee or 0)),
     )
     session.add(tournament)
     await session.flush()

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -524,6 +524,25 @@ async def get_standings_data(session, tournament_id):
     return rank_standings(participants, matches)
 
 
+async def count_unreported_matches(session, tournament_id):
+    """Non-bye matches in this tournament with no result yet (team_a_wins IS NULL).
+
+    A tournament can be finished (status='completed') with matches still unreported — those
+    count as 0-0, so standings aren't truly final. Payout surfaces this before disbursing.
+    """
+    stmt = (
+        select(func.count())
+        .select_from(TournamentMatch)
+        .join(TournamentRound, TournamentMatch.round_id == TournamentRound.id)
+        .where(
+            TournamentRound.tournament_id == tournament_id,
+            TournamentMatch.is_bye.is_(False),
+            TournamentMatch.team_a_wins.is_(None),
+        )
+    )
+    return int((await session.execute(stmt)).scalar_one())
+
+
 async def tournament_match_is_unfinished(session, match_id):
     """True iff the tournament match exists, isn't a bye, and has no result yet."""
     if not match_id:

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -59,6 +59,21 @@ async def _sum_amount(session, *conditions) -> int:
     return int(result.scalar() or 0)
 
 
+async def _pending_reserve(session, guild_id: str, player_id: str, source: str) -> WalletTx | None:
+    """The player's live ('pending') reserve carrying this exact ``source`` tag, or None —
+    the one definition of 'a live reserve' (kept next to _balances so every WalletTx
+    predicate lives here; the uq_wallet_tx_live_escrow index enforces the same shape)."""
+    result = await session.execute(
+        select(WalletTx).where(
+            WalletTx.guild_id == guild_id,
+            WalletTx.player_id == player_id,
+            WalletTx.source == source,
+            WalletTx.status == "pending",
+        ).order_by(WalletTx.id).limit(1)
+    )
+    return result.scalars().first()
+
+
 async def _balances(session, guild_id: str, player_id: str) -> tuple[int, int]:
     """(balance, reserved) inside an existing session/transaction — one grouped query."""
     q = select(
@@ -163,16 +178,10 @@ async def credit_done(
     try:
         return await with_db_retry(_do)
     except IntegrityError:
-        # uq_wallet_tx_job_kind: a concurrent handler booked this job between our
-        # check and insert — fetch and return its row (idempotent).
-        if not job_id:
-            raise
-        async with db_session() as session:
-            row = (await session.execute(
-                select(WalletTx).where(WalletTx.job_id == job_id, WalletTx.kind == kind)
-            )).scalars().first()
-            logger.info(f"credit_done: job {job_id} booked concurrently, returning existing")
-            return row
+        # uq_wallet_tx_job_kind: a concurrent handler booked this job between our check
+        # and insert — re-run; _do's own idempotency branch returns the existing row.
+        logger.info(f"credit_done: job {job_id} booked concurrently, refetching")
+        return await _do()
 
 
 # ---------------------------------------------------------------------------
@@ -324,15 +333,10 @@ async def pay(
         async with MONEY_LOCK:
             return await with_db_retry(_do)
     except IntegrityError:
-        # uq_wallet_tx_transfer_legs: this source was settled concurrently — return its legs.
-        async with db_session() as session:
-            rows = (await session.execute(
-                select(WalletTx).where(
-                    WalletTx.source == source, WalletTx.kind.in_(["pay", "receive"])
-                ).order_by(WalletTx.id)
-            )).scalars().all()
-            logger.info(f"pay: source {source} settled concurrently, returning existing")
-            return rows[0], rows[1]
+        # uq_wallet_tx_transfer_legs: this source was settled concurrently — re-run;
+        # _do's own idempotency branch returns the existing legs.
+        logger.info(f"pay: source {source} settled concurrently, refetching")
+        return await _do()
 
 
 async def adjust(guild_id: str, player_id: str, amount: int, notes: str, created_by: str) -> WalletTx:

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -22,14 +22,13 @@ Write rules (from the plan):
 Reconciliation: ``reconcile()`` asserts bot's physical vault tix == SUM of all 'done'
 amounts (the audit that the claim ledger never invents value).
 """
-import asyncio
 import uuid
 from dataclasses import dataclass
 from loguru import logger
-from sqlalchemy import select, func
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import select, func, case
 
 from database.db_session import db_session
+from database.retry import with_db_retry
 from models.wallet_tx import WalletTx
 
 VALID_KINDS = {"deposit", "withdraw", "pay", "receive", "adjust", "escrow"}
@@ -44,28 +43,6 @@ class Wallet:
     available: int    # balance - reserved
 
 
-# ---------------------------------------------------------------------------
-# retry helper (transient SQLite write-lock backoff, matching debt_service)
-# ---------------------------------------------------------------------------
-async def _with_retry(thunk):
-    """Run an async thunk, retrying on transient 'database is locked' with backoff."""
-    max_retries = 3
-    retry_delay = 1.0
-    for attempt in range(max_retries):
-        try:
-            return await thunk()
-        except OperationalError as e:
-            if "database is locked" in str(e) and attempt < max_retries - 1:
-                logger.warning(
-                    f"Wallet DB locked on attempt {attempt + 1}/{max_retries}, "
-                    f"retrying in {retry_delay}s..."
-                )
-                await asyncio.sleep(retry_delay)
-                retry_delay *= 2
-            else:
-                raise
-
-
 async def _sum_amount(session, *conditions) -> int:
     q = select(func.coalesce(func.sum(WalletTx.amount), 0)).where(*conditions)
     result = await session.execute(q)
@@ -73,20 +50,17 @@ async def _sum_amount(session, *conditions) -> int:
 
 
 async def _balances(session, guild_id: str, player_id: str) -> tuple[int, int]:
-    """(balance, reserved) inside an existing session/transaction."""
-    balance = await _sum_amount(
-        session,
+    """(balance, reserved) inside an existing session/transaction — one grouped query."""
+    q = select(
+        func.coalesce(func.sum(case((WalletTx.status == "done", WalletTx.amount), else_=0)), 0),
+        func.coalesce(func.sum(case((WalletTx.status == "pending", WalletTx.amount), else_=0)), 0),
+    ).where(
         WalletTx.guild_id == guild_id,
         WalletTx.player_id == player_id,
-        WalletTx.status == "done",
+        WalletTx.status.in_(("done", "pending")),
     )
-    pending = await _sum_amount(
-        session,
-        WalletTx.guild_id == guild_id,
-        WalletTx.player_id == player_id,
-        WalletTx.status == "pending",
-    )
-    return balance, -pending  # pending debits are negative -> reserved is positive
+    balance, pending = (await session.execute(q)).one()
+    return int(balance), -int(pending)  # pending debits are negative -> reserved is positive
 
 
 # ---------------------------------------------------------------------------
@@ -110,58 +84,24 @@ async def get_wallet(guild_id: str, player_id: str) -> Wallet:
         return Wallet(guild_id, player_id, balance, reserved, balance - reserved)
 
 
-async def get_all_balances(guild_id: str) -> dict[str, int]:
-    """Non-zero settled balances for every player in the guild (for the audit board)."""
-    async with db_session() as session:
-        query = (
-            select(WalletTx.player_id, func.sum(WalletTx.amount).label("balance"))
-            .where(WalletTx.guild_id == guild_id, WalletTx.status == "done")
-            .group_by(WalletTx.player_id)
-            .having(func.sum(WalletTx.amount) != 0)
-        )
-        result = await session.execute(query)
-        return {row.player_id: int(row.balance) for row in result.all()}
-
-
-async def total_wallets(guild_id: str = None) -> int:
+async def total_wallets() -> int:
     """SUM of all settled balances — the claim side of the reconciliation invariant.
-
-    The physical vault (one MTGO custodian) is shared across guilds, so the audit total
-    is global by default; pass ``guild_id`` only for a per-guild subtotal.
-    """
+    Global on purpose: the physical vault (one MTGO custodian) is shared across guilds."""
     async with db_session() as session:
-        conditions = [WalletTx.status == "done"]
-        if guild_id is not None:
-            conditions.append(WalletTx.guild_id == guild_id)
-        return await _sum_amount(session, *conditions)
+        return await _sum_amount(session, WalletTx.status == "done")
 
 
-async def get_history(guild_id: str, player_id: str = None, limit: int = 25) -> list[WalletTx]:
+async def get_history(guild_id: str, player_id: str, limit: int = 25) -> list[WalletTx]:
     limit = min(limit, 100)
     async with db_session() as session:
-        query = select(WalletTx).where(WalletTx.guild_id == guild_id)
-        if player_id:
-            query = query.where(WalletTx.player_id == player_id)
-        query = query.order_by(WalletTx.created_at.desc(), WalletTx.id.desc()).limit(limit)
+        query = (
+            select(WalletTx)
+            .where(WalletTx.guild_id == guild_id, WalletTx.player_id == player_id)
+            .order_by(WalletTx.created_at.desc(), WalletTx.id.desc())
+            .limit(limit)
+        )
         result = await session.execute(query)
         return list(result.scalars().all())
-
-
-async def get_pending_reserve(guild_id: str, player_id: str, source: str) -> WalletTx | None:
-    """The player's outstanding ('pending') reserve carrying this exact ``source`` tag, or
-    None. Lets a reservation be made idempotent: re-securing the same tournament entry can
-    reuse the existing hold instead of stacking a second one (e.g. after a crash between
-    reserving and marking the participant paid)."""
-    async with db_session() as session:
-        result = await session.execute(
-            select(WalletTx).where(
-                WalletTx.guild_id == guild_id,
-                WalletTx.player_id == player_id,
-                WalletTx.source == source,
-                WalletTx.status == "pending",
-            ).order_by(WalletTx.id).limit(1)
-        )
-        return result.scalars().first()
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +150,7 @@ async def credit_done(
             logger.info(f"credit_done: {player_id} +{amount} ({kind}) job={job_id} -> tx {tx.id}")
             return tx
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +191,7 @@ async def reserve_debit(
             logger.info(f"reserve_debit: {player_id} reserved {amount} ({kind}) -> tx {tx.id}")
             return tx
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 async def attach_job(tx_id: int, job_id: str) -> WalletTx:
@@ -267,7 +207,7 @@ async def attach_job(tx_id: int, job_id: str) -> WalletTx:
             await session.refresh(tx)
             return tx
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 async def _resolve_reserve(tx_id: int, new_status: str) -> WalletTx:
@@ -286,7 +226,7 @@ async def _resolve_reserve(tx_id: int, new_status: str) -> WalletTx:
                 logger.info(f"reserve tx {tx_id} already {tx.status} (idempotent no-op)")
             return tx
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 async def settle_reserve(tx_id: int) -> WalletTx:
@@ -357,7 +297,7 @@ async def pay(
             logger.info(f"pay: {from_player} -> {to_player} {amount} tix (source {source})")
             return debit, credit
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 async def adjust(guild_id: str, player_id: str, amount: int, notes: str, created_by: str) -> WalletTx:
@@ -378,18 +318,18 @@ async def adjust(guild_id: str, player_id: str, amount: int, notes: str, created
             logger.info(f"adjust: {player_id} {amount:+d} by {created_by}")
             return tx
 
-    return await _with_retry(_do)
+    return await with_db_retry(_do)
 
 
 # ---------------------------------------------------------------------------
 # reconciliation audit: physical vault tix == SUM(settled wallets)
 # ---------------------------------------------------------------------------
-async def reconcile(bot_tix: int, guild_id: str = None) -> dict:
+async def reconcile(bot_tix: int) -> dict:
     """Compare the physical vault tix (from the serve ``/vault``) to the claim total.
 
-    ``bot_tix`` is global (one custodian), so by default the claim side is summed across
-    all guilds. Returns {ok, wallet_total, bot_tix, diff}; ok when they match exactly."""
-    wallet_total = await total_wallets(guild_id)
+    Both sides are global (one custodian, one claim ledger). Returns
+    {ok, wallet_total, bot_tix, diff}; ok when they match exactly."""
+    wallet_total = await total_wallets()
     diff = bot_tix - wallet_total
     ok = diff == 0
     if not ok:

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -22,16 +22,26 @@ Write rules (from the plan):
 Reconciliation: ``reconcile()`` asserts bot's physical vault tix == SUM of all 'done'
 amounts (the audit that the claim ledger never invents value).
 """
+import asyncio
 import uuid
 from dataclasses import dataclass
 from loguru import logger
 from sqlalchemy import select, func, case
+from sqlalchemy.exc import IntegrityError
 
 from database.db_session import db_session
 from database.retry import with_db_retry
 from models.wallet_tx import WalletTx
 
 VALID_KINDS = {"deposit", "withdraw", "pay", "receive", "adjust", "escrow"}
+
+# Serializes every DEBIT (check-available-then-spend) across the process. The bot is the
+# database's only writer, so this lock is sufficient to prevent two concurrent debits from
+# both reading the same balance and both spending it. Held only around short transactions;
+# credits don't need it (they can't overdraw, and double-booking is blocked by the
+# uq_wallet_tx_* unique indexes). NOT reentrant — acquire only at service entry points,
+# never from code already running under it.
+MONEY_LOCK = asyncio.Lock()
 
 
 @dataclass
@@ -150,7 +160,19 @@ async def credit_done(
             logger.info(f"credit_done: {player_id} +{amount} ({kind}) job={job_id} -> tx {tx.id}")
             return tx
 
-    return await with_db_retry(_do)
+    try:
+        return await with_db_retry(_do)
+    except IntegrityError:
+        # uq_wallet_tx_job_kind: a concurrent handler booked this job between our
+        # check and insert — fetch and return its row (idempotent).
+        if not job_id:
+            raise
+        async with db_session() as session:
+            row = (await session.execute(
+                select(WalletTx).where(WalletTx.job_id == job_id, WalletTx.kind == kind)
+            )).scalars().first()
+            logger.info(f"credit_done: job {job_id} booked concurrently, returning existing")
+            return row
 
 
 # ---------------------------------------------------------------------------
@@ -191,7 +213,8 @@ async def reserve_debit(
             logger.info(f"reserve_debit: {player_id} reserved {amount} ({kind}) -> tx {tx.id}")
             return tx
 
-    return await with_db_retry(_do)
+    async with MONEY_LOCK:
+        return await with_db_retry(_do)
 
 
 async def attach_job(tx_id: int, job_id: str) -> WalletTx:
@@ -297,7 +320,19 @@ async def pay(
             logger.info(f"pay: {from_player} -> {to_player} {amount} tix (source {source})")
             return debit, credit
 
-    return await with_db_retry(_do)
+    try:
+        async with MONEY_LOCK:
+            return await with_db_retry(_do)
+    except IntegrityError:
+        # uq_wallet_tx_transfer_legs: this source was settled concurrently — return its legs.
+        async with db_session() as session:
+            rows = (await session.execute(
+                select(WalletTx).where(
+                    WalletTx.source == source, WalletTx.kind.in_(["pay", "receive"])
+                ).order_by(WalletTx.id)
+            )).scalars().all()
+            logger.info(f"pay: source {source} settled concurrently, returning existing")
+            return rows[0], rows[1]
 
 
 async def adjust(guild_id: str, player_id: str, amount: int, notes: str, created_by: str) -> WalletTx:

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -1,0 +1,380 @@
+"""
+Tix wallet service — the obligation/claim ledger over ``WalletTx``.
+
+A player's wallet is a *view* over their transaction log (there is no stored balance):
+    balance   = SUM(amount WHERE status='done')          # settled claim on the vault
+    reserved  = -SUM(amount WHERE status='pending')      # withdraws in flight (debits)
+    available = balance - reserved                        # what they can actually spend
+
+Design mirrors ``services/debt_service.py``: single ``db_session()`` per op, idempotency
+keyed on a stable id (``job_id`` for serve ops, ``source`` for internal pays), and
+retry-with-backoff on transient SQLite "database is locked" errors.
+
+Write rules (from the plan):
+  * Credits (deposit / receive) are written ONLY as 'done', and only once their MTGO job
+    has completed — never on enqueue. Idempotent by ``job_id``.
+  * A withdraw is a two-step reserve→settle: ``reserve_debit`` immediately writes a
+    'pending' debit (protecting the balance from double-spend), then the job poller flips
+    it to 'done' (``settle_reserve``) or 'cancelled' (``cancel_reserve``, releasing it).
+  * Internal ``pay`` moves tix between two players with no MTGO trade: two 'done' rows in
+    one transaction, idempotent by ``source``.
+
+Reconciliation: ``reconcile()`` asserts bot's physical vault tix == SUM of all 'done'
+amounts (the audit that the claim ledger never invents value).
+"""
+import asyncio
+import uuid
+from dataclasses import dataclass
+from loguru import logger
+from sqlalchemy import select, func
+from sqlalchemy.exc import OperationalError
+
+from database.db_session import db_session
+from models.wallet_tx import WalletTx
+
+VALID_KINDS = {"deposit", "withdraw", "pay", "receive", "adjust"}
+
+
+@dataclass
+class Wallet:
+    guild_id: str
+    player_id: str
+    balance: int      # settled
+    reserved: int     # pending withdraws (>=0)
+    available: int    # balance - reserved
+
+
+# ---------------------------------------------------------------------------
+# retry helper (transient SQLite write-lock backoff, matching debt_service)
+# ---------------------------------------------------------------------------
+async def _with_retry(thunk):
+    """Run an async thunk, retrying on transient 'database is locked' with backoff."""
+    max_retries = 3
+    retry_delay = 1.0
+    for attempt in range(max_retries):
+        try:
+            return await thunk()
+        except OperationalError as e:
+            if "database is locked" in str(e) and attempt < max_retries - 1:
+                logger.warning(
+                    f"Wallet DB locked on attempt {attempt + 1}/{max_retries}, "
+                    f"retrying in {retry_delay}s..."
+                )
+                await asyncio.sleep(retry_delay)
+                retry_delay *= 2
+            else:
+                raise
+
+
+async def _sum_amount(session, *conditions) -> int:
+    q = select(func.coalesce(func.sum(WalletTx.amount), 0)).where(*conditions)
+    result = await session.execute(q)
+    return int(result.scalar() or 0)
+
+
+async def _balances(session, guild_id: str, player_id: str) -> tuple[int, int]:
+    """(balance, reserved) inside an existing session/transaction."""
+    balance = await _sum_amount(
+        session,
+        WalletTx.guild_id == guild_id,
+        WalletTx.player_id == player_id,
+        WalletTx.status == "done",
+    )
+    pending = await _sum_amount(
+        session,
+        WalletTx.guild_id == guild_id,
+        WalletTx.player_id == player_id,
+        WalletTx.status == "pending",
+    )
+    return balance, -pending  # pending debits are negative -> reserved is positive
+
+
+# ---------------------------------------------------------------------------
+# reads
+# ---------------------------------------------------------------------------
+async def get_balance(guild_id: str, player_id: str) -> int:
+    async with db_session() as session:
+        balance, _ = await _balances(session, guild_id, player_id)
+        return balance
+
+
+async def get_available(guild_id: str, player_id: str) -> int:
+    async with db_session() as session:
+        balance, reserved = await _balances(session, guild_id, player_id)
+        return balance - reserved
+
+
+async def get_wallet(guild_id: str, player_id: str) -> Wallet:
+    async with db_session() as session:
+        balance, reserved = await _balances(session, guild_id, player_id)
+        return Wallet(guild_id, player_id, balance, reserved, balance - reserved)
+
+
+async def get_all_balances(guild_id: str) -> dict[str, int]:
+    """Non-zero settled balances for every player in the guild (for the audit board)."""
+    async with db_session() as session:
+        query = (
+            select(WalletTx.player_id, func.sum(WalletTx.amount).label("balance"))
+            .where(WalletTx.guild_id == guild_id, WalletTx.status == "done")
+            .group_by(WalletTx.player_id)
+            .having(func.sum(WalletTx.amount) != 0)
+        )
+        result = await session.execute(query)
+        return {row.player_id: int(row.balance) for row in result.all()}
+
+
+async def total_wallets(guild_id: str = None) -> int:
+    """SUM of all settled balances — the claim side of the reconciliation invariant.
+
+    The physical vault (one MTGO custodian) is shared across guilds, so the audit total
+    is global by default; pass ``guild_id`` only for a per-guild subtotal.
+    """
+    async with db_session() as session:
+        conditions = [WalletTx.status == "done"]
+        if guild_id is not None:
+            conditions.append(WalletTx.guild_id == guild_id)
+        return await _sum_amount(session, *conditions)
+
+
+async def get_history(guild_id: str, player_id: str = None, limit: int = 25) -> list[WalletTx]:
+    limit = min(limit, 100)
+    async with db_session() as session:
+        query = select(WalletTx).where(WalletTx.guild_id == guild_id)
+        if player_id:
+            query = query.where(WalletTx.player_id == player_id)
+        query = query.order_by(WalletTx.created_at.desc(), WalletTx.id.desc()).limit(limit)
+        result = await session.execute(query)
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# credits (deposit / receive) — written only as 'done', idempotent by job_id
+# ---------------------------------------------------------------------------
+async def credit_done(
+    guild_id: str,
+    player_id: str,
+    amount: int,
+    kind: str,
+    *,
+    job_id: str = None,
+    counterparty_id: str = None,
+    source: str = None,
+    notes: str = None,
+) -> WalletTx:
+    """Book a settled credit (+amount). Idempotent by ``job_id`` when provided —
+    a replayed deposit-job poll returns the existing row instead of double-crediting."""
+    if amount <= 0:
+        raise ValueError("Credit amount must be positive")
+    if kind not in VALID_KINDS:
+        raise ValueError(f"Invalid kind: {kind}")
+
+    async def _do():
+        async with db_session() as session:
+            if job_id:
+                existing = await session.execute(
+                    select(WalletTx).where(
+                        WalletTx.job_id == job_id,
+                        WalletTx.kind == kind,
+                        WalletTx.status == "done",
+                    )
+                )
+                row = existing.scalars().first()
+                if row:
+                    logger.info(f"credit_done: job {job_id} already booked (idempotent), returning existing")
+                    return row
+            tx = WalletTx(
+                guild_id=guild_id, player_id=player_id, kind=kind, amount=amount,
+                status="done", counterparty_id=counterparty_id, job_id=job_id,
+                source=source, notes=notes,
+            )
+            session.add(tx)
+            await session.flush()
+            await session.refresh(tx)
+            logger.info(f"credit_done: {player_id} +{amount} ({kind}) job={job_id} -> tx {tx.id}")
+            return tx
+
+    return await _with_retry(_do)
+
+
+# ---------------------------------------------------------------------------
+# withdraw = reserve (pending debit) -> settle | cancel
+# ---------------------------------------------------------------------------
+async def reserve_debit(
+    guild_id: str,
+    player_id: str,
+    amount: int,
+    *,
+    kind: str = "withdraw",
+    counterparty_id: str = None,
+    source: str = "serve",
+    notes: str = None,
+) -> WalletTx:
+    """Atomically check ``available >= amount`` and write a 'pending' debit (-amount)
+    that reserves the tix. Caller then POSTs the MTGO job and calls ``attach_job``.
+    Raises ValueError if funds are insufficient."""
+    if amount <= 0:
+        raise ValueError("Withdraw amount must be positive")
+
+    async def _do():
+        async with db_session() as session:
+            balance, reserved = await _balances(session, guild_id, player_id)
+            available = balance - reserved
+            if amount > available:
+                raise ValueError(
+                    f"Insufficient funds: need {amount}, available {available} "
+                    f"(balance {balance}, reserved {reserved})"
+                )
+            tx = WalletTx(
+                guild_id=guild_id, player_id=player_id, kind=kind, amount=-amount,
+                status="pending", counterparty_id=counterparty_id, source=source, notes=notes,
+            )
+            session.add(tx)
+            await session.flush()
+            await session.refresh(tx)
+            logger.info(f"reserve_debit: {player_id} reserved {amount} ({kind}) -> tx {tx.id}")
+            return tx
+
+    return await _with_retry(_do)
+
+
+async def attach_job(tx_id: int, job_id: str) -> WalletTx:
+    """Attach the serve job id to a reservation once the POST returns."""
+    async def _do():
+        async with db_session() as session:
+            tx = await session.get(WalletTx, tx_id)
+            if tx is None:
+                logger.warning(f"attach_job: tx {tx_id} not found")
+                return None
+            tx.job_id = job_id
+            await session.flush()
+            await session.refresh(tx)
+            return tx
+
+    return await _with_retry(_do)
+
+
+async def _resolve_reserve(tx_id: int, new_status: str) -> WalletTx:
+    async def _do():
+        async with db_session() as session:
+            tx = await session.get(WalletTx, tx_id)
+            if tx is None:
+                logger.warning(f"resolve reserve: tx {tx_id} not found")
+                return None
+            if tx.status == "pending":
+                tx.status = new_status
+                await session.flush()
+                await session.refresh(tx)
+                logger.info(f"reserve tx {tx_id} -> {new_status}")
+            else:
+                logger.info(f"reserve tx {tx_id} already {tx.status} (idempotent no-op)")
+            return tx
+
+    return await _with_retry(_do)
+
+
+async def settle_reserve(tx_id: int) -> WalletTx:
+    """Withdraw job completed: confirm the reservation (pending -> done). Idempotent."""
+    return await _resolve_reserve(tx_id, "done")
+
+
+async def cancel_reserve(tx_id: int) -> WalletTx:
+    """Withdraw job failed/aborted: release the reservation (pending -> cancelled). Idempotent."""
+    return await _resolve_reserve(tx_id, "cancelled")
+
+
+# ---------------------------------------------------------------------------
+# internal pay (no MTGO trade) — two 'done' rows, idempotent by source
+# ---------------------------------------------------------------------------
+async def pay(
+    guild_id: str,
+    from_player: str,
+    to_player: str,
+    amount: int,
+    *,
+    source: str = None,
+    notes: str = None,
+) -> tuple[WalletTx, WalletTx]:
+    """Move ``amount`` tix from one wallet to another with no trade. Checks the payer's
+    available funds, writes a -amount 'pay' row and a +amount 'receive' row in one
+    transaction. Idempotent by ``source`` (pass a debt/settlement id to make a
+    debt-settlement pay replay-safe; a uuid is generated otherwise)."""
+    if amount <= 0:
+        raise ValueError("Payment amount must be positive")
+    if from_player == to_player:
+        raise ValueError("Cannot pay yourself")
+    if source is None:
+        source = str(uuid.uuid4())
+
+    async def _do():
+        async with db_session() as session:
+            # idempotency: both legs already written for this source?
+            existing = await session.execute(
+                select(WalletTx).where(WalletTx.source == source, WalletTx.kind.in_(["pay", "receive"]))
+                .order_by(WalletTx.id)
+            )
+            rows = existing.scalars().all()
+            if len(rows) >= 2:
+                logger.info(f"pay: source {source} already settled (idempotent), returning existing")
+                return rows[0], rows[1]
+
+            balance, reserved = await _balances(session, guild_id, from_player)
+            available = balance - reserved
+            if amount > available:
+                raise ValueError(
+                    f"Insufficient funds: {from_player} needs {amount}, available {available}"
+                )
+
+            debit = WalletTx(
+                guild_id=guild_id, player_id=from_player, kind="pay", amount=-amount,
+                status="done", counterparty_id=to_player, source=source, notes=notes,
+            )
+            credit = WalletTx(
+                guild_id=guild_id, player_id=to_player, kind="receive", amount=amount,
+                status="done", counterparty_id=from_player, source=source, notes=notes,
+            )
+            session.add(debit)
+            session.add(credit)
+            await session.flush()
+            await session.refresh(debit)
+            await session.refresh(credit)
+            logger.info(f"pay: {from_player} -> {to_player} {amount} tix (source {source})")
+            return debit, credit
+
+    return await _with_retry(_do)
+
+
+async def adjust(guild_id: str, player_id: str, amount: int, notes: str, created_by: str) -> WalletTx:
+    """Admin credit/debit (audit correction). ``amount`` signed. Bypasses the funds
+    check (an admin may drive a balance negative to record a real-world discrepancy)."""
+    if amount == 0:
+        raise ValueError("Adjustment cannot be zero")
+
+    async def _do():
+        async with db_session() as session:
+            tx = WalletTx(
+                guild_id=guild_id, player_id=player_id, kind="adjust", amount=amount,
+                status="done", source="admin", notes=f"{notes} (by {created_by})",
+            )
+            session.add(tx)
+            await session.flush()
+            await session.refresh(tx)
+            logger.info(f"adjust: {player_id} {amount:+d} by {created_by}")
+            return tx
+
+    return await _with_retry(_do)
+
+
+# ---------------------------------------------------------------------------
+# reconciliation audit: physical vault tix == SUM(settled wallets)
+# ---------------------------------------------------------------------------
+async def reconcile(bot_tix: int, guild_id: str = None) -> dict:
+    """Compare the physical vault tix (from the serve ``/vault``) to the claim total.
+
+    ``bot_tix`` is global (one custodian), so by default the claim side is summed across
+    all guilds. Returns {ok, wallet_total, bot_tix, diff}; ok when they match exactly."""
+    wallet_total = await total_wallets(guild_id)
+    diff = bot_tix - wallet_total
+    ok = diff == 0
+    if not ok:
+        logger.warning(f"RECONCILE MISMATCH: bot_tix={bot_tix} wallets={wallet_total} diff={diff:+d}")
+    return {"ok": ok, "wallet_total": wallet_total, "bot_tix": bot_tix, "diff": diff}

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -32,7 +32,7 @@ from sqlalchemy.exc import OperationalError
 from database.db_session import db_session
 from models.wallet_tx import WalletTx
 
-VALID_KINDS = {"deposit", "withdraw", "pay", "receive", "adjust"}
+VALID_KINDS = {"deposit", "withdraw", "pay", "receive", "adjust", "escrow"}
 
 
 @dataclass
@@ -145,6 +145,23 @@ async def get_history(guild_id: str, player_id: str = None, limit: int = 25) -> 
         query = query.order_by(WalletTx.created_at.desc(), WalletTx.id.desc()).limit(limit)
         result = await session.execute(query)
         return list(result.scalars().all())
+
+
+async def get_pending_reserve(guild_id: str, player_id: str, source: str) -> WalletTx | None:
+    """The player's outstanding ('pending') reserve carrying this exact ``source`` tag, or
+    None. Lets a reservation be made idempotent: re-securing the same tournament entry can
+    reuse the existing hold instead of stacking a second one (e.g. after a crash between
+    reserving and marking the participant paid)."""
+    async with db_session() as session:
+        result = await session.execute(
+            select(WalletTx).where(
+                WalletTx.guild_id == guild_id,
+                WalletTx.player_id == player_id,
+                WalletTx.source == source,
+                WalletTx.status == "pending",
+            ).order_by(WalletTx.id).limit(1)
+        )
+        return result.scalars().first()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this adds

An MTGO **tix wallet** for DraftBot, and tournaments that can charge a real entry fee, escrow it, and pay out the prize pool.

The bot never holds tix itself: an MTGO TradeBot "serve" (running next to a logged-in MTGO client, reached over Tailscale) owns the physical collection and executes trades. DraftBot keeps the **claim ledger** — who is owed what out of that vault — and the two are tied together by one invariant:

> **vault tix == SUM(settled wallet balances)**

`/wallet reconcile` audits exactly that.

### Player-facing

| Command | What it does |
|---|---|
| `/wallet` | balance / reserved / available + recent activity |
| `/wallet deposit <n>` | trade tix to the custodian → wallet credited when the trade completes |
| `/wallet withdraw <n>` | reserve tix → custodian trades them back to you → settled |
| `/wallet pay @player <n>` | internal transfer, no MTGO trade |
| `/link_mtgo <username>` | identity bridge (required before any trade) |
| `/tournament create … entry_fee:N payout:top2` | paid tournaments |
| `/tournament payout` | preview + confirm, then disburse the pool |

A paid registration holds the fee from the captain's wallet; if the wallet is short, the bot opens a deposit job for the difference and completes the registration when the trade lands. On `/tournament start` every hold moves into a synthetic **prize wallet**; on payout it's split by the declared structure (winner-take-all / top2 / top3 / top4).

### Design notes

- **Append-only ledger, no stored balance.** `WalletTx` is the single source of truth; balance is `SUM(amount WHERE status='done')`, mirroring `DebtLedger`. A balance can't drift from its own history.
- **Credits only on `done`.** A deposit books nothing until its MTGO job completes; withdraws are reserve → settle/cancel, so in-flight tix can't be double-spent.
- **Internal transfers preserve the invariant** — escrow, prize reallocation and payouts move claims between wallets without touching the vault.

## Correctness work

The feature was reviewed by four parallel cleanup agents (reuse / simplification / efficiency / altitude), then adversarially reviewed by Codex for money-path correctness, then hardened, then re-reviewed by the same four-angle pass. Fixes from that:

- **Lost POST responses** — an ambiguous POST failure (delivered, response lost) no longer orphans a trade: the job is adopted from the serve's `/jobs` listing. Definite rejections still fail fast, and only then is a withdraw's reserve released.
- **Stranded jobs** — every started job is persisted (`mtgo_jobs`); a watchdog re-polls anything pending at startup and every 10 minutes, so a trade completing after a poll timeout or across a restart is always booked. **This one was found by live testing** (a serve stall completed at 28 minutes, past the 14-minute poll).
- **DB-enforced idempotency** — partial unique indexes make double-booking impossible rather than merely unlikely: one booking per `(job_id, kind)`, one leg per `(source, kind)`, one live escrow reserve per source.
- **Debit serialization** — a process-wide money lock wraps every check-available-then-spend path, so two concurrent debits can't both spend the same balance (sound because the bot is the DB's only writer).
- **Atomicity** — escrow reserve + participant-paid flip commit together; admin comps commit with their registration; tournament start seeds and reallocates the pot in one transaction.

## Testing

- **Full suite: 1005 passed, 9 skipped.**
- **Concurrency smoke test** racing each guard: duplicate credits, duplicate pays, over-drafting debits, double escrow secures, double payouts — all held.
- **Two live end-to-end rounds** against the real TradeBot over Tailscale, driven through Discord: link → deposit (with a mid-trade bot restart, recovered by the resumer) → two paid registrations → start → result → finish → payout → withdraw → reconcile. Real tix moved on MTGO in both directions and the ledger balanced.
- **Migration verified against a fresh production copy** (stamped `dispnamefill0`): the four wallet migrations apply cleanly to a single head with all three unique indexes present. The chain was re-parented onto main's head rather than merged, since it has never run in prod — prod's auto-migration on restart executes exactly the path that was tested.

## Deploying

1. Droplet needs Tailscale and reachability to the serve host (`curl -H "Authorization: Bearer $TOKEN" http://<tailnet-ip>:8787/health`). Inbound TCP 8787 must be allowed on the serve's Windows firewall for the tailnet range.
2. Add `MTGO_TRADEBOT_URL` and `MTGO_TRADEBOT_TOKEN` to prod `.env` — the integration stays **disabled** unless both are set, so merging this is inert until they are.
3. The target guild needs `"money_server": true`; entry fees are additionally gated on the serve being configured.
4. Restart `draftbot.service` (migrations run automatically).

Operational note: the custodian is whichever MTGO account the serve is attached to, and deposits/withdraws only work while that machine is up. When it isn't, wallet commands degrade to "vault unreachable" and paid registrations fail safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTWPB33ixEx53ZG9q7SDLG
