### PR TITLE
Keep the registration board's deficit fresh on deposit and auto-draw

### DIFF
--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -114,16 +114,20 @@ class WalletCommands(commands.Cog):
                 # just committed to that entry, so its fee shouldn't be siphoned to a
                 # creditor on the way in.
                 completed = await escrow.sweep_pending_entries(player_id)
-                bal = await wallet_service.get_balance(guild_id, player_id)
                 drawn = await resolution.auto_draw(guild_id, player_id)
+                bal = await wallet_service.get_balance(guild_id, player_id)
+                # Refresh after BOTH: a deposit that only part-covers a fee, and an
+                # auto-draw that spends one, each move the "needs N more tix" figure
+                # without completing anything — so the completed ids alone aren't enough.
+                stale = set(completed) | set(await escrow.open_boards_for_captain(player_id))
+                for t_id in stale:
+                    try:
+                        await update_registration_board(bot, t_id)
+                    except Exception as e:
+                        logger.warning(f"board refresh failed for {t_id}: {e}")
                 msg = f"✅ Deposit confirmed: **+{amount} tix**. Balance: **{bal} tix**."
                 if completed:
                     msg += f" Completed **{len(completed)}** pending tournament registration(s)."
-                    for t_id in set(completed):
-                        try:
-                            await update_registration_board(bot, t_id)
-                        except Exception as e:
-                            logger.warning(f"board refresh failed for {t_id}: {e}")
                 if drawn:
                     total = sum(d.get("amount", 0) for d in drawn)
                     msg += f" Auto-applied **{total} tix** to {len(drawn)} debt(s)."

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -182,6 +182,26 @@ async def refund_entry(session, guild_id: str, tournament_id: int,
     return leg.amount
 
 
+async def open_boards_for_captain(captain_id: str) -> list[int]:
+    """Tournament ids in registration where ``captain_id`` still has an unpaid entry.
+
+    Their boards render "needs N more tix", derived from this captain's balance — a
+    partial deposit (or an auto-draw that spends one) moves N without completing
+    anything, so the sweep's completed-ids alone would leave those boards stale."""
+    async with db_session() as session:
+        rows = (await session.execute(
+            select(Tournament.id)
+            .join(TournamentParticipant,
+                  TournamentParticipant.tournament_id == Tournament.id)
+            .where(
+                Tournament.status == "registration",
+                Tournament.entry_fee > 0,
+                TournamentParticipant.status != "paid",
+                TournamentParticipant.captain_user_id == captain_id,
+            ))).scalars().all()
+    return list(dict.fromkeys(rows))
+
+
 async def sweep_pending_entries(captain_id: str = None) -> list[int]:
     """Complete every pending entry whose captain's wallet can now cover the fee.
 

--- a/tests/test_escrow_pending_entries.py
+++ b/tests/test_escrow_pending_entries.py
@@ -136,3 +136,37 @@ async def test_ledger_nets_to_zero_across_entry_and_refund(test_db):  # noqa: F8
 
     await escrow.drop_with_refund(t_id, "Netters")
     assert await wallet_service.total_wallets() == 2  # refund moved it back
+
+
+# --- board freshness while an entry is still short -----------------------------
+# A partial deposit (or an auto-draw that spends one) moves the "needs N more tix"
+# figure without completing anything, so the sweep's completed-ids alone leave the
+# board stale. open_boards_for_captain is what the deposit follow-up refreshes on.
+
+@pytest.mark.asyncio
+async def test_open_boards_lists_a_captains_unpaid_entries(test_db):  # noqa: F811
+    t_id, _ = await _paid_tournament(fee=2, team="Short Squad")
+
+    assert await escrow.open_boards_for_captain(CAPTAIN) == [t_id]
+    assert await escrow.open_boards_for_captain("someone-else") == []
+
+
+@pytest.mark.asyncio
+async def test_a_partial_deposit_leaves_the_board_listed_but_completes_nothing(test_db):  # noqa: F811
+    """The exact case that showed a stale deficit: 1 tix toward a 2 tix fee."""
+    t_id, p_id = await _paid_tournament(fee=2, team="Short Squad")
+    await wallet_service.credit_done(GUILD, CAPTAIN, 1, job_id="j-partial")
+
+    assert await escrow.sweep_pending_entries(CAPTAIN) == []      # nothing completed
+    assert await escrow.open_boards_for_captain(CAPTAIN) == [t_id]  # ...but still needs a refresh
+    assert await _status(p_id) == "pending"
+    assert await wallet_service.get_balance(GUILD, CAPTAIN) == 1   # partial stays liquid
+
+
+@pytest.mark.asyncio
+async def test_a_paid_entry_drops_off_the_open_boards_list(test_db):  # noqa: F811
+    t_id, _ = await _paid_tournament(fee=2, team="Payers")
+    await wallet_service.credit_done(GUILD, CAPTAIN, 2, job_id="j-full")
+
+    assert await escrow.sweep_pending_entries(CAPTAIN) == [t_id]
+    assert await escrow.open_boards_for_captain(CAPTAIN) == []


### PR DESCRIPTION
## The bug

The board renders `needs N more tix` for a pending team, derived from the captain's wallet balance. But the only refresh trigger was the escrow sweep's list of **completed** entries — so a deposit that doesn't cover the whole fee completes nothing, refreshes nothing, and the board keeps showing the old figure.

Deposit 1 tix toward a 2 tix fee and the board still says "needs 2 more tix". Auto-draw spending that partial deposit has the same blind spot in reverse: the captain's balance drops, the real deficit grows, the board doesn't move.

## The fix

`open_boards_for_captain(captain_id)` returns the registration-phase tournaments where that captain still owes a fee. The deposit follow-up now refreshes `completed ∪ those`, and does it **after** `auto_draw` has run, so the number reflects the balance the captain is actually left with rather than the balance they had for an instant mid-handler.

Entry fees stay all-or-nothing: a partial deposit is never escrowed, so it remains liquid and debts can still consume it. That's deliberate and unchanged — this only makes the board tell the truth about what's left to deposit.

## Tests

- `open_boards_for_captain` lists a captain's unpaid entries, is scoped to that captain, and drops an entry once it's paid.
- The exact failing case: 1 tix toward a 2 tix fee completes nothing, leaves the entry pending and the tix liquid, and still marks the board for refresh.

Suite: 1064 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTWPB33ixEx53ZG9q7SDLG