### PR TITLE
DraftBot: drop match_results.guild_id — the draft session is the source of truth

### DIFF
--- a/alembic/versions/dropguild01_drop_match_results_guild_id.py
+++ b/alembic/versions/dropguild01_drop_match_results_guild_id.py
@@ -1,0 +1,55 @@
+"""drop match_results.guild_id -- the draft session is the source of truth
+
+The column was a denormalized copy with no writer: none of the three
+MatchResult creation sites in utils.py ever set it, so it read NULL on 31,403
+of 41,920 prod rows (every match created since mid-2025). The populated rows
+predate the model even knowing the column existed -- it was added to the live
+DB out of band and backfilled once, then models/match.py was retrofitted in
+"update model to reflect db" (0a4b5b6, July 2025).
+
+Nothing read it: every guild-scoped query already joins DraftSession
+(services/ledger_stats.py, scripts/backfill_streak_enders.py), which is why a
+75%-empty column went unnoticed for a year. Verified on a prod copy before
+dropping -- the column carries no information the join can't produce:
+
+  * 10,517 non-null rows: all resolve to a session, all agree with it, 0 disagree
+  * 31,391 null rows: all resolve to a session (derivable)
+  * 12 null rows: no session_id at all, so no guild was ever recorded on
+    either side; they are one unplayed draft's pairings (0-0, no winner, never
+    submitted) and are invisible to every stats path regardless
+
+Backfilling instead would have copied 31,391 values a join already yields and
+started drifting again from the next draft on, since the writers stayed
+unfixed. Deriving leaves one source of truth and turns a future
+MatchResult.guild_id into an AttributeError rather than a silently short
+result.
+
+Revision ID: dropguild01
+Revises: tourneyboard01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "dropguild01"
+down_revision = "tourneyboard01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # batch mode for SQLite portability: native DROP COLUMN needs 3.35+, and
+    # the deployment's sqlite version isn't ours to assume.
+    with op.batch_alter_table("match_results") as batch:
+        batch.drop_column("guild_id")
+
+
+def downgrade():
+    with op.batch_alter_table("match_results") as batch:
+        batch.add_column(sa.Column("guild_id", sa.String(64), nullable=True))
+    # Re-derive from the owning session rather than restoring the old mix of
+    # populated and NULL: the join is what the column always should have been.
+    op.execute(
+        "UPDATE match_results SET guild_id = ("
+        "  SELECT ds.guild_id FROM draft_sessions ds"
+        "  WHERE ds.session_id = match_results.session_id)"
+    )

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -784,7 +784,6 @@ class AdminCommands(commands.Cog):
                     player1_wins=0,
                     player2_wins=0,
                     winner_id=None,
-                    guild_id=draft_session.guild_id
                 )
                 db_session.add(match_result)
                 created_count += 1

--- a/models/match.py
+++ b/models/match.py
@@ -42,7 +42,9 @@ class MatchResult(Base):
     player2_wins = Column(Integer, default=0)
     winner_id = Column(String(64), nullable=True)
     pairing_message_id = Column(String(64))
-    guild_id = Column(String(64))
+    # No guild_id: a match belongs to whatever guild its draft_session does.
+    # The column that used to sit here was a copy nothing wrote (dropguild01),
+    # so it read NULL for 75% of rows; scope matches by joining DraftSession.
     result_submitted_at = Column(DateTime, nullable=True)
     
     # Relationship with DraftSession

--- a/tests/test_backfill_win_streaks.py
+++ b/tests/test_backfill_win_streaks.py
@@ -104,7 +104,6 @@ async def create_test_match_history(session, player_id, guild_id, match_pattern)
             player1_id=player_id,
             player2_id="999",
             winner_id=winner_id,
-            guild_id=guild_id
         )
         session.add(match)
 

--- a/tests/test_server_draft_stats.py
+++ b/tests/test_server_draft_stats.py
@@ -108,7 +108,7 @@ def eastern_host():
 _match_counter = 0
 
 
-async def _seed_match_result(session_id: str, result_submitted_at: datetime | None, guild_id: str = GUILD) -> None:
+async def _seed_match_result(session_id: str, result_submitted_at: datetime | None) -> None:
     """Insert a MatchResult row for a session. result_submitted_at=None models
     an unreported match still in progress."""
     global _match_counter
@@ -122,7 +122,6 @@ async def _seed_match_result(session_id: str, result_submitted_at: datetime | No
                 player2_id="p2",
                 winner_id="p1" if result_submitted_at else None,
                 result_submitted_at=result_submitted_at,
-                guild_id=guild_id,
             ))
 
 


### PR DESCRIPTION
Removes `match_results.guild_id`. A match belongs to whatever guild its draft session does — there's no reason for a second copy, and the copy we had was wrong for most rows.

## What was actually happening

None of the three `MatchResult(...)` creation sites in `utils.py` ever set `guild_id`, so it read **NULL on 31,403 of 41,920** production rows — every match created since mid-2025. The rows that *do* have a value predate the model knowing the column existed: it was added to the live database out of band and backfilled once, then `models/match.py` was retrofitted in a commit titled *"update model to reflect db"* (`0a4b5b6`, July 2025). Hence the inverted pattern where the **older** rows are the populated ones.

Nothing ever read it. Every guild-scoped query already joins `DraftSession` — `services/ledger_stats.py:168`, `scripts/backfill_streak_enders.py:197` — so no stat, leaderboard, or ledger number was ever affected. That's exactly why a 75%-empty column survived a year unnoticed.

## Why drop instead of backfill

A backfill would copy 31,391 values the join already produces, and — without also fixing the three writers — start drifting again from the next draft onward. A denormalized copy is only safe when something guarantees it stays in sync; nothing did here. Deriving leaves one source of truth, and turns a future `MatchResult.guild_id` into an immediate `AttributeError` instead of a silently short result.

The concrete cost of *not* fixing it: profiling a per-guild export, `WHERE guild_id = '<arena>'` returns **0 matches** for a guild with 298 drafts (the truth, via the session join, is 3,024). The dangerous inverse — a filter written as "not the other guilds" — would have shipped other servers' data with nothing looking wrong.

## Verified on a prod copy before dropping

The column carries no information the join can't produce:

| Rows | State | Unique information |
|---|---|---|
| 10,517 | populated, session agrees (**0** disagreements) | none — exact duplicate |
| 31,391 | NULL, resolves via `session_id` | none — derivable |
| 12 | NULL, **no `session_id` at all** | none — no guild recorded either side |

Those last 12 are one unplayed draft's pairings — 8 players, 3 rounds × 4 matches, all 0-0, no winner, never submitted, pairing messages timestamped 2026-04-28 15:43:49Z. They're invisible to every stats path regardless. **Left in place**: deleting rows is a separate decision, and they're inert.

The migration round-tripped on that copy. Upgrade preserves all rows and joins; **downgrade re-derives from the owning session** rather than restoring the old half-filled mix (41,977 populated, the 12 NULL, 0 disagreements) — i.e. reverting leaves the column more correct than it ever was. `batch_alter_table` so it doesn't depend on the deployment's SQLite version.

## Scope notes

- `helpers/legacy_import.py` is **deliberately untouched**. Its `UPDATE match_results SET guild_id` runs inside `legacyimport0`, which is ordered *before* this migration, and its tests build their own DDL rather than using the model — historically faithful for migration code.
- Three model-level uses cleaned up: the `admin_commands.py` repair path that fabricates placeholder draw rows, and two test seeders.

Full suite: **1079 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNQ9PeNfT5bzXR1E38Wp9C
