### PR TITLE
DraftBot: top25pct payout structure (top 25% of teams, 5/3/2/2 shares)

### DIFF
--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -314,7 +314,7 @@ class TournamentCog(commands.Cog):
         ),
         payout: discord.Option(
             str, "Prize-pool split for entry-fee tournaments",
-            choices=list(escrow.PAYOUT_STRUCTURES), default="winner_take_all"
+            choices=list(escrow.PAYOUT_CHOICES), default="winner_take_all"
         ),
     ):
         if not await self._check_enabled(ctx):
@@ -674,7 +674,7 @@ class TournamentCog(commands.Cog):
         ),
         structure: discord.Option(
             str, "Override the declared payout split",
-            choices=list(escrow.PAYOUT_STRUCTURES), required=False, default=None
+            choices=list(escrow.PAYOUT_CHOICES), required=False, default=None
         ),
     ):
         if not await self._check_enabled(ctx):

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -63,14 +63,36 @@ PAYOUT_STRUCTURES = {
     "top4": [40, 30, 20, 10],
 }
 
+# top25pct — the league-page structure — pays 25% of the field (rounded down,
+# minimum one place) rather than a fixed place count, so its share list is
+# derived per-field in _structure_ratios instead of living in the dict above.
+# Stepped ladder: 5/3/2/2 for the first four places, 2 shares for places 5-6,
+# and 1 share for every place beyond — so first place's cut scales up as a
+# larger field adds low tail places instead of being diluted by them.
+TOP25_SHARES = [5, 3, 2, 2, 2, 2]
+TOP25_EXTENSION_SHARE = 1
+
+# Everything a create/payout command may name: static presets plus the dynamic one.
+PAYOUT_CHOICES = list(PAYOUT_STRUCTURES) + ["top25pct"]
+
 
 def describe_structure(name: str) -> str:
+    if name == "top25pct":
+        return "top 25% of teams (5/3/2/2 shares)"
     ratios = PAYOUT_STRUCTURES.get(name)
     if not ratios:
         return name
     if name == "winner_take_all":
         return "winner-take-all"
     return f"top {len(ratios)} ({'/'.join(str(r) for r in ratios)})"
+
+
+def _structure_ratios(structure: str, field_size: int) -> list:
+    """The share list a structure pays over a field of ``field_size`` teams."""
+    if structure == "top25pct":
+        places = max(1, field_size // 4)
+        return (TOP25_SHARES + [TOP25_EXTENSION_SHARE] * (places - len(TOP25_SHARES)))[:places]
+    return PAYOUT_STRUCTURES.get(structure) or PAYOUT_STRUCTURES["winner_take_all"]
 
 
 def compute_allocations(pool: int, structure: str, ranked: list) -> list:
@@ -80,7 +102,7 @@ def compute_allocations(pool: int, structure: str, ranked: list) -> list:
     [(place, captain_id, team_name, amount)] for amounts > 0. Integer tix; the whole pool is
     always distributed — normalized to the places actually paid (so fewer teams than the
     structure names just concentrates the split), with the rounding remainder going to 1st."""
-    ratios = PAYOUT_STRUCTURES.get(structure) or PAYOUT_STRUCTURES["winner_take_all"]
+    ratios = _structure_ratios(structure, len(ranked))
     n = min(len(ratios), len(ranked))
     if n == 0 or pool <= 0:
         return []

--- a/tests/test_payout_structures.py
+++ b/tests/test_payout_structures.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for the prize-pool split logic in services.tournament_escrow_service.
+
+compute_allocations had no direct coverage before top25pct was added; the
+static-structure tests here pin the pre-existing behavior alongside the new
+field-size-dependent structure.
+"""
+from services.tournament_escrow_service import (
+    PAYOUT_CHOICES,
+    PAYOUT_STRUCTURES,
+    compute_allocations,
+    describe_structure,
+)
+
+
+def ranked(n):
+    """A finish-ordered field of n teams: 1st first."""
+    return [(f"captain{i}", f"Team{i}") for i in range(1, n + 1)]
+
+
+class TestStaticStructures:
+    def test_winner_take_all_pays_everything_to_first(self):
+        allocs = compute_allocations(1200, "winner_take_all", ranked(8))
+        assert allocs == [(1, "captain1", "Team1", 1200)]
+
+    def test_top4_splits_by_percentages(self):
+        allocs = compute_allocations(1000, "top4", ranked(8))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 400), (2, 300), (3, 200), (4, 100)]
+
+    def test_fewer_teams_than_places_renormalizes(self):
+        # top4 over a 3-team field: 40/30/20 renormalized over 90.
+        allocs = compute_allocations(900, "top4", ranked(3))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 400), (2, 300), (3, 200)]
+
+    def test_rounding_remainder_goes_to_first(self):
+        # top2 65/35 of 101: floors to 65/35, remainder 1 -> 1st.
+        allocs = compute_allocations(101, "top2", ranked(4))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 66), (2, 35)]
+        assert sum(amt for _, _, _, amt in allocs) == 101
+
+    def test_unknown_structure_falls_back_to_winner_take_all(self):
+        allocs = compute_allocations(500, "no_such_structure", ranked(4))
+        assert allocs == [(1, "captain1", "Team1", 500)]
+
+    def test_empty_pool_or_field_pays_nothing(self):
+        assert compute_allocations(0, "top2", ranked(4)) == []
+        assert compute_allocations(500, "top2", []) == []
+
+
+class TestTop25Pct:
+    """The league's advertised split: top 25% of teams (rounded down, min one
+    place) on a stepped share ladder — 5/3/2/2 for the first four places,
+    2 shares for places 5-6, 1 share for every place beyond."""
+
+    def test_sixteen_teams_matches_the_league_page_example(self):
+        # 16 teams * 150 tix = 2400 pool; 4 places on 5/3/2/2 shares of 12.
+        allocs = compute_allocations(2400, "top25pct", ranked(16))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 1000), (2, 600), (3, 400), (4, 400)]
+
+    def test_eight_teams_pays_two_places(self):
+        allocs = compute_allocations(1200, "top25pct", ranked(8))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 750), (2, 450)]
+
+    def test_twelve_teams_pays_three_places(self):
+        allocs = compute_allocations(1000, "top25pct", ranked(12))
+        assert [(p, amt) for p, _, _, amt in allocs] == [(1, 500), (2, 300), (3, 200)]
+
+    def test_twenty_teams_extends_to_five_places_at_two_shares(self):
+        allocs = compute_allocations(1400, "top25pct", ranked(20))
+        assert [(p, amt) for p, _, _, amt in allocs] == [
+            (1, 500), (2, 300), (3, 200), (4, 200), (5, 200),
+        ]
+
+    def test_places_beyond_six_step_down_to_one_share(self):
+        # 32 teams -> 8 places on 5/3/2/2/2/2/1/1 (18 shares) of a 4800 pool.
+        allocs = compute_allocations(4800, "top25pct", ranked(32))
+        assert [(p, amt) for p, _, _, amt in allocs] == [
+            (1, 1336), (2, 800), (3, 533), (4, 533),
+            (5, 533), (6, 533), (7, 266), (8, 266),
+        ]
+
+    def test_tiny_field_still_pays_the_winner(self):
+        # 3 teams: 25% rounds down to 0 -> min one place.
+        allocs = compute_allocations(450, "top25pct", ranked(3))
+        assert allocs == [(1, "captain1", "Team1", 450)]
+
+    def test_whole_pool_is_always_distributed(self):
+        for teams in (3, 8, 11, 16, 20, 33):
+            for pool in (997, 1400, 2400):
+                allocs = compute_allocations(pool, "top25pct", ranked(teams))
+                assert sum(amt for _, _, _, amt in allocs) == pool, (teams, pool)
+
+    def test_places_scale_with_field_size(self):
+        for teams, places in ((4, 1), (7, 1), (8, 2), (15, 3), (16, 4), (24, 6)):
+            allocs = compute_allocations(10_000, "top25pct", ranked(teams))
+            assert len(allocs) == places, teams
+
+
+class TestStructureWiring:
+    def test_top25pct_is_offered_alongside_the_static_structures(self):
+        assert set(PAYOUT_CHOICES) == set(PAYOUT_STRUCTURES) | {"top25pct"}
+
+    def test_command_choices_use_the_full_list(self):
+        from cogs.tournament_commands import TournamentCog
+
+        for command_name in ("create", "payout"):
+            command = next(
+                c for c in TournamentCog.tournament.walk_commands() if c.name == command_name
+            )
+            option = next(o for o in command.options if o.name in ("payout", "structure"))
+            assert set(c if isinstance(c, str) else c.value for c in option.choices) == set(
+                PAYOUT_CHOICES
+            ), command_name
+
+    def test_describe_top25pct(self):
+        text = describe_structure("top25pct")
+        assert "25%" in text and "5/3/2/2" in text
+
+    def test_describe_static_structures_unchanged(self):
+        assert describe_structure("winner_take_all") == "winner-take-all"
+        assert describe_structure("top3") == "top 3 (50/30/20)"


### PR DESCRIPTION
Adds the payout structure the league page advertises: **top 25% of teams (rounded down), paid on 5/3/2/2 shares.**

## Why

The existing presets are all fixed-place percentage splits — `winner_take_all`, `top2`, `top3`, `top4` — so nothing could derive the paid-place count from the field size. `top4` isn't a substitute either: on the page's own example (16 teams, 2,400 tix) it pays **960/720/480/240**, while the advertised shares pay **1000/600/400/400**.

## How

`top25pct` has no fixed ratio list, so it lives outside `PAYOUT_STRUCTURES` and is resolved per-field at payout time by a new `_structure_ratios(structure, field_size)`:

- **places** = `field // 4`, minimum 1
- **shares** = `5/3/2/2` for the first four places, `2` for places 5–6, `1` for every place beyond

The stepped tail (rather than a flat 2) means the top prizes scale up as a bigger field adds low tail places instead of being diluted by them:

| Field | Places | 1st | 2nd | 3rd–4th | 5th–6th | 7th+ |
|---|---|---|---|---|---|---|
| 8 (1,200) | 2 | 750 | 450 | — | — | — |
| 16 (2,400) | 4 | 1000 | 600 | 400 | — | — |
| 24 (3,600) | 6 | 1125 | 675 | 450 | 450 | — |
| 32 (4,800) | 8 | 1336 | 800 | 533 | 533 | 266 |

Everything downstream is untouched: the share list feeds the existing `compute_allocations` normalization, so integer-tix flooring, remainder-to-first, and "the whole pool is always distributed" behave exactly as before. Both `/tournament create` and `/tournament payout` offer the new structure via `PAYOUT_CHOICES` (the static presets plus the dynamic one).

## Tests

`compute_allocations` had no direct coverage, so this adds a file (18 cases) that pins the **pre-existing** behavior alongside the new structure:

- static presets: percentage splits, renormalization when the field is shorter than the structure, rounding remainder to 1st, unknown-structure fallback to winner-take-all, empty pool/field
- `top25pct`: the league page's 16-team example verbatim, place-count scaling (8→2, 12→3, 16→4, 20→5, 24→6, 32→8), the stepped tail at 32 teams, the min-one-place floor on a 3-team field, and a sweep asserting the whole pool is distributed across field sizes × odd pool values
- wiring: both slash-command options actually offer all five structures

Full suite green.

## Note on the base

Branched off `main`, which has the escrow/payout code from #399. It does **not** include #400 (registration board), which merged into `mtgo-escrow-wallet` after #399 landed — this change is independent of that work and touches different regions of `tournament_commands.py`.

## Follow-up (not in this PR)

The league page also promises **finals playoffs**, which nothing supports: `advance_round` completes the tournament after the last Swiss round, `add_match` is restricted to `manual` + `registration` status, and `/tournament payout` ranks strictly by Swiss standings — so hand-run finals currently cannot change who gets first-place money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNQ9PeNfT5bzXR1E38Wp9C
