### PR TITLE
DraftBot: group the leaderboards into clusters

### DIFF
--- a/alembic/versions/lbgroups01_add_group_header_message_ids.py
+++ b/alembic/versions/lbgroups01_add_group_header_message_ids.py
@@ -1,0 +1,33 @@
+"""track the leaderboard group header messages
+
+Leaderboards now post in clusters (performance / streaks / quizzes) with a
+header message opening each one. This column remembers those header messages so
+they are edited in place like the boards, rather than duplicated on every run.
+
+A JSON map keyed by group rather than a column per group: this table already
+carries two columns per category, and adding a fourth cluster shouldn't need a
+migration.
+
+Revision ID: lbgroups01
+Revises: orphanmatch01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "lbgroups01"
+down_revision = "orphanmatch01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("leaderboard_messages") as batch:
+        batch.add_column(sa.Column("group_header_message_ids", sa.JSON(), nullable=True))
+    # Existing rows: no headers posted yet, so an empty map (not NULL) means
+    # "nothing tracked" without every read needing a None guard.
+    op.execute("UPDATE leaderboard_messages SET group_header_message_ids = '{}'")
+
+
+def downgrade():
+    with op.batch_alter_table("leaderboard_messages") as batch:
+        batch.drop_column("group_header_message_ids")

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -8,8 +8,10 @@ from models.leaderboard_message import LeaderboardMessage
 from services.leaderboard_service import get_timeframe_date
 from services.leaderboard_formatter import create_leaderboard_embed
 from loguru import logger
+from helpers.permissions import has_bot_manager_role
 from leaderboard_config import (
     ALL_CATEGORIES as LEADERBOARD_CATEGORIES,
+    LEADERBOARD_GROUPS,
     STANDARD_TIMEFRAMES,
     STREAK_TIMEFRAMES,
     STREAK_CATEGORIES
@@ -83,8 +85,41 @@ class LeaderboardCog(commands.Cog):
     
     @discord.slash_command(name="leaderboard", description="Show all player leaderboards for drafts")
     async def leaderboard(self, ctx):
-        """Display all leaderboards of player statistics"""
+        """Display all leaderboards of player statistics.
+
+        Boards post in clusters (see LEADERBOARD_GROUPS) under a header per
+        group. This path only ever edits existing messages in place, so it
+        never disturbs a channel; /rebuild_leaderboards is what reposts them
+        in group order.
+        """
         await ctx.defer()
+        await self._post_all(ctx, rebuild=False)
+
+    @discord.slash_command(
+        name="rebuild_leaderboards",
+        description="Admin: delete and repost every leaderboard so the grouping order applies",
+    )
+    @has_bot_manager_role()
+    async def rebuild_leaderboards(self, ctx):
+        """Repost the boards grouped.
+
+        Discord orders a channel by post time and the normal update path edits
+        in place, so boards posted before the grouping keep their old order.
+        This deletes the tracked messages and posts them back grouped — the
+        only path that destroys messages, hence admin-gated and separate from
+        /leaderboard rather than a flag on it.
+
+        Deliberately no confirmation step, unlike /tournament payout's
+        PayoutConfirmView: what's destroyed is regenerated from the database in
+        the same call, so the worst case is a channel that looks briefly empty,
+        not a loss. Add one if boards ever carry state that isn't rederivable.
+        """
+        await ctx.defer(ephemeral=True)
+        logger.info(f"Leaderboard rebuild requested in guild {ctx.guild.id} by {ctx.author.id}")
+        await self._post_all(ctx, rebuild=True)
+
+    async def _post_all(self, ctx, rebuild):
+        """Shared body of /leaderboard and /rebuild_leaderboards."""
         
         # Get the guild ID
         guild_id = str(ctx.guild.id)
@@ -96,18 +131,23 @@ class LeaderboardCog(commands.Cog):
             leaderboard_record, timeframes, channel = await self._get_leaderboard_setup(ctx, guild_id)
             if not channel:
                 # If we couldn't get the channel, there's a deeper issue
-                await ctx.respond("Error: Couldn't access any channels to post leaderboards.")
+                await ctx.followup.send("Error: Couldn't access any channels to post leaderboards.")
                 return
             
-            # Process each category
-            for category in LEADERBOARD_CATEGORIES:
-                await self._update_category_leaderboard(
-                    category=category,
-                    guild_id=guild_id,
-                    channel=channel,
-                    leaderboard_record=leaderboard_record,
-                    timeframe=timeframes.get(category, 'lifetime')
-                )
+            if rebuild:
+                leaderboard_record = await self._clear_posted_messages(channel, leaderboard_record)
+
+            # Post group by group: a header, then that group's boards beneath it
+            for group in LEADERBOARD_GROUPS:
+                await self._update_group_header(channel, leaderboard_record, group)
+                for category in group["categories"]:
+                    await self._update_category_leaderboard(
+                        category=category,
+                        guild_id=guild_id,
+                        channel=channel,
+                        leaderboard_record=leaderboard_record,
+                        timeframe=timeframes.get(category, 'lifetime')
+                    )
             
             # Update last_updated timestamp
             async with db_session() as session:
@@ -115,12 +155,14 @@ class LeaderboardCog(commands.Cog):
                 leaderboard_record.last_updated = datetime.now()
                 await session.commit()
             
-            # Complete the interaction
-            await ctx.respond("✅")
+            where = f" in {channel.mention}"
+            await ctx.followup.send(
+                f"{'♻️ Rebuilt' if rebuild else '✅ Updated'} all leaderboards{where}.",
+                ephemeral=rebuild)
             
         except Exception as e:
             logger.error(f"Error processing leaderboards: {e}", exc_info=True)
-            await ctx.respond(f"Error creating leaderboards: {str(e)}")
+            await ctx.followup.send(f"Error creating leaderboards: {str(e)}")
 
     async def _get_leaderboard_setup(self, ctx, guild_id):
         """Get or create leaderboard record, timeframes, and channel for posting"""
@@ -220,6 +262,70 @@ class LeaderboardCog(commands.Cog):
             leaderboard_record.time_vault_and_key_view_message_id = None
             await session.commit()
     
+    def _tracked_message_ids(self, leaderboard_record):
+        """Every message id this record owns: group headers, then boards."""
+        headers = (leaderboard_record.group_header_message_ids or {}).values()
+        boards = [getattr(leaderboard_record, f"{c}_view_message_id", None)
+                  for c in LEADERBOARD_CATEGORIES]
+        return [mid for mid in [*headers, *boards, leaderboard_record.message_id] if mid]
+
+    async def _clear_posted_messages(self, channel, leaderboard_record):
+        """Delete the tracked messages and forget their ids, so the next pass
+        reposts everything in group order.
+
+        Ordering in a channel is post order, and the normal path edits messages
+        in place — so a board that predates the grouping stays where it was
+        posted. This is the escape hatch, and it is opt-in (rebuild:true)
+        precisely because it destroys the existing messages.
+        """
+        for message_id in self._tracked_message_ids(leaderboard_record):
+            try:
+                message = await channel.fetch_message(int(message_id))
+                await message.delete()
+            except discord.NotFound:
+                pass          # already gone; nothing to clean up
+            except discord.HTTPException as e:
+                logger.warning(f"Could not delete leaderboard message {message_id}: {e}")
+
+        async with db_session() as session:
+            leaderboard_record = await session.merge(leaderboard_record)
+            leaderboard_record.group_header_message_ids = {}
+            for category in LEADERBOARD_CATEGORIES:
+                if hasattr(leaderboard_record, f"{category}_view_message_id"):
+                    setattr(leaderboard_record, f"{category}_view_message_id", None)
+            leaderboard_record.message_id = ""
+            await session.commit()
+        logger.info("Cleared posted leaderboard messages for rebuild")
+        return leaderboard_record
+
+    async def _update_group_header(self, channel, leaderboard_record, group):
+        """Post (or edit) the header message that opens one group's boards."""
+        content = f"# {group['title']}\n{group['blurb']}"
+        headers = dict(leaderboard_record.group_header_message_ids or {})
+        message_id = headers.get(group["key"])
+
+        if message_id:
+            try:
+                existing = await channel.fetch_message(int(message_id))
+                await existing.edit(content=content)
+                return
+            except discord.NotFound:
+                logger.warning(f"Header message for {group['key']} missing, reposting")
+            except discord.HTTPException as e:
+                logger.error(f"Error updating {group['key']} header: {e}")
+                return
+
+        new_message = await channel.send(content)
+        headers[group["key"]] = str(new_message.id)
+        # Reassign rather than mutate: SQLAlchemy doesn't track in-place edits
+        # to a plain JSON dict, so a mutation would never persist. Set it before
+        # the merge so the merged copy carries it (as _update_category_leaderboard
+        # does), rather than writing the same dict onto two handles.
+        leaderboard_record.group_header_message_ids = headers
+        async with db_session() as session:
+            await session.merge(leaderboard_record)
+            await session.commit()
+
     async def _update_category_leaderboard(self, category, guild_id, channel, leaderboard_record, timeframe):
         """Update or create a leaderboard for a specific category"""
         logger.info(f"Processing {category} leaderboard")

--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -263,11 +263,19 @@ class LeaderboardCog(commands.Cog):
             await session.commit()
     
     def _tracked_message_ids(self, leaderboard_record):
-        """Every message id this record owns: group headers, then boards."""
+        """Every real message id this record owns: group headers, then boards.
+
+        Only digit strings survive: message_id carries the literal
+        "placeholder" on a record that has never posted (see
+        _create_leaderboard_record) or has just been repointed at a new channel
+        (_update_leaderboard_channel), and int("placeholder") would raise
+        ValueError past the Discord-error handling in _clear_posted_messages.
+        """
         headers = (leaderboard_record.group_header_message_ids or {}).values()
         boards = [getattr(leaderboard_record, f"{c}_view_message_id", None)
                   for c in LEADERBOARD_CATEGORIES]
-        return [mid for mid in [*headers, *boards, leaderboard_record.message_id] if mid]
+        candidates = [*headers, *boards, leaderboard_record.message_id]
+        return [mid for mid in candidates if mid and str(mid).isdigit()]
 
     async def _clear_posted_messages(self, channel, leaderboard_record):
         """Delete the tracked messages and forget their ids, so the next pass

--- a/leaderboard_config.py
+++ b/leaderboard_config.py
@@ -4,9 +4,10 @@ This is the SINGLE SOURCE OF TRUTH for category definitions.
 
 When adding a new leaderboard category:
 1. Add to CATEGORY_CONFIGS dict below
-2. Add query logic to services/leaderboard_service.py
-3. Add database columns to models/leaderboard_message.py (2 per category)
-4. Run migration
+2. Add it to a group in LEADERBOARD_GROUPS (this sets where it appears)
+3. Add query logic to services/leaderboard_service.py
+4. Add database columns to models/leaderboard_message.py (2 per category)
+5. Run migration
 
 The category will automatically propagate to:
 - /leaderboard command (cogs/leaderboard.py)
@@ -116,8 +117,37 @@ CATEGORY_CONFIGS = {
     }
 }
 
-# Derived list for iteration (guaranteed to match dict keys)
-ALL_CATEGORIES = list(CATEGORY_CONFIGS.keys())
+# How the boards cluster in the channel. Each group gets a header message and
+# its boards are posted beneath it, in this order — so this list, not the
+# CATEGORY_CONFIGS dict, decides what the channel looks like.
+#
+# A new category must be added to a group: ALL_CATEGORIES is derived from here,
+# and test_leaderboard_groups asserts the two stay in sync, so an ungrouped
+# category fails the suite rather than silently vanishing from the channel.
+LEADERBOARD_GROUPS = [
+    {
+        "key": "performance",
+        "title": "🏆 Performance",
+        "blurb": "Who's winning — win rates, partnerships, and volume.",
+        "categories": ["draft_record", "match_win", "time_vault_and_key", "drafts_played"],
+    },
+    {
+        "key": "streaks",
+        "title": "🔥 Streaks",
+        "blurb": "Runs in progress and the best ever set.",
+        "categories": ["hot_streak", "draft_win_streak", "longest_win_streak", "perfect_streak"],
+    },
+    {
+        "key": "quizzes",
+        "title": "🧠 Quizzes",
+        "blurb": "Reading the table without playing it.",
+        "categories": ["quiz_points", "trophy_quiz_points"],
+    },
+]
+
+# Derived list for iteration, in the order the groups declare (guaranteed by
+# test to cover exactly the CATEGORY_CONFIGS keys).
+ALL_CATEGORIES = [c for group in LEADERBOARD_GROUPS for c in group["categories"]]
 
 # Categories that should auto-update after draft completion
 AUTO_UPDATE_CATEGORIES = ALL_CATEGORIES  # All categories by default

--- a/models/leaderboard_message.py
+++ b/models/leaderboard_message.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import JSON, Column, DateTime, Integer, String
 from database.models_base import Base
 from datetime import datetime
 
@@ -10,6 +10,10 @@ class LeaderboardMessage(Base):
     channel_id = Column(String(64), nullable=False)
     message_id = Column(String(64), nullable=False)
     last_updated = Column(DateTime, default=datetime.now, onupdate=datetime.now)
+    # {group key: message id} for the section headers above each cluster.
+    # A JSON map rather than a column per group: this table already pays
+    # two columns per category, and a fourth group shouldn't need a migration.
+    group_header_message_ids = Column(JSON, default=dict)
     draft_record_view_message_id = Column(String(64))
     match_win_view_message_id = Column(String(64))
     drafts_played_view_message_id = Column(String(64))

--- a/tests/test_leaderboard_groups.py
+++ b/tests/test_leaderboard_groups.py
@@ -1,0 +1,158 @@
+"""Leaderboards post in clusters: every category belongs to exactly one group,
+and the group order is what decides the channel layout."""
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from leaderboard_config import (
+    ALL_CATEGORIES,
+    CATEGORY_CONFIGS,
+    LEADERBOARD_GROUPS,
+    STREAK_CATEGORIES,
+)
+
+
+def _grouped_categories():
+    return [c for group in LEADERBOARD_GROUPS for c in group["categories"]]
+
+
+class TestGroupsCoverEveryCategory:
+    def test_every_category_is_in_exactly_one_group(self):
+        """An ungrouped category would silently vanish from the channel, since
+        the cog iterates groups rather than CATEGORY_CONFIGS."""
+        grouped = _grouped_categories()
+        assert sorted(grouped) == sorted(CATEGORY_CONFIGS)
+        assert len(grouped) == len(set(grouped)), "a category appears in two groups"
+
+    def test_all_categories_follows_group_order(self):
+        assert ALL_CATEGORIES == _grouped_categories()
+
+    def test_groups_have_the_fields_the_header_renders(self):
+        for group in LEADERBOARD_GROUPS:
+            assert group["key"] and group["title"] and group["blurb"]
+        keys = [g["key"] for g in LEADERBOARD_GROUPS]
+        assert len(keys) == len(set(keys)), "duplicate group key"
+
+    def test_streaks_are_grouped_together(self):
+        """The streak boards share a timeframe vocabulary (active/30d/90d/
+        lifetime), so they should read as one cluster."""
+        streaks = next(g for g in LEADERBOARD_GROUPS if g["key"] == "streaks")
+        assert set(STREAK_CATEGORIES) <= set(streaks["categories"])
+
+
+def _record(**overrides):
+    record = MagicMock()
+    record.group_header_message_ids = {}
+    record.message_id = "1"
+    for category in ALL_CATEGORIES:
+        setattr(record, f"{category}_view_message_id", None)
+    for key, value in overrides.items():
+        setattr(record, key, value)
+    return record
+
+
+def _channel(sent_id=999):
+    channel = MagicMock()
+    message = MagicMock()
+    message.id = sent_id
+    message.edit = AsyncMock()
+    message.delete = AsyncMock()
+    channel.send = AsyncMock(return_value=message)
+    channel.fetch_message = AsyncMock(return_value=message)
+    return channel, message
+
+
+def _cog():
+    from cogs.leaderboard import LeaderboardCog
+    return LeaderboardCog(MagicMock())
+
+
+class TestGroupHeaders:
+    @pytest.mark.asyncio
+    async def test_posts_a_header_and_remembers_it(self, monkeypatch):
+        import cogs.leaderboard as mod
+        monkeypatch.setattr(mod, "db_session", _fake_session)
+        channel, message = _channel(sent_id=555)
+        record = _record()
+        group = LEADERBOARD_GROUPS[0]
+
+        await _cog()._update_group_header(channel, record, group)
+
+        content = channel.send.await_args.args[0]
+        assert group["title"] in content and group["blurb"] in content
+        assert record.group_header_message_ids[group["key"]] == "555"
+
+    @pytest.mark.asyncio
+    async def test_edits_the_existing_header_instead_of_reposting(self, monkeypatch):
+        import cogs.leaderboard as mod
+        monkeypatch.setattr(mod, "db_session", _fake_session)
+        channel, message = _channel()
+        group = LEADERBOARD_GROUPS[0]
+        record = _record(group_header_message_ids={group["key"]: "42"})
+
+        await _cog()._update_group_header(channel, record, group)
+
+        message.edit.assert_awaited_once()
+        channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reposts_when_the_header_was_deleted(self, monkeypatch):
+        import cogs.leaderboard as mod
+        monkeypatch.setattr(mod, "db_session", _fake_session)
+        channel, message = _channel(sent_id=777)
+        channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "gone"))
+        group = LEADERBOARD_GROUPS[0]
+        record = _record(group_header_message_ids={group["key"]: "42"})
+
+        await _cog()._update_group_header(channel, record, group)
+
+        channel.send.assert_awaited_once()
+        assert record.group_header_message_ids[group["key"]] == "777"
+
+
+class TestRebuild:
+    @pytest.mark.asyncio
+    async def test_rebuild_deletes_headers_and_boards(self, monkeypatch):
+        """Ordering in Discord is post order, so a rebuild has to remove the
+        old messages before the grouped order can take effect."""
+        import cogs.leaderboard as mod
+        monkeypatch.setattr(mod, "db_session", _fake_session)
+        channel, message = _channel()
+        record = _record(group_header_message_ids={"performance": "10"})
+        record.draft_record_view_message_id = "11"
+
+        await _cog()._clear_posted_messages(channel, record)
+
+        assert message.delete.await_count >= 2   # header + board (+ hot_streak)
+
+    def test_tracked_ids_include_headers_boards_and_hot_streak(self):
+        record = _record(group_header_message_ids={"performance": "10"}, message_id="99")
+        record.match_win_view_message_id = "11"
+        ids = _cog()._tracked_message_ids(record)
+        assert set(ids) == {"10", "11", "99"}
+
+    def test_tracked_ids_skip_unposted_boards(self):
+        """None entries would become fetch_message(None) crashes."""
+        record = _record(message_id="")
+        assert _cog()._tracked_message_ids(record) == []
+
+
+class _FakeSession:
+    """Stands in for db_session(): merge returns the record unchanged."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def merge(self, record):
+        return record
+
+    async def commit(self):
+        return None
+
+
+def _fake_session():
+    return _FakeSession()

--- a/tests/test_leaderboard_groups.py
+++ b/tests/test_leaderboard_groups.py
@@ -137,6 +137,14 @@ class TestRebuild:
         record = _record(message_id="")
         assert _cog()._tracked_message_ids(record) == []
 
+    def test_tracked_ids_skip_the_placeholder_sentinel(self):
+        """message_id is the literal "placeholder" on a record that has never
+        posted, or one just repointed at a new channel. int() would raise
+        ValueError right past _clear_posted_messages' Discord-error handling
+        and take the whole rebuild down with it."""
+        record = _record(message_id="placeholder")
+        assert _cog()._tracked_message_ids(record) == []
+
 
 class _FakeSession:
     """Stands in for db_session(): merge returns the record unchanged."""

--- a/utils.py
+++ b/utils.py
@@ -1139,7 +1139,13 @@ async def update_leaderboards_for_guild(bot, guild_id: str, session_id=None, str
                 logger.warning(f"Missing permissions in leaderboard channel {channel.name}")
                 return
 
-            # All categories to display (imported from central config)
+            # All categories to display (imported from central config).
+            # Flat, not grouped: this path only ever EDITS boards that already
+            # exist, so it can't leave one stranded without its group header.
+            # Headers are posted by /leaderboard and /rebuild_leaderboards and
+            # carry static text, so there's nothing here for them to refresh --
+            # editing a group's title/blurb in leaderboard_config needs one of
+            # those commands to show up.
             categories = AUTO_UPDATE_CATEGORIES
 
             # Get timeframes for each category from database or defaults


### PR DESCRIPTION
Ten leaderboards were listed in the order categories happened to be added — quizzes sat between two streak boards, partnership win-rate between participation and a streak. They now post in three clusters, each opened by a header message.

```
🏆 Performance   draft record · match win · vault/key · drafts played
🔥 Streaks       hot · draft-win · longest-win · perfect
🧠 Quizzes       pick quiz · trophy quiz
```

## How the grouping holds

`LEADERBOARD_GROUPS` is the ordered registry, and **`ALL_CATEGORIES` derives from it** — so group membership, not dict insertion order, decides the channel layout. A test asserts the two stay in sync, meaning a category added without a group fails the suite rather than quietly vanishing from the channel (the cog iterates groups now, so an ungrouped board would simply never post). The config docstring's "adding a category" checklist gains that step.

Header message ids live in a new **JSON column keyed by group** rather than a column per group: this table already carries two columns per category and says so in its own docstring, and a fourth cluster shouldn't need a migration. The map is reassigned rather than mutated, since SQLAlchemy doesn't track in-place edits to a plain JSON dict.

## Why there's a separate rebuild command

Discord orders a channel by post time, and the update path edits messages in place — so boards posted before this change keep their old order no matter how the config reads. `/rebuild_leaderboards` deletes the tracked messages so they come back grouped.

It's **admin-gated and a separate command rather than a flag on `/leaderboard`**, because it's the only path that destroys messages, and `/leaderboard` is public. That matches this repo's convention: existing bool flags (`dry_run`) are toggles on already-gated admin commands, not privilege-escalating flags on public ones.

It deliberately has **no confirmation step**, unlike `/tournament payout`'s `PayoutConfirmView`: everything it destroys is regenerated from the database in the same call, so the worst case is a channel that looks briefly empty. That divergence is now stated in the docstring rather than left implicit — say the word if you'd rather have a confirm.

The two flat category loops (post-draft auto-update in `utils.py`, restart refresh in the cog) stay flat and are commented as such: they only ever *edit* existing boards, so they can't strand one without its header. The tradeoff, also noted in the comment: editing a group's title or blurb only shows up via the two slash commands.

## A bug the live test caught

`message_id` carries the literal string `"placeholder"` on a record that has never posted, or one just repointed at a new channel — the column is NOT NULL, so both pre-existing paths park that sentinel there. `_clear_posted_messages` calls `int()` on every tracked id inside a `try` that catches `discord.NotFound` and `discord.HTTPException`; `ValueError` is neither, so on such a record `/rebuild_leaderboards` would have **died before deleting anything** — hitting exactly the guilds most likely to run it. `_tracked_message_ids` now keeps only digit strings, with a regression test.

## Verification

Migration round-tripped on a prod copy (all five guild rows get `{}`, not NULL). Live in the test guild: `/leaderboard` posted all three headers and ten boards in group order and recorded the header ids; `/rebuild_leaderboards` then cleared and reposted them with fresh ids and no errors in the log. Screenshot shows the clusters with their timeframe buttons intact.

Full suite: **1110 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNQ9PeNfT5bzXR1E38Wp9C
