### PR TITLE
DraftBot: delete the 12 match rows that belong to no draft session

### DIFF
--- a/alembic/versions/orphanmatch01_delete_session_less_match_rows.py
+++ b/alembic/versions/orphanmatch01_delete_session_less_match_rows.py
@@ -1,0 +1,50 @@
+"""delete match rows that belong to no draft session
+
+Follow-up to dropguild01, which found them: 12 prod rows carry no session_id
+at all -- not a dangling reference, no link ever recorded. They are one team
+draft's complete scaffolding (8 players, 3 rounds x 4 matches, match_number
+1-12, contiguous ids, three pairing messages timestamped 2026-04-28
+15:43:49Z) that was paired and then never played: every row 0-0, no winner,
+result_submitted_at NULL.
+
+Nothing can attribute them. No draft_sessions row holds those players, so
+there is no session to point them at, and with dropguild01 there is no
+guild_id on the row either. They are invisible to every stats path (all of
+which join DraftSession), so this removes clutter rather than changing any
+number -- the value is that the next person profiling this table doesn't
+rediscover them the hard way.
+
+The predicate is guarded to result-free rows: a session-less row that somehow
+carries a result is left in place and stays visible, rather than being swept
+up by a broad "session_id IS NULL" delete. Verified on a prod copy that all
+12 qualify and that zero rows have a dangling (non-null, unresolvable)
+session_id.
+
+One-way: deleted rows cannot be restored, so downgrade is a no-op rather than
+a lie.
+
+Revision ID: orphanmatch01
+Revises: dropguild01
+"""
+from alembic import op
+
+revision = "orphanmatch01"
+down_revision = "dropguild01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "DELETE FROM match_results"
+        " WHERE session_id IS NULL"
+        "   AND winner_id IS NULL"
+        "   AND result_submitted_at IS NULL"
+        "   AND COALESCE(player1_wins, 0) = 0"
+        "   AND COALESCE(player2_wins, 0) = 0"
+    )
+
+
+def downgrade():
+    # Deleted scaffolding rows carried no information to restore.
+    pass


### PR DESCRIPTION
Follow-up to #407, which surfaced these while proving `match_results.guild_id` was redundant.

## What gets deleted

12 rows that carry **no `session_id` at all** — not a dangling reference, no link ever recorded. They are one team draft's complete scaffolding:

- 8 players, 3 rounds × 4 matches, `match_number` 1–12, contiguous ids
- three pairing messages, snowflakes timestamped **2026-04-28 15:43:49Z**, within half a second of each other
- every row **0-0, no winner, `result_submitted_at` NULL** — paired, then never played

No `draft_sessions` row holds those players, so the parent session is *gone*, not merely unlinked. With `guild_id` dropped in #407 there is no other attribution clue on the row either.

## Why it's safe

Deleting changes **no number anywhere**. Every guild- and player-scoped query joins `DraftSession`, so rows with a NULL `session_id` have always been invisible to stats, leaderboards, and the ledger. This removes clutter, not data — the value is that the next person profiling this table doesn't rediscover them the hard way, which is exactly how they came to light.

The predicate is deliberately narrower than the obvious `WHERE session_id IS NULL`:

```sql
DELETE FROM match_results
 WHERE session_id IS NULL
   AND winner_id IS NULL
   AND result_submitted_at IS NULL
   AND COALESCE(player1_wins, 0) = 0
   AND COALESCE(player2_wins, 0) = 0
```

A session-less row that somehow carried a result stays put and stays visible, rather than being swept up silently.

Verified on a prod copy: all 12 qualify, **zero** rows have a dangling (non-null, unresolvable) `session_id`, and after both migrations run the remaining **41,977** rows all still join their session.

One-way — deleted scaffolding carries nothing to restore, so `downgrade` is an explicit no-op rather than a lie.

Full suite: **1079 passed**, 9 skipped.

## Not included

"Dead sessions" could also mean abandoned `draft_sessions` rows, which is a much larger and more debatable population — **154** have no match rows at all (94 of those never reached the teams stage), and **1,515** never recorded a victory message. Those are real history rather than scaffolding, so I've left them alone; happy to scope that separately if it's what you had in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNQ9PeNfT5bzXR1E38Wp9C
