### PR TITLE
Registration board: simplify pass + always show how to join

### DIFF
--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -14,7 +14,7 @@ from services.tournament_formatter import (
     create_registration_embed,
     create_standings_embed,
     post_registration_board,
-    update_registration_board,
+    refresh_boards,
     update_standings_message,
 )
 from services.tournament_service import (
@@ -287,10 +287,7 @@ class TournamentCog(commands.Cog):
     async def _refresh_board(self, tournament_id, closed=False):
         """Refresh a tournament's registration board. The board is a view — never let a
         Discord failure break the command that changed the roster."""
-        try:
-            await update_registration_board(self.bot, tournament_id, closed=closed)
-        except Exception as e:
-            logger.warning(f"Registration board refresh failed for {tournament_id}: {e}")
+        await refresh_boards(self.bot, [tournament_id], closed=closed)
 
     @tournament.command(name="enable", description="Admin: enable tournament commands on this server")
     @has_bot_manager_role()

--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -27,7 +27,7 @@ from services import wallet_service
 from services import mtgo_resolution_service as resolution
 from services import tournament_escrow_service as escrow
 from services.mtgo_tradebot_client import EVENT_TICKET
-from services.tournament_formatter import update_registration_board
+from services.tournament_formatter import refresh_boards
 from helpers.money_gate import (
     DEFAULT_WAIT_MINUTES, custodian_name, explain_trade_failure, gate_read, gate_serve,
     linked_username, spawn_followup,
@@ -116,15 +116,10 @@ class WalletCommands(commands.Cog):
                 completed = await escrow.sweep_pending_entries(player_id)
                 drawn = await resolution.auto_draw(guild_id, player_id)
                 bal = await wallet_service.get_balance(guild_id, player_id)
-                # Refresh after BOTH: a deposit that only part-covers a fee, and an
-                # auto-draw that spends one, each move the "needs N more tix" figure
-                # without completing anything — so the completed ids alone aren't enough.
-                stale = set(completed) | set(await escrow.open_boards_for_captain(player_id))
-                for t_id in stale:
-                    try:
-                        await update_registration_board(bot, t_id)
-                    except Exception as e:
-                        logger.warning(f"board refresh failed for {t_id}: {e}")
+                # Completed entries AND ones this captain is still short on — see
+                # escrow.open_boards_for_captain.
+                await refresh_boards(
+                    bot, set(completed) | set(await escrow.open_boards_for_captain(player_id)))
                 msg = f"✅ Deposit confirmed: **+{amount} tix**. Balance: **{bal} tix**."
                 if completed:
                     msg += f" Completed **{len(completed)}** pending tournament registration(s)."

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -290,14 +290,14 @@ async def pending_jobs_watchdog(bot=None):
             # Funds can also land outside a tracked job (a plain /wallet deposit, a
             # teammate's /wallet pay), so finish any entry the wallet can now cover.
             from services import tournament_escrow_service as escrow
-            completed = await escrow.sweep_pending_entries()
+            await escrow.sweep_pending_entries()
             if bot is not None:
-                from services.tournament_formatter import update_registration_board
-                for t_id in set(completed):
-                    try:
-                        await update_registration_board(bot, t_id)
-                    except Exception as e:
-                        logger.warning(f"board refresh failed for {t_id}: {e}")
+                # Re-render every open board, not just ones whose entries completed:
+                # /wallet pay, a withdraw and a debt settlement all move a captain's
+                # balance — and so the "needs N more tix" figure — by routes no
+                # refresh call site covers. This tick is the backstop for all of them.
+                from services.tournament_formatter import refresh_boards
+                await refresh_boards(bot, await escrow.open_registration_boards())
         except Exception as e:
             logger.warning(f"pending_jobs_watchdog: rescan failed: {e}")
         await asyncio.sleep(_RESCAN_INTERVAL_S)

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -182,24 +182,44 @@ async def refund_entry(session, guild_id: str, tournament_id: int,
     return leg.amount
 
 
-async def open_boards_for_captain(captain_id: str) -> list[int]:
-    """Tournament ids in registration where ``captain_id`` still has an unpaid entry.
+def _unpaid_entry_conditions(captain_id: str = None) -> list:
+    """What counts as a still-open entry: a fee-charging tournament still taking
+    registrations, with a team that hasn't paid. One definition, used by both the sweep
+    that completes such entries and the lookup of boards whose figures they drive."""
+    conditions = [
+        Tournament.status == "registration",
+        Tournament.entry_fee > 0,
+        TournamentParticipant.status != "paid",
+    ]
+    if captain_id:
+        conditions.append(TournamentParticipant.captain_user_id == captain_id)
+    return conditions
 
-    Their boards render "needs N more tix", derived from this captain's balance — a
-    partial deposit (or an auto-draw that spends one) moves N without completing
-    anything, so the sweep's completed-ids alone would leave those boards stale."""
+
+async def open_boards_for_captain(captain_id: str) -> list[int]:
+    """Tournament ids where ``captain_id`` still has an unpaid entry.
+
+    Those boards render "needs N more tix" from this captain's balance, so a partial
+    deposit (or an auto-draw that spends one) moves N without completing anything —
+    the sweep's completed-ids alone would leave them stale."""
     async with db_session() as session:
-        rows = (await session.execute(
+        return list((await session.execute(
             select(Tournament.id)
             .join(TournamentParticipant,
                   TournamentParticipant.tournament_id == Tournament.id)
-            .where(
-                Tournament.status == "registration",
-                Tournament.entry_fee > 0,
-                TournamentParticipant.status != "paid",
-                TournamentParticipant.captain_user_id == captain_id,
-            ))).scalars().all()
-    return list(dict.fromkeys(rows))
+            .where(*_unpaid_entry_conditions(captain_id))
+            .distinct())).scalars().all())
+
+
+async def open_registration_boards() -> list[int]:
+    """Every tournament still taking registrations. The watchdog re-renders all of them
+    each tick: balances move by routes no board-refresh call site covers (a teammate's
+    /wallet pay, a withdraw, a debt settlement), so a periodic re-render is what keeps
+    'needs N more tix' honest without chasing each money path."""
+    async with db_session() as session:
+        return list((await session.execute(
+            select(Tournament.id).where(Tournament.status == "registration")
+        )).scalars().all())
 
 
 async def sweep_pending_entries(captain_id: str = None) -> list[int]:
@@ -215,13 +235,7 @@ async def sweep_pending_entries(captain_id: str = None) -> list[int]:
 
     Pass ``captain_id`` to scope it to one person (after their deposit lands, only their
     entries can have become payable). Returns the tournament ids whose entries completed."""
-    conditions = [
-        Tournament.status == "registration",
-        Tournament.entry_fee > 0,
-        TournamentParticipant.status != "paid",
-    ]
-    if captain_id:
-        conditions.append(TournamentParticipant.captain_user_id == captain_id)
+    conditions = _unpaid_entry_conditions(captain_id)
     async with db_session() as session:
         rows = (await session.execute(
             select(TournamentParticipant, Tournament)

--- a/services/tournament_formatter.py
+++ b/services/tournament_formatter.py
@@ -39,6 +39,27 @@ def create_standings_embed(tournament, participants):
     return embed
 
 
+def _add_how_to_join(embed, fee, closed):
+    """Spell out how to sign up, for as long as sign-ups are open.
+
+    This used to appear only on an empty board, so it vanished the moment the first
+    team registered — exactly when newcomers start reading the board. A paid entry
+    also isn't one step: the fee is paid from the captain's wallet, so someone who has
+    never deposited needs the MTGO link and the deposit named too, not just the
+    register command."""
+    if closed:
+        return
+    if fee > 0:
+        value = (
+            f"1. `/link_mtgo <your MTGO username>` — once, so the bot can trade with you\n"
+            f"2. `/tournament register <team name>` — holds your spot\n"
+            f"3. `/wallet deposit {fee}` — your spot completes when the tix land"
+        )
+    else:
+        value = "`/tournament register <team name>`"
+    embed.add_field(name="How to join", value=value, inline=False)
+
+
 def create_registration_embed(tournament, participants, pot=0, deficits=None,
                               closed=False):
     """Build the registration board (pure): who is in, and for a paid tournament who
@@ -55,9 +76,8 @@ def create_registration_embed(tournament, participants, pot=0, deficits=None,
                           color=discord.Color.gold())
 
     if not participants:
-        embed.add_field(name="Teams (0)",
-                        value="No teams yet — register with `/tournament register`.",
-                        inline=False)
+        embed.add_field(name="Teams (0)", value="No teams yet.", inline=False)
+        _add_how_to_join(embed, fee, closed)
         return embed
 
     lines = []
@@ -97,6 +117,7 @@ def create_registration_embed(tournament, participants, pot=0, deficits=None,
     for i, chunk in enumerate(chunks):
         name = label if i == 0 else "Teams (cont.)"
         embed.add_field(name=name, value="\n".join(chunk), inline=False)
+    _add_how_to_join(embed, fee, closed)
     return embed
 
 
@@ -141,6 +162,17 @@ async def _board_state(session, tournament):
         guild_id, [p.captain_user_id for p in pending])
     deficits = {p.id: max(fee - balances.get(p.captain_user_id, 0), 0) for p in pending}
     return participants, pot, deficits
+
+
+async def refresh_boards(bot, tournament_ids, closed=False):
+    """Refresh several boards, guarded. The board is a view: a Discord failure on one
+    logs and the rest still update. Every caller that reacts to a change goes through
+    here rather than hand-rolling the try/except."""
+    for t_id in set(tournament_ids):
+        try:
+            await update_registration_board(bot, t_id, closed=closed)
+        except Exception as e:
+            logger.warning(f"board refresh failed for {t_id}: {e}")
 
 
 async def update_registration_board(bot, tournament_id, closed=False):

--- a/tests/test_escrow_pending_entries.py
+++ b/tests/test_escrow_pending_entries.py
@@ -139,17 +139,6 @@ async def test_ledger_nets_to_zero_across_entry_and_refund(test_db):  # noqa: F8
 
 
 # --- board freshness while an entry is still short -----------------------------
-# A partial deposit (or an auto-draw that spends one) moves the "needs N more tix"
-# figure without completing anything, so the sweep's completed-ids alone leave the
-# board stale. open_boards_for_captain is what the deposit follow-up refreshes on.
-
-@pytest.mark.asyncio
-async def test_open_boards_lists_a_captains_unpaid_entries(test_db):  # noqa: F811
-    t_id, _ = await _paid_tournament(fee=2, team="Short Squad")
-
-    assert await escrow.open_boards_for_captain(CAPTAIN) == [t_id]
-    assert await escrow.open_boards_for_captain("someone-else") == []
-
 
 @pytest.mark.asyncio
 async def test_a_partial_deposit_leaves_the_board_listed_but_completes_nothing(test_db):  # noqa: F811
@@ -159,6 +148,7 @@ async def test_a_partial_deposit_leaves_the_board_listed_but_completes_nothing(t
 
     assert await escrow.sweep_pending_entries(CAPTAIN) == []      # nothing completed
     assert await escrow.open_boards_for_captain(CAPTAIN) == [t_id]  # ...but still needs a refresh
+    assert await escrow.open_boards_for_captain("someone-else") == []  # scoped to the captain
     assert await _status(p_id) == "pending"
     assert await wallet_service.get_balance(GUILD, CAPTAIN) == 1   # partial stays liquid
 
@@ -170,3 +160,24 @@ async def test_a_paid_entry_drops_off_the_open_boards_list(test_db):  # noqa: F8
 
     assert await escrow.sweep_pending_entries(CAPTAIN) == [t_id]
     assert await escrow.open_boards_for_captain(CAPTAIN) == []
+
+
+@pytest.mark.asyncio
+async def test_open_registration_boards_is_the_watchdog_backstop(test_db):  # noqa: F811
+    """The watchdog re-renders these every tick, which is what keeps a board honest
+    after balance changes no refresh call site covers (/wallet pay, a withdraw, a debt
+    settlement) — so it must list open tournaments regardless of fee or paid state."""
+    open_paid, _ = await _paid_tournament(fee=2, team="Still Open")
+    async with db_session() as session:
+        free = Tournament(guild_id=GUILD, name="Free Cup", total_rounds=0, format="manual",
+                          status="registration", entry_fee=0)
+        started = Tournament(guild_id=GUILD, name="Started Cup", total_rounds=0,
+                             format="manual", status="active", entry_fee=2)
+        session.add_all([free, started])
+        await session.flush()
+        free_id, started_id = free.id, started.id
+
+    boards = await escrow.open_registration_boards()
+
+    assert open_paid in boards and free_id in boards   # every open board gets re-rendered
+    assert started_id not in boards                    # a started tournament is frozen

--- a/tests/test_registration_board.py
+++ b/tests/test_registration_board.py
@@ -61,6 +61,39 @@ def test_empty_board_invites_registration():
     assert "/tournament register" in _text(create_registration_embed(_tournament(), []))
 
 
+def test_join_instructions_stay_visible_once_teams_have_registered():
+    """They used to show only on an empty board, so they vanished exactly when
+    newcomers start reading it."""
+    teams = [_team(1, "Alpha", "10", "paid")]
+    text = _text(create_registration_embed(_tournament(), teams, pot=1))
+
+    assert "How to join" in text
+    assert "/tournament register" in text
+
+
+def test_paid_join_instructions_name_the_link_and_deposit_steps():
+    """Paying an entry isn't one step: the fee comes from the captain's wallet, so a
+    newcomer needs the MTGO link and the deposit amount, not just the register command."""
+    text = _text(create_registration_embed(_tournament(fee=3), [], pot=0))
+
+    assert "/link_mtgo" in text
+    assert "/wallet deposit 3" in text
+
+
+def test_free_join_instructions_are_just_the_one_command():
+    text = _text(create_registration_embed(_tournament(fee=0), []))
+
+    assert "/tournament register" in text
+    assert "/link_mtgo" not in text and "/wallet deposit" not in text
+
+
+def test_a_closed_board_drops_the_join_instructions():
+    teams = [_team(1, "Alpha", "10", "paid")]
+    text = _text(create_registration_embed(_tournament(), teams, pot=1, closed=True))
+
+    assert "How to join" not in text
+
+
 def test_large_roster_splits_across_fields_under_the_discord_cap():
     """Discord caps a single embed field's value at 1024 characters. Roster lines
     are ~52 chars and deficit lines ~43, so a paid tournament breaks at roughly 10

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -125,8 +125,10 @@ async def test_refresh_board_swallows_a_discord_failure():
     from cogs.tournament_commands import TournamentCog
 
     cog = TournamentCog(MagicMock())
+    # patched where the failure originates: the cog delegates to refresh_boards, which
+    # owns the guard for every caller (cog, wallet deposit, watchdog)
     with patch(
-        "cogs.tournament_commands.update_registration_board",
+        "services.tournament_formatter.update_registration_board",
         AsyncMock(side_effect=RuntimeError("discord boom")),
     ):
         await cog._refresh_board(1)  # must not raise


### PR DESCRIPTION
This is the commit that missed the #403 merge — #403 landed at `b0a8b23` (the deficit-freshness fix), and this follow-up commit was pushed a minute later. Same content, re-applied on current `main`.

## Always show how to join

The join instructions only rendered on an **empty** board, so they vanished the moment the first team registered — exactly when newcomers start reading it. They're now their own field for as long as sign-ups are open, and a paid entry names all three steps, since paying isn't one command:

```
How to join
1. /link_mtgo <your MTGO username> — once, so the bot can trade with you
2. /tournament register <team name> — holds your spot
3. /wallet deposit 2 — your spot completes when the tix land
```

Free tournaments collapse to just `/tournament register <team name>`; the field is dropped once registration closes.

## Simplify pass (4-angle review of the deficit fix)

- **The deficit fix was a bandaid.** `/wallet pay`, a withdraw settling, and a debt settlement all move a captain's balance and refreshed nothing, so the same staleness was already latent in three more paths. The 10-minute watchdog — which exists as the catch-all for funds arriving by untracked routes — was itself only refreshing boards whose entries *completed*, the criterion that bug proved insufficient. It now re-renders every open registration board each tick, closing all of them without chasing each money path.
- One `_unpaid_entry_conditions()` predicate shared by the sweep and the open-boards lookup, instead of the same rule written out twice.
- One `refresh_boards(bot, ids, closed=False)` owns the guard-and-log; the cog helper, the deposit follow-up and the watchdog all delegate to it. There were three hand-rolled copies and the log wording had already drifted.
- `.distinct()` in SQL instead of `dict.fromkeys` (the caller unions into a set, so the preserved order was never used), one canonical explanation instead of three copies, and a redundant test folded into the one covering its case.

## Backfill

Existing boards pick this up automatically: the embed is rebuilt wholesale on every refresh, and the watchdog now re-renders every open board each tick — so live boards gain the instructions within ten minutes of the restart, with no manual re-post. Closed boards are deliberately left alone.

Suite: 1068 passed, 9 skipped (verified on the pre-cherry-pick branch; the commit is byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTWPB33ixEx53ZG9q7SDLG