### PR TITLE
Tournament team rosters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,10 @@ DraftBot is a sophisticated Discord bot designed to automate and enhance Magic: 
 2. **Import Models**: Ensure new models are imported in `models/__init__.py`
 3. **Generate Migration**: `pipenv run alembic revision --autogenerate -m "description"`
 4. **Test Migration**: `pipenv run alembic upgrade head`
-5. **Deploy**: Migration runs automatically on production restart
+5. **Back up production first if the migration destroys data** — production runs
+   migrations unguarded, so a `DROP`/`DELETE` is irreversible there. See
+   "Migrations run unguarded" under Production Environment.
+6. **Deploy**: Migration runs automatically on production restart
 
 ### Common Commands
 **IMPORTANT: Always use `pipenv run` for all Python commands to ensure proper virtual environment.**
@@ -65,7 +68,7 @@ pipenv run python bot.py
 pipenv run pyrefly check
 
 # Service management (production)
-sudo systemctl restart draftbot.service      # Restart with auto-migration
+sudo systemctl restart draftbot.service      # Restart with auto-migration (UNGUARDED - back up first if it drops data)
 sudo journalctl -u draftbot.service -f       # View logs
 ```
 
@@ -250,7 +253,23 @@ never re-asserted per use site:
 ### Monitoring
 - Service status: `sudo systemctl status draftbot.service`
 - Real-time logs: `sudo journalctl -u draftbot.service -f`
-- Database backups: Automatic timestamped backups before migrations
+- Database backups: **none are automatic.** See "Migrations run unguarded" below.
+
+### Migrations run unguarded
+
+`draftbot.service` runs `ExecStartPre=... alembic upgrade head` with no backup
+step in front of it, and `alembic/env.py` has no hook of its own. Nothing copies
+the production database before a migration touches it.
+
+**Back up the production database yourself before deploying a migration that
+destroys data** — any `DROP TABLE`, `DROP COLUMN`, or bulk `DELETE`/`UPDATE`.
+Once the service restarts, the old rows are gone and there is nothing to roll
+back to; a migration's `downgrade()` restores the schema, never the data.
+
+Do not confuse this with `scripts/fetch_prod_db.sh`. Its timestamped
+`drafts.db.backup.<stamp>` copy protects your **local** database from being
+overwritten by the fetch. It runs on your machine, on demand, in the opposite
+direction, and never touches the server.
 
 ### Configuration Management
 - Environment variables in `.env` file

--- a/alembic/versions/dropteamreg01_drop_legacy_team_registration.py
+++ b/alembic/versions/dropteamreg01_drop_legacy_team_registration.py
@@ -1,0 +1,49 @@
+"""drop the legacy team_registration table
+
+team_registration was the old league's roster: a {user_id: display_name} JSON map
+keyed 1:1 to teams.TeamName, which is unique across the whole database with no
+guild column. Its last reader went away with league.py in 81318df ("league
+cleanup"); the model has since been imported and never called. Tournament rosters
+(tournament_team_members, added in rosters01) replace it with a per-tournament
+scope, so this is dead schema rather than something to migrate forward.
+
+DESTRUCTIVE, AND PRODUCTION RUNS MIGRATIONS UNGUARDED. draftbot.service runs
+`alembic upgrade head` from ExecStartPre with no backup step, so these rows are
+gone the moment the service restarts, and downgrade() below restores the schema
+only -- never the data. Its 14 rows (53 league players) were dumped to a file
+before this was written. They cover TeamID 1-14 while every tournament team is 15
+and up, so none of it could have been carried into the new table anyway.
+
+Kept separate from rosters01 on purpose: that migration is additive and cleanly
+reversible, this one is neither, and bundling them would force the drop to ship in
+lockstep with the roster feature and make reverting the feature resurrect an
+orphan table.
+
+Revision ID: dropteamreg01
+Revises: rosters01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "dropteamreg01"
+down_revision = "rosters01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("team_registration")
+
+
+def downgrade():
+    # Shape only. The rows are not restorable from here; see the dump referenced
+    # in this migration's docstring.
+    op.create_table(
+        "team_registration",
+        sa.Column("ID", sa.Integer(), nullable=False),
+        sa.Column("TeamID", sa.Integer(), nullable=True),
+        sa.Column("TeamName", sa.String(length=128), nullable=False),
+        sa.Column("TeamMembers", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("ID"),
+        sa.UniqueConstraint("TeamName"),
+    )

--- a/alembic/versions/rosters01_add_tournament_team_members.py
+++ b/alembic/versions/rosters01_add_tournament_team_members.py
@@ -1,0 +1,73 @@
+"""add tournament team rosters, drop the legacy team_registration table
+
+Tournaments recorded only a captain, so a team's other players were nowhere in
+the database. tournament_team_members records them, scoped to the participant
+rather than to the team identity: teams.TeamName is unique across the whole
+database with no guild column, so a roster hung off the team row would merge two
+guilds that pick the same team name (there are already teams called "Echo" and
+"Foxtrot") and would rewrite a finished tournament's roster when the team
+re-entered a later one.
+
+team_registration is the old league's version of the same idea, keyed 1:1 to that
+globally-unique team name. Its last reader went away with league.py in 81318df
+("league cleanup"); the model has since been imported but never used. It is
+dropped here rather than left as schema drift.
+
+NOTE: dropping it destroys its rows, and production runs `alembic upgrade head`
+from the systemd unit with no backup step in front of it. Its 14 rows (53 league
+players) were dumped before this migration was written. They are legacy
+special-guild league rosters and share no team with any tournament participant --
+team_registration covers TeamID 1-14, every tournament team is 15 and up -- so
+nothing here can be recovered into the new table anyway.
+
+Revision ID: rosters01
+Revises: lbgroups01
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "rosters01"
+down_revision = "lbgroups01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "tournament_team_members",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("participant_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=128), nullable=False),
+        sa.Column("added_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["participant_id"], ["tournament_participants.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("participant_id", "user_id", name="uq_participant_member"),
+    )
+    op.create_index("ix_tournament_team_members_participant_id",
+                    "tournament_team_members", ["participant_id"])
+    # Indexed because the "is this player already on another team?" check filters
+    # on user_id across the tournament on every add.
+    op.create_index("ix_tournament_team_members_user_id",
+                    "tournament_team_members", ["user_id"])
+
+    op.drop_table("team_registration")
+
+
+def downgrade():
+    # Recreates team_registration's shape only. Its rows are not restorable here;
+    # see the dump referenced in this migration's docstring.
+    op.create_table(
+        "team_registration",
+        sa.Column("ID", sa.Integer(), nullable=False),
+        sa.Column("TeamID", sa.Integer(), nullable=True),
+        sa.Column("TeamName", sa.String(length=128), nullable=False),
+        sa.Column("TeamMembers", sa.JSON(), nullable=True),
+        sa.PrimaryKeyConstraint("ID"),
+        sa.UniqueConstraint("TeamName"),
+    )
+    op.drop_index("ix_tournament_team_members_user_id",
+                  table_name="tournament_team_members")
+    op.drop_index("ix_tournament_team_members_participant_id",
+                  table_name="tournament_team_members")
+    op.drop_table("tournament_team_members")

--- a/alembic/versions/rosters01_add_tournament_team_members.py
+++ b/alembic/versions/rosters01_add_tournament_team_members.py
@@ -1,24 +1,16 @@
-"""add tournament team rosters, drop the legacy team_registration table
+"""add tournament team rosters
 
 Tournaments recorded only a captain, so a team's other players were nowhere in
 the database. tournament_team_members records them, scoped to the participant
-rather than to the team identity: teams.TeamName is unique across the whole
-database with no guild column, so a roster hung off the team row would merge two
-guilds that pick the same team name (there are already teams called "Echo" and
-"Foxtrot") and would rewrite a finished tournament's roster when the team
-re-entered a later one.
+rather than to the global Team identity: teams.TeamName is unique across the
+whole database with no guild column, so a roster hung off the team row would
+merge two guilds that pick the same team name (there are already teams called
+"Echo" and "Foxtrot") and would rewrite a finished tournament's roster when the
+team re-entered a later one.
 
-team_registration is the old league's version of the same idea, keyed 1:1 to that
-globally-unique team name. Its last reader went away with league.py in 81318df
-("league cleanup"); the model has since been imported but never used. It is
-dropped here rather than left as schema drift.
-
-NOTE: dropping it destroys its rows, and production runs `alembic upgrade head`
-from the systemd unit with no backup step in front of it. Its 14 rows (53 league
-players) were dumped before this migration was written. They are legacy
-special-guild league rosters and share no team with any tournament participant --
-team_registration covers TeamID 1-14, every tournament team is 15 and up -- so
-nothing here can be recovered into the new table anyway.
+Additive and fully reversible. Dropping the legacy team_registration table is a
+separate, destructive migration (dropteamreg01) so it can be reviewed and backed
+up on its own -- see that file.
 
 Revision ID: rosters01
 Revises: lbgroups01
@@ -46,26 +38,13 @@ def upgrade():
     )
     op.create_index("ix_tournament_team_members_participant_id",
                     "tournament_team_members", ["participant_id"])
-    # Indexed because the "is this player already on another team?" check filters
-    # on user_id across the tournament on every add.
+    # Indexed because the "which other teams is this player on?" lookup filters on
+    # user_id across the tournament on every add.
     op.create_index("ix_tournament_team_members_user_id",
                     "tournament_team_members", ["user_id"])
 
-    op.drop_table("team_registration")
-
 
 def downgrade():
-    # Recreates team_registration's shape only. Its rows are not restorable here;
-    # see the dump referenced in this migration's docstring.
-    op.create_table(
-        "team_registration",
-        sa.Column("ID", sa.Integer(), nullable=False),
-        sa.Column("TeamID", sa.Integer(), nullable=True),
-        sa.Column("TeamName", sa.String(length=128), nullable=False),
-        sa.Column("TeamMembers", sa.JSON(), nullable=True),
-        sa.PrimaryKeyConstraint("ID"),
-        sa.UniqueConstraint("TeamName"),
-    )
     op.drop_index("ix_tournament_team_members_user_id",
                   table_name="tournament_team_members")
     op.drop_index("ix_tournament_team_members_participant_id",

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -602,7 +602,7 @@ class TournamentCog(commands.Cog):
         self,
         ctx,
         player: discord.Option(discord.Member, "The teammate to add"),
-        team: discord.Option(str, "Bot managers only: which team's roster to edit",
+        team: discord.Option(str, "Which team (needed if you captain more than one)",
                              required=False, default=None),
     ):
         if not await self._check_enabled(ctx):
@@ -657,7 +657,7 @@ class TournamentCog(commands.Cog):
         self,
         ctx,
         player: discord.Option(discord.Member, "The teammate to remove"),
-        team: discord.Option(str, "Bot managers only: which team's roster to edit",
+        team: discord.Option(str, "Which team (needed if you captain more than one)",
                              required=False, default=None),
     ):
         if not await self._check_enabled(ctx):

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -34,12 +34,13 @@ from services.tournament_service import (
     finish_tournament,
     find_current_match,
     find_participant_by_name,
-    find_participant_for_captain,
+    find_participants_for_captain,
     get_active_tournament,
     get_latest_completed_tournament,
     get_rosters,
     get_standings_data,
     list_participants,
+    other_teams_for_user,
     register_team,
     remove_teammate,
     set_result,
@@ -556,31 +557,44 @@ class TournamentCog(commands.Cog):
     async def _roster_target(self, ctx, session, tournament, team):
         """The participant whose roster this command edits, or None if it can't.
 
-        With no ``team`` a captain edits their own roster, which is the ordinary
-        path. Naming a team is the bot-manager route: it is how a mis-added player
-        gets fixed, and the only way to give a roster to the imported teams that
-        carry no real captain (captain_user_id "0"). Returns None only after
-        replying, so callers just return.
+        Naming a ``team`` you captain is allowed and is how a captain of several
+        teams picks one; naming someone else's needs the bot-manager role, which is
+        also how a mis-added player gets fixed and how the imported teams with no
+        real captain (captain_user_id "0") get a roster at all.
+
+        Returns None only after replying, so callers just return.
         """
         if team:
-            if not await is_bot_manager(ctx):
-                await ctx.followup.send(
-                    "Only bot managers can edit another team's roster — leave `team` "
-                    "empty to edit your own.", ephemeral=True)
-                return None
             participant = await find_participant_by_name(session, tournament.id, team)
             if participant is None:
                 await ctx.followup.send(
                     f"❌ '{team}' is not registered for **{tournament.name}**.",
                     ephemeral=True)
+                return None
+            if (participant.captain_user_id != str(ctx.author.id)
+                    and not await is_bot_manager(ctx)):
+                await ctx.followup.send(
+                    f"**{participant.team_name}** isn't your team — only its captain "
+                    f"<@{participant.captain_user_id}> or a bot manager can edit its "
+                    f"roster.", ephemeral=True)
+                return None
             return participant
 
-        participant = await find_participant_for_captain(session, tournament.id, ctx.author.id)
-        if participant is None:
+        owned = await find_participants_for_captain(session, tournament.id, ctx.author.id)
+        if not owned:
             await ctx.followup.send(
                 f"You don't captain a team in **{tournament.name}**. Register one with "
                 f"`/tournament register <team name>` first.", ephemeral=True)
-        return participant
+            return None
+        if len(owned) > 1:
+            # Silently editing the first would be the worst outcome: nothing would
+            # tell them the change landed on the other team.
+            names = ", ".join(f"**{p.team_name}**" for p in owned)
+            await ctx.followup.send(
+                f"You captain {names} in **{tournament.name}** — say which one with "
+                f"the `team` option.", ephemeral=True)
+            return None
+        return owned[0]
 
     @tournament.command(name="add_teammate",
                         description="Add a player to your team's roster")
@@ -616,19 +630,26 @@ class TournamentCog(commands.Cog):
                 await ctx.followup.send(f"❌ {e}", ephemeral=True)
                 return
             p_name = participant.team_name
+            # Sharing a player between teams is allowed, but it should never happen
+            # unnoticed — say so on the reply instead of blocking the add.
+            others = await other_teams_for_user(
+                session, t_id, player.id, participant.id)
+            also_on = ", ".join(f"**{p.team_name}**" for p in others)
 
         # Outside the session: the board reads the roster back in its own session,
         # so refreshing before this one commits would render the pre-change state.
         await self._refresh_board(t_id)
+        shared = f"\nAlso on {also_on} in this tournament." if also_on else ""
         if created:
             logger.info(f"{player.id} added to team '{p_name}' in tournament {t_id} "
                         f"by {ctx.author.id}")
             await ctx.followup.send(
-                f"✅ {player.mention} is on **{p_name}**'s roster for **{t_name}**.",
+                f"✅ {player.mention} is on **{p_name}**'s roster for **{t_name}**.{shared}",
                 ephemeral=True)
         else:
             await ctx.followup.send(
-                f"{player.mention} is already on **{p_name}**'s roster.", ephemeral=True)
+                f"{player.mention} is already on **{p_name}**'s roster.{shared}",
+                ephemeral=True)
 
     @tournament.command(name="remove_teammate",
                         description="Take a player off your team's roster")

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -305,10 +305,11 @@ class TournamentCog(commands.Cog):
         await ctx.respond("Tournaments are not enabled on this server.", ephemeral=True)
         return False
 
-    async def _refresh_board(self, tournament_id, closed=False):
+    async def _refresh_board(self, tournament_id):
         """Refresh a tournament's registration board. The board is a view — never let a
-        Discord failure break the command that changed the roster."""
-        await refresh_boards(self.bot, [tournament_id], closed=closed)
+        Discord failure break the command that changed the roster. Open vs closed is
+        derived from the tournament's own status inside the refresh."""
+        await refresh_boards(self.bot, [tournament_id])
 
     @tournament.command(name="enable", description="Admin: enable tournament commands on this server")
     @has_bot_manager_role()
@@ -789,7 +790,7 @@ class TournamentCog(commands.Cog):
             res = await escrow.close_registration_and_seed(ctx.guild.id, random.Random())
             tournament_id = res["tournament_id"]
             logger.info(f"Tournament {tournament_id} started in guild {ctx.guild.id} by {ctx.author.id}")
-            await self._refresh_board(tournament_id, closed=True)
+            await self._refresh_board(tournament_id)
             pot_line = f" 🏦 Prize pool: **{res['pot']} tix**." if res["fee"] > 0 else ""
             play = self._destination(ctx, PAIRINGS.setting)
             standings = self._destination(ctx, STANDINGS.setting)

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -594,6 +594,9 @@ class TournamentCog(commands.Cog):
         if not await self._check_enabled(ctx):
             return
         await ctx.defer(ephemeral=True)
+        if player.bot:
+            await ctx.followup.send("Bots can't be on a team's roster.", ephemeral=True)
+            return
 
         async with db_session() as session:
             tournament = await get_active_tournament(session, ctx.guild.id)

--- a/cogs/tournament_commands.py
+++ b/cogs/tournament_commands.py
@@ -13,7 +13,8 @@ from helpers.tournament_channels import (
 )
 from database.db_session import db_session
 from helpers.money_gate import gate_serve, linked_username
-from helpers.permissions import has_bot_manager_role
+from helpers.display_names import get_display_name
+from helpers.permissions import has_bot_manager_role, is_bot_manager
 from helpers.pin_helpers import safe_pin
 from models.tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
 from sqlalchemy import or_, select
@@ -27,20 +28,32 @@ from services.tournament_formatter import (
 from services.tournament_service import (
     advance_round,
     add_match,
+    add_teammate,
     count_unreported_matches,
     create_tournament,
     finish_tournament,
     find_current_match,
+    find_participant_by_name,
+    find_participant_for_captain,
     get_active_tournament,
     get_latest_completed_tournament,
+    get_rosters,
     get_standings_data,
     list_participants,
     register_team,
+    remove_teammate,
     set_result,
 )
 from services.mtgo_tradebot_client import EVENT_TICKET
 from services import tournament_escrow_service as escrow
 from services import wallet_service
+
+
+# Registering records only the captain, so every successful registration has to say
+# how the rest of the team gets on the board -- otherwise the roster silently stays
+# a team of one.
+ROSTER_PROMPT = ("Now add your teammates with `/tournament add_teammate @player` "
+                 "— one command per player.")
 
 
 def tournament_enabled(guild_id):
@@ -487,7 +500,8 @@ class TournamentCog(commands.Cog):
                 await self._refresh_board(t_id)
                 await ctx.followup.send(
                     f"✅ **{p_name}** is registered for **{t_name}** with "
-                    f"{ctx.author.mention} as captain.", ephemeral=True)
+                    f"{ctx.author.mention} as captain.\n"
+                    f"{ROSTER_PROMPT}", ephemeral=True)
             else:
                 await ctx.followup.send(
                     f"**{p_name}** is already registered for **{t_name}** "
@@ -513,7 +527,8 @@ class TournamentCog(commands.Cog):
             await self._refresh_board(t_id)
             await ctx.followup.send(
                 f"✅ **{p_name}** is registered for **{t_name}** — **{fee} "
-                f"{EVENT_TICKET}(s)** paid into the prize pool. You're in.", ephemeral=True)
+                f"{EVENT_TICKET}(s)** paid into the prize pool. You're in.\n"
+                f"{ROSTER_PROMPT}", ephemeral=True)
             return
         if not res.get("ok"):
             # register_team already committed a pending participant above, so the board
@@ -537,6 +552,120 @@ class TournamentCog(commands.Cog):
             f"To finish, run `/wallet deposit {deficit}` whenever you're ready (you have "
             f"{have} tix; the fee is {fee}). Registration completes automatically once the "
             f"tix land — no need to re-register.", ephemeral=True)
+
+    async def _roster_target(self, ctx, session, tournament, team):
+        """The participant whose roster this command edits, or None if it can't.
+
+        With no ``team`` a captain edits their own roster, which is the ordinary
+        path. Naming a team is the bot-manager route: it is how a mis-added player
+        gets fixed, and the only way to give a roster to the imported teams that
+        carry no real captain (captain_user_id "0"). Returns None only after
+        replying, so callers just return.
+        """
+        if team:
+            if not await is_bot_manager(ctx):
+                await ctx.followup.send(
+                    "Only bot managers can edit another team's roster — leave `team` "
+                    "empty to edit your own.", ephemeral=True)
+                return None
+            participant = await find_participant_by_name(session, tournament.id, team)
+            if participant is None:
+                await ctx.followup.send(
+                    f"❌ '{team}' is not registered for **{tournament.name}**.",
+                    ephemeral=True)
+            return participant
+
+        participant = await find_participant_for_captain(session, tournament.id, ctx.author.id)
+        if participant is None:
+            await ctx.followup.send(
+                f"You don't captain a team in **{tournament.name}**. Register one with "
+                f"`/tournament register <team name>` first.", ephemeral=True)
+        return participant
+
+    @tournament.command(name="add_teammate",
+                        description="Add a player to your team's roster")
+    async def add_teammate_cmd(
+        self,
+        ctx,
+        player: discord.Option(discord.Member, "The teammate to add"),
+        team: discord.Option(str, "Bot managers only: which team's roster to edit",
+                             required=False, default=None),
+    ):
+        if not await self._check_enabled(ctx):
+            return
+        await ctx.defer(ephemeral=True)
+
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no tournament running right now.",
+                                        ephemeral=True)
+                return
+            t_id, t_name = tournament.id, tournament.name
+            participant = await self._roster_target(ctx, session, tournament, team)
+            if participant is None:
+                return
+            try:
+                _, created = await add_teammate(
+                    session, participant, player.id,
+                    get_display_name(player, ctx.guild))
+            except ValueError as e:
+                await ctx.followup.send(f"❌ {e}", ephemeral=True)
+                return
+            p_name = participant.team_name
+
+        # Outside the session: the board reads the roster back in its own session,
+        # so refreshing before this one commits would render the pre-change state.
+        await self._refresh_board(t_id)
+        if created:
+            logger.info(f"{player.id} added to team '{p_name}' in tournament {t_id} "
+                        f"by {ctx.author.id}")
+            await ctx.followup.send(
+                f"✅ {player.mention} is on **{p_name}**'s roster for **{t_name}**.",
+                ephemeral=True)
+        else:
+            await ctx.followup.send(
+                f"{player.mention} is already on **{p_name}**'s roster.", ephemeral=True)
+
+    @tournament.command(name="remove_teammate",
+                        description="Take a player off your team's roster")
+    async def remove_teammate_cmd(
+        self,
+        ctx,
+        player: discord.Option(discord.Member, "The teammate to remove"),
+        team: discord.Option(str, "Bot managers only: which team's roster to edit",
+                             required=False, default=None),
+    ):
+        if not await self._check_enabled(ctx):
+            return
+        await ctx.defer(ephemeral=True)
+
+        async with db_session() as session:
+            tournament = await get_active_tournament(session, ctx.guild.id)
+            if tournament is None:
+                await ctx.followup.send("There is no tournament running right now.",
+                                        ephemeral=True)
+                return
+            t_id = tournament.id
+            participant = await self._roster_target(ctx, session, tournament, team)
+            if participant is None:
+                return
+            try:
+                removed = await remove_teammate(session, participant, player.id)
+            except ValueError as e:
+                await ctx.followup.send(f"❌ {e}", ephemeral=True)
+                return
+            p_name = participant.team_name
+
+        if not removed:
+            await ctx.followup.send(
+                f"{player.mention} isn't on **{p_name}**'s roster.", ephemeral=True)
+            return
+        await self._refresh_board(t_id)
+        logger.info(f"{player.id} removed from team '{p_name}' in tournament {t_id} "
+                    f"by {ctx.author.id}")
+        await ctx.followup.send(
+            f"✅ {player.mention} is off **{p_name}**'s roster.", ephemeral=True)
 
     @tournament.command(name="add_team", description="Admin: register a team on a captain's behalf")
     @has_bot_manager_role()
@@ -998,8 +1127,10 @@ class TournamentCog(commands.Cog):
             if tournament is None:
                 await ctx.followup.send("There is no active tournament in this server.", ephemeral=True)
                 return
+            rosters = {}
             if tournament.status == "registration":
                 participants = await list_participants(session, tournament.id)
+                rosters = await get_rosters(session, tournament.id)
             else:
                 participants = await get_standings_data(session, tournament.id)
 
@@ -1013,7 +1144,8 @@ class TournamentCog(commands.Cog):
                     str(ctx.guild.id), [p.captain_user_id for p in pending])
                 deficits = {p.id: max(fee - balances.get(p.captain_user_id, 0), 0)
                             for p in pending}
-            embed = create_registration_embed(tournament, participants, held, deficits)
+            embed = create_registration_embed(tournament, participants, held, deficits,
+                                              rosters=rosters)
         else:
             embed = create_standings_embed(tournament, participants)
             if fee > 0:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,7 +1,7 @@
 from .draft_session import DraftSession
 from .match import MatchResult, Match
 from .player import PlayerStats, PlayerLimit
-from .team import Team, TeamRegistration, WeeklyLimit
+from .team import Team, WeeklyLimit
 from .challenge import Challenge, SwissChallenge
 from .utility import TeamFinder
 from .stake import StakeInfo
@@ -19,7 +19,13 @@ from .quiz_stats import QuizStats
 from .quiz_scheduling import QuizChannel, QuizSchedule
 from .debt_ledger import DebtLedger
 from .debt_summary_message import DebtSummaryMessage
-from .tournament import Tournament, TournamentMatch, TournamentParticipant, TournamentRound
+from .tournament import (
+    Tournament,
+    TournamentMatch,
+    TournamentParticipant,
+    TournamentRound,
+    TournamentTeamMember,
+)
 from .trophy_quiz_session import TrophyQuizSession
 from .trophy_quiz_submission import TrophyQuizSubmission
 from .mtgo_account import MtgoAccount
@@ -34,7 +40,6 @@ __all__ = [
     'PlayerStats',
     'PlayerLimit',
     'Team',
-    'TeamRegistration',
     'WeeklyLimit',
     'Challenge',
     'SwissChallenge',
@@ -61,6 +66,7 @@ __all__ = [
     'Tournament',
     'TournamentParticipant',
     'TournamentRound',
+    'TournamentTeamMember',
     'TournamentMatch',
     'TrophyQuizSession',
     'TrophyQuizSubmission',

--- a/models/team.py
+++ b/models/team.py
@@ -15,7 +15,7 @@ class Team(Base):
     # Add relationships
     weekly_limits = relationship("WeeklyLimit", back_populates="team")
 
-# TeamRegistration lived here until the `rosters01` migration. It was the old
+# TeamRegistration lived here until the `dropteamreg01` migration. It was the old
 # league's roster table (league.py, deleted in 81318df "league cleanup"), keyed
 # 1:1 to a globally-unique Team name. Tournament rosters replaced it — see
 # models/tournament.py TournamentTeamMember, which scopes a roster to one

--- a/models/team.py
+++ b/models/team.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, JSON, ForeignKey, text, Text
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, text, Text
 from sqlalchemy.orm import relationship
 from database.models_base import Base
 
@@ -15,16 +15,12 @@ class Team(Base):
     # Add relationships
     weekly_limits = relationship("WeeklyLimit", back_populates="team")
 
-class TeamRegistration(Base):
-    __tablename__ = 'team_registration'
+# TeamRegistration lived here until the `rosters01` migration. It was the old
+# league's roster table (league.py, deleted in 81318df "league cleanup"), keyed
+# 1:1 to a globally-unique Team name. Tournament rosters replaced it — see
+# models/tournament.py TournamentTeamMember, which scopes a roster to one
+# tournament instead of to a team name shared across every guild.
 
-    ID = Column(Integer, primary_key=True, nullable=False, autoincrement=True)
-    TeamID = Column(Integer)
-    TeamName = Column(String(128), unique=True, nullable=False)
-    TeamMembers = Column(JSON)
-
-    # Add relationship
-    # team = relationship("Team")  # Commented out - no FK in production
 
 class WeeklyLimit(Base):
     __tablename__ = 'weekly_limits'

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -84,6 +84,42 @@ class TournamentParticipant(Base):
         return f"<TournamentParticipant(tournament_id={self.tournament_id}, team={self.team_name!r})>"
 
 
+class TournamentTeamMember(Base):
+    """A player on a team's roster, for one tournament.
+
+    Scoped to the participant rather than to the global Team identity on purpose:
+    teams.TeamName is unique across the whole database with no guild column, so a
+    roster hung off the Team row would merge two servers that happen to pick the
+    same team name, and would rewrite a finished tournament's roster whenever the
+    team re-entered a later one.
+
+    The captain is NOT stored here. tournament_participants.captain_user_id stays
+    the single authority for who owns the team (it is who escrow charges and who
+    payouts go to); duplicating them into the roster would give money-bearing state
+    two places to disagree.
+    """
+
+    __tablename__ = 'tournament_team_members'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    participant_id = Column(Integer, ForeignKey('tournament_participants.id'),
+                            nullable=False, index=True)
+    user_id = Column(String(64), nullable=False, index=True)
+    # Snapshot of the name at the time they were added. Boards render <@user_id> so
+    # Discord always resolves the current name; this is the fallback for members who
+    # have since left the guild, and the readable record in logs and exports.
+    display_name = Column(String(128), nullable=False)
+    added_at = Column(DateTime, default=datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint('participant_id', 'user_id', name='uq_participant_member'),
+    )
+
+    def __repr__(self):
+        return (f"<TournamentTeamMember(participant_id={self.participant_id}, "
+                f"user_id={self.user_id})>")
+
+
 class TournamentRound(Base):
     __tablename__ = 'tournament_rounds'
 

--- a/services/tournament_formatter.py
+++ b/services/tournament_formatter.py
@@ -53,18 +53,41 @@ def _add_how_to_join(embed, fee, closed):
         value = (
             f"1. `/link_mtgo <your MTGO username>` — once, so the bot can trade with you\n"
             f"2. `/tournament register <team name>` — holds your spot\n"
-            f"3. `/wallet deposit {fee}` — your spot completes when the tix land"
+            f"3. `/wallet deposit {fee}` — your spot completes when the tix land\n"
+            f"4. `/tournament add_teammate @player` — once per teammate"
         )
     else:
-        value = "`/tournament register <team name>`"
+        value = (
+            "1. `/tournament register <team name>`\n"
+            "2. `/tournament add_teammate @player` — once per teammate"
+        )
     embed.add_field(name="How to join", value=value, inline=False)
 
 
+CAPTAIN_MARK = "👑"
+
+
+def _team_line(index, participant, fee, members):
+    """One roster row: rank, paid mark, team, then the full team inline.
+
+    Members share the team's line rather than getting one each: at 25 teams a line
+    per player would quadruple the row count and push the board through Discord's
+    embed limits, and the roster reads as a team either way.
+    """
+    paid = participant.status == "paid"
+    mark = "✅" if paid or fee == 0 else "⏳"
+    roster = [f"{CAPTAIN_MARK} <@{participant.captain_user_id}>"]
+    roster += [f"<@{m.user_id}>" for m in members]
+    return f"{index}. {mark} **{participant.team_name}** — {' · '.join(roster)}"
+
+
 def create_registration_embed(tournament, participants, pot=0, deficits=None,
-                              closed=False):
+                              closed=False, rosters=None):
     """Build the registration board (pure): who is in, and for a paid tournament who
-    has actually paid. ``deficits`` maps participant id -> tix still needed."""
+    has actually paid. ``deficits`` maps participant id -> tix still needed;
+    ``rosters`` maps participant id -> that team's TournamentTeamMember rows."""
     deficits = deficits or {}
+    rosters = rosters or {}
     fee = tournament.entry_fee or 0
     phase = "Registration closed" if closed else "Registration open"
     title = f"🏆 {tournament.name} — {phase}"
@@ -82,11 +105,9 @@ def create_registration_embed(tournament, participants, pot=0, deficits=None,
 
     lines = []
     for i, p in enumerate(participants, start=1):
-        paid = p.status == "paid"
-        mark = "✅" if paid or fee == 0 else "⏳"
-        lines.append(f"{i}. {mark} **{p.team_name}** — captain <@{p.captain_user_id}>")
+        lines.append(_team_line(i, p, fee, rosters.get(p.id, [])))
         short = deficits.get(p.id, 0)
-        if fee > 0 and not paid and not closed and short > 0:
+        if fee > 0 and p.status != "paid" and not closed and short > 0:
             lines.append(f"     needs {short} more tix — `/wallet deposit {short}`")
     if fee > 0:
         paid_n = sum(1 for p in participants if p.status == "paid")
@@ -117,6 +138,7 @@ def create_registration_embed(tournament, participants, pot=0, deficits=None,
     for i, chunk in enumerate(chunks):
         name = label if i == 0 else "Teams (cont.)"
         embed.add_field(name=name, value="\n".join(chunk), inline=False)
+    embed.set_footer(text=f"{CAPTAIN_MARK} team captain")
     _add_how_to_join(embed, fee, closed)
     return embed
 
@@ -146,14 +168,15 @@ async def update_standings_message(bot, tournament_id):
 
 
 async def _board_state(session, tournament):
-    """(participants, pot, deficits) for a tournament's board."""
+    """(participants, pot, deficits, rosters) for a tournament's board."""
     from services import wallet_service
-    from services.tournament_service import list_participants
+    from services.tournament_service import get_rosters, list_participants
 
     participants = await list_participants(session, tournament.id)
+    rosters = await get_rosters(session, tournament.id)
     fee = tournament.entry_fee or 0
     if fee <= 0:
-        return participants, 0, {}
+        return participants, 0, {}, rosters
     guild_id = str(tournament.guild_id)
     pot = await wallet_service.balance_in(
         session, guild_id, wallet_service.prize_wallet_id(tournament.id))
@@ -161,7 +184,7 @@ async def _board_state(session, tournament):
     balances = await wallet_service.balances_for(
         guild_id, [p.captain_user_id for p in pending])
     deficits = {p.id: max(fee - balances.get(p.captain_user_id, 0), 0) for p in pending}
-    return participants, pot, deficits
+    return participants, pot, deficits, rosters
 
 
 async def refresh_boards(bot, tournament_ids, closed=False):
@@ -182,8 +205,9 @@ async def update_registration_board(bot, tournament_id, closed=False):
         tournament = await session.get(Tournament, tournament_id)
         if tournament is None or not tournament.board_message_id:
             return
-        participants, pot, deficits = await _board_state(session, tournament)
-        embed = create_registration_embed(tournament, participants, pot, deficits, closed)
+        participants, pot, deficits, rosters = await _board_state(session, tournament)
+        embed = create_registration_embed(tournament, participants, pot, deficits, closed,
+                                          rosters)
         channel_id = int(tournament.board_channel_id)
         message_id = int(tournament.board_message_id)
 
@@ -212,8 +236,9 @@ async def post_registration_board(channel, tournament_id):
         tournament = await session.get(Tournament, tournament_id)
         if tournament is None:
             return None
-        participants, pot, deficits = await _board_state(session, tournament)
-        embed = create_registration_embed(tournament, participants, pot, deficits)
+        participants, pot, deficits, rosters = await _board_state(session, tournament)
+        embed = create_registration_embed(tournament, participants, pot, deficits,
+                                          rosters=rosters)
     try:
         message = await channel.send(embed=embed)
     except discord.HTTPException as e:

--- a/services/tournament_formatter.py
+++ b/services/tournament_formatter.py
@@ -66,6 +66,13 @@ def _add_how_to_join(embed, fee, closed):
 
 CAPTAIN_MARK = "👑"
 
+# A mention renders as ~24 characters with its separator, and every member of a team
+# shares one line. The field chunker below splits BETWEEN lines, so it cannot rescue a
+# single line that is itself over Discord's 1024-char cap -- past that, Discord rejects
+# the whole edit and the board freezes on a stale roster. Cap the names shown so one
+# line stays well inside the limit even beside a 128-char team name.
+MAX_MEMBERS_SHOWN = 20
+
 
 def _team_line(index, participant, fee, members):
     """One roster row: rank, paid mark, team, then the full team inline.
@@ -77,7 +84,10 @@ def _team_line(index, participant, fee, members):
     paid = participant.status == "paid"
     mark = "✅" if paid or fee == 0 else "⏳"
     roster = [f"{CAPTAIN_MARK} <@{participant.captain_user_id}>"]
-    roster += [f"<@{m.user_id}>" for m in members]
+    roster += [f"<@{m.user_id}>" for m in members[:MAX_MEMBERS_SHOWN]]
+    overflow = len(members) - MAX_MEMBERS_SHOWN
+    if overflow > 0:
+        roster.append(f"+{overflow} more")
     return f"{index}. {mark} **{participant.team_name}** — {' · '.join(roster)}"
 
 
@@ -187,24 +197,31 @@ async def _board_state(session, tournament):
     return participants, pot, deficits, rosters
 
 
-async def refresh_boards(bot, tournament_ids, closed=False):
+async def refresh_boards(bot, tournament_ids):
     """Refresh several boards, guarded. The board is a view: a Discord failure on one
     logs and the rest still update. Every caller that reacts to a change goes through
     here rather than hand-rolling the try/except."""
     for t_id in set(tournament_ids):
         try:
-            await update_registration_board(bot, t_id, closed=closed)
+            await update_registration_board(bot, t_id)
         except Exception as e:
             logger.warning(f"board refresh failed for {t_id}: {e}")
 
 
-async def update_registration_board(bot, tournament_id, closed=False):
+async def update_registration_board(bot, tournament_id):
     """Edit the registration board in place. No-op if it was never posted; a board that
-    has been deleted clears its ids so it stops being retried."""
+    has been deleted clears its ids so it stops being retried.
+
+    Whether the board reads as open or closed is derived from the tournament, not
+    passed in by the caller. Rosters stay editable after a tournament starts, and
+    every roster edit refreshes the board -- with a caller-supplied flag, the first
+    such edit flipped a started tournament back to "Registration open" and
+    re-advertised the join steps."""
     async with db_session() as session:
         tournament = await session.get(Tournament, tournament_id)
         if tournament is None or not tournament.board_message_id:
             return
+        closed = tournament.status != "registration"
         participants, pot, deficits, rosters = await _board_state(session, tournament)
         embed = create_registration_embed(tournament, participants, pot, deficits, closed,
                                           rosters)

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -6,7 +6,7 @@ standings.
 All functions take an AsyncSession so callers control the transaction and tests
 can point them at a temp database (mirrors the leaderboard_service convention).
 """
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 
 from database.db_session import db_session
 from draft_organization.swiss import pair_round, rank_standings, round_robin_schedule
@@ -16,6 +16,7 @@ from models.tournament import (
     TournamentMatch,
     TournamentParticipant,
     TournamentRound,
+    TournamentTeamMember,
 )
 
 ACTIVE_STATUSES = ("registration", "active")
@@ -37,7 +38,7 @@ ALL_OPEN_FORMATS = ("round_robin", "manual")
 MANUAL_ROUND_SIZE = 10  # matches per pairings message, well under Discord's 25-button cap
 
 
-async def _participant_by_name(session, tournament_id, team_name):
+async def find_participant_by_name(session, tournament_id, team_name):
     """Find a tournament participant by team name (case-insensitive), or None."""
     stmt = select(TournamentParticipant).where(
         TournamentParticipant.tournament_id == tournament_id,
@@ -160,9 +161,143 @@ async def remove_team(session, tournament_id, team_name):
     participant = (await session.execute(stmt)).scalars().first()
     if participant is None:
         raise ValueError(f"'{team_name}' is not registered for this tournament.")
+    # The roster has no ORM relationship to cascade through (deliberately — lazy
+    # loading a relationship on an async session is a footgun), so its rows are
+    # cleared explicitly. Without this they would outlive the team that owned them.
+    await session.execute(
+        delete(TournamentTeamMember).where(
+            TournamentTeamMember.participant_id == participant.id
+        )
+    )
     await session.delete(participant)
     await session.flush()
     return participant
+
+
+# ---- team rosters ---------------------------------------------------------------
+
+async def find_participant_for_captain(session, tournament_id, captain_user_id):
+    """The team this user captains in the tournament, or None."""
+    stmt = select(TournamentParticipant).where(
+        TournamentParticipant.tournament_id == tournament_id,
+        TournamentParticipant.captain_user_id == str(captain_user_id),
+    )
+    return (await session.execute(stmt)).scalars().first()
+
+
+async def _team_already_holding(session, tournament_id, user_id, exclude_participant_id):
+    """The other team in this tournament that already has this player, or None.
+
+    Checks captaincy as well as the roster: someone who captains Bravo is on Bravo
+    even though no roster row says so.
+    """
+    user_id = str(user_id)
+    captains = select(TournamentParticipant).where(
+        TournamentParticipant.tournament_id == tournament_id,
+        TournamentParticipant.captain_user_id == user_id,
+        TournamentParticipant.id != exclude_participant_id,
+    )
+    found = (await session.execute(captains)).scalars().first()
+    if found is not None:
+        return found
+    rostered = (
+        select(TournamentParticipant)
+        .join(TournamentTeamMember,
+              TournamentTeamMember.participant_id == TournamentParticipant.id)
+        .where(
+            TournamentParticipant.tournament_id == tournament_id,
+            TournamentTeamMember.user_id == user_id,
+            TournamentParticipant.id != exclude_participant_id,
+        )
+    )
+    return (await session.execute(rostered)).scalars().first()
+
+
+async def _assert_roster_editable(session, participant):
+    """Rosters stay editable while a tournament runs, but a finished one is a record."""
+    tournament = await session.get(Tournament, participant.tournament_id)
+    if tournament is None:
+        raise ValueError("Tournament not found.")
+    if tournament.status == "completed":
+        raise ValueError(f"'{tournament.name}' is completed — its rosters are final.")
+    return tournament
+
+
+async def add_teammate(session, participant, user_id, display_name):
+    """Put a player on a team's roster.
+
+    Returns (member, created). Idempotent, like register_team: adding someone who
+    is already on the roster returns the existing row with created=False and leaves
+    their stored display name alone. Raises ValueError if the tournament is
+    completed, if the player is the team's own captain, or if they already belong
+    to another team in the same tournament.
+    """
+    await _assert_roster_editable(session, participant)
+    user_id = str(user_id)
+
+    if user_id == participant.captain_user_id:
+        raise ValueError(
+            f"<@{user_id}> is the captain of {participant.team_name} and is already on the team."
+        )
+
+    stmt = select(TournamentTeamMember).where(
+        TournamentTeamMember.participant_id == participant.id,
+        TournamentTeamMember.user_id == user_id,
+    )
+    existing = (await session.execute(stmt)).scalars().first()
+    if existing is not None:
+        return existing, False
+
+    clash = await _team_already_holding(session, participant.tournament_id, user_id,
+                                        participant.id)
+    if clash is not None:
+        raise ValueError(
+            f"<@{user_id}> is already on **{clash.team_name}** in this tournament."
+        )
+
+    member = TournamentTeamMember(
+        participant_id=participant.id,
+        user_id=user_id,
+        display_name=display_name,
+    )
+    session.add(member)
+    await session.flush()
+    return member, True
+
+
+async def remove_teammate(session, participant, user_id):
+    """Take a player off a team's roster. Returns True if they were on it."""
+    await _assert_roster_editable(session, participant)
+    stmt = select(TournamentTeamMember).where(
+        TournamentTeamMember.participant_id == participant.id,
+        TournamentTeamMember.user_id == str(user_id),
+    )
+    member = (await session.execute(stmt)).scalars().first()
+    if member is None:
+        return False
+    await session.delete(member)
+    await session.flush()
+    return True
+
+
+async def get_rosters(session, tournament_id):
+    """{participant_id: [members in add order]} for one tournament.
+
+    One query for the whole event: the registration board renders every team at
+    once, so a per-participant lookup would be an N+1 on every board refresh.
+    Teams with an empty roster are absent from the mapping.
+    """
+    stmt = (
+        select(TournamentTeamMember)
+        .join(TournamentParticipant,
+              TournamentTeamMember.participant_id == TournamentParticipant.id)
+        .where(TournamentParticipant.tournament_id == tournament_id)
+        .order_by(TournamentTeamMember.id)
+    )
+    rosters = {}
+    for member in (await session.execute(stmt)).scalars().all():
+        rosters.setdefault(member.participant_id, []).append(member)
+    return rosters
 
 
 # ---- slice 2: rounds, results, standings -------------------------------------
@@ -278,8 +413,8 @@ async def add_match(session, tournament_id, team_a_name, team_b_name):
     if tournament.status != "registration":
         raise ValueError("Add matches before starting the tournament.")
 
-    a = await _participant_by_name(session, tournament_id, team_a_name)
-    b = await _participant_by_name(session, tournament_id, team_b_name)
+    a = await find_participant_by_name(session, tournament_id, team_a_name)
+    b = await find_participant_by_name(session, tournament_id, team_b_name)
     if a is None or b is None:
         missing = team_a_name if a is None else team_b_name
         raise ValueError(f"'{missing}' is not registered for this tournament.")

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -7,6 +7,7 @@ All functions take an AsyncSession so callers control the transaction and tests
 can point them at a temp database (mirrors the leaderboard_service convention).
 """
 from sqlalchemy import delete, func, or_, select
+from sqlalchemy.exc import IntegrityError
 
 from database.db_session import db_session
 from draft_organization.swiss import pair_round, rank_standings, round_robin_schedule
@@ -264,8 +265,16 @@ async def add_teammate(session, participant, user_id, display_name):
         user_id=user_id,
         display_name=display_name,
     )
-    session.add(member)
-    await session.flush()
+    try:
+        # SAVEPOINT so losing the race below doesn't poison the caller's transaction.
+        async with session.begin_nested():
+            session.add(member)
+            await session.flush()
+    except IntegrityError:
+        # Another add committed this same player between our lookup above and this
+        # insert. uq_participant_member held, so the roster is right -- report it the
+        # way the uncontended duplicate is reported rather than raising at the user.
+        return (await session.execute(stmt)).scalars().first(), False
     return member, True
 
 

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -6,7 +6,7 @@ standings.
 All functions take an AsyncSession so callers control the transaction and tests
 can point them at a temp database (mirrors the leaderboard_service convention).
 """
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 
 from database.db_session import db_session
 from draft_organization.swiss import pair_round, rank_standings, round_robin_schedule
@@ -176,41 +176,50 @@ async def remove_team(session, tournament_id, team_name):
 
 # ---- team rosters ---------------------------------------------------------------
 
-async def find_participant_for_captain(session, tournament_id, captain_user_id):
-    """The team this user captains in the tournament, or None."""
-    stmt = select(TournamentParticipant).where(
-        TournamentParticipant.tournament_id == tournament_id,
-        TournamentParticipant.captain_user_id == str(captain_user_id),
-    )
-    return (await session.execute(stmt)).scalars().first()
+async def find_participants_for_captain(session, tournament_id, captain_user_id):
+    """Every team this user captains in the tournament, in registration order.
 
-
-async def _team_already_holding(session, tournament_id, user_id, exclude_participant_id):
-    """The other team in this tournament that already has this player, or None.
-
-    Checks captaincy as well as the roster: someone who captains Bravo is on Bravo
-    even though no roster row says so.
+    A list rather than one row because nothing stops a user registering several
+    teams -- register_team keys uniqueness on the team, never the captain. Taking
+    .first() here sent roster edits to whichever row the database happened to
+    return and left the captain's other teams unreachable, with no error to say so.
     """
-    user_id = str(user_id)
-    captains = select(TournamentParticipant).where(
-        TournamentParticipant.tournament_id == tournament_id,
-        TournamentParticipant.captain_user_id == user_id,
-        TournamentParticipant.id != exclude_participant_id,
-    )
-    found = (await session.execute(captains)).scalars().first()
-    if found is not None:
-        return found
-    rostered = (
+    stmt = (
         select(TournamentParticipant)
-        .join(TournamentTeamMember,
-              TournamentTeamMember.participant_id == TournamentParticipant.id)
         .where(
             TournamentParticipant.tournament_id == tournament_id,
-            TournamentTeamMember.user_id == user_id,
-            TournamentParticipant.id != exclude_participant_id,
+            TournamentParticipant.captain_user_id == str(captain_user_id),
         )
+        .order_by(TournamentParticipant.id)
     )
-    return (await session.execute(rostered)).scalars().first()
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def other_teams_for_user(session, tournament_id, user_id, exclude_participant_id):
+    """The tournament's other teams this player already belongs to.
+
+    Players may be shared between teams, so this no longer blocks anything -- it
+    feeds the note on the reply, which is how the overlap stays visible. Counts
+    captaincy as well as roster rows: someone who captains Bravo is on Bravo even
+    though no roster row says so.
+    """
+    user_id = str(user_id)
+    stmt = (
+        select(TournamentParticipant)
+        .outerjoin(TournamentTeamMember,
+                   TournamentTeamMember.participant_id == TournamentParticipant.id)
+        .where(
+            TournamentParticipant.tournament_id == tournament_id,
+            TournamentParticipant.id != exclude_participant_id,
+            or_(
+                TournamentParticipant.captain_user_id == user_id,
+                TournamentTeamMember.user_id == user_id,
+            ),
+        )
+        .order_by(TournamentParticipant.id)
+        .distinct()
+    )
+    return list((await session.execute(stmt)).scalars().all())
 
 
 async def _assert_roster_editable(session, participant):
@@ -229,8 +238,10 @@ async def add_teammate(session, participant, user_id, display_name):
     Returns (member, created). Idempotent, like register_team: adding someone who
     is already on the roster returns the existing row with created=False and leaves
     their stored display name alone. Raises ValueError if the tournament is
-    completed, if the player is the team's own captain, or if they already belong
-    to another team in the same tournament.
+    completed or if the player is this team's own captain.
+
+    Belonging to another team in the same tournament is allowed -- players get
+    shared, and callers surface that with other_teams_for_user rather than blocking.
     """
     await _assert_roster_editable(session, participant)
     user_id = str(user_id)
@@ -247,13 +258,6 @@ async def add_teammate(session, participant, user_id, display_name):
     existing = (await session.execute(stmt)).scalars().first()
     if existing is not None:
         return existing, False
-
-    clash = await _team_already_holding(session, participant.tournament_id, user_id,
-                                        participant.id)
-    if clash is not None:
-        raise ValueError(
-            f"<@{user_id}> is already on **{clash.team_name}** in this tournament."
-        )
 
     member = TournamentTeamMember(
         participant_id=participant.id,

--- a/session.py
+++ b/session.py
@@ -8,7 +8,6 @@ from models import (
     PlayerStats,
     PlayerLimit,
     Team,
-    TeamRegistration,
     WeeklyLimit,
     Challenge,
     SwissChallenge,

--- a/tests/test_registration_board.py
+++ b/tests/test_registration_board.py
@@ -1,6 +1,7 @@
 """The registration board: renders roster + payment state, and edits in place."""
 import pytest
 
+from conftest import test_db  # noqa: F401  (fixture)
 from models.tournament import (
     Tournament,
     TournamentParticipant,
@@ -247,3 +248,68 @@ def test_large_roster_with_members_still_splits_under_the_cap():
     full_text = "".join(f.value for f in embed.fields)
     for t in teams:
         assert t.team_name in full_text
+
+
+# ---- the board's phase follows the tournament, not the caller ------------------
+
+async def _refresh_and_capture(status):
+    """Run update_registration_board against a tournament in `status`, return the embed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from database.db_session import db_session
+    from services.tournament_formatter import update_registration_board
+    from services.tournament_service import create_tournament, register_team
+
+    async with db_session() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        await register_team(session, t.id, "Alpha", "42")
+        t.status = status
+        t.board_channel_id = "111"
+        t.board_message_id = "222"
+        await session.commit()
+        t_id = t.id
+
+    message = MagicMock()
+    message.edit = AsyncMock()
+    channel = MagicMock()
+    channel.fetch_message = AsyncMock(return_value=message)
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=channel)
+
+    await update_registration_board(bot, t_id)
+    return message.edit.call_args.kwargs["embed"]
+
+
+@pytest.mark.asyncio
+async def test_board_of_a_started_tournament_refreshes_as_closed(test_db):  # noqa: F811
+    """Rosters stay editable after the start, and every roster edit refreshes the
+    board. If the phase came from the caller's flag it would flip a started
+    tournament back to 'Registration open' and re-advertise the join steps."""
+    embed = await _refresh_and_capture("active")
+
+    assert "Registration closed" in embed.title
+    assert "How to join" not in "".join(f.name for f in embed.fields)
+
+
+@pytest.mark.asyncio
+async def test_board_still_open_while_registration_is(test_db):  # noqa: F811
+    embed = await _refresh_and_capture("registration")
+
+    assert "Registration open" in embed.title
+    assert "How to join" in "".join(f.name for f in embed.fields)
+
+
+def test_one_huge_roster_cannot_overflow_its_field():
+    """The chunker splits BETWEEN lines, so it cannot rescue a single line that is
+    itself over Discord's 1024-char field cap. A team's members all share one line,
+    so an unbounded roster would freeze the board on a rejected edit."""
+    teams = [_team(1, "Alpha", "10", "paid")]
+    rosters = {1: [_member(str(100000000000000000 + i)) for i in range(60)]}
+
+    embed = create_registration_embed(_tournament(), teams, pot=1, rosters=rosters)
+
+    for f in embed.fields:
+        assert len(f.value) < 1024, f"field {f.name!r} is {len(f.value)} chars"
+    text = "".join(f.value for f in embed.fields)
+    assert "more" in text, "the dropped members should be accounted for, not silently lost"

--- a/tests/test_registration_board.py
+++ b/tests/test_registration_board.py
@@ -1,7 +1,11 @@
 """The registration board: renders roster + payment state, and edits in place."""
 import pytest
 
-from models.tournament import Tournament, TournamentParticipant
+from models.tournament import (
+    Tournament,
+    TournamentParticipant,
+    TournamentTeamMember,
+)
 from services.tournament_formatter import create_registration_embed
 
 
@@ -178,3 +182,68 @@ async def test_a_deleted_board_clears_its_ids_so_it_stops_retrying(test_db):  # 
     async with db_session() as session:
         t = await session.get(Tournament, t_id)
         assert t.board_message_id is None and t.board_channel_id is None
+
+
+def _member(user_id, name="Player"):
+    return TournamentTeamMember(participant_id=1, user_id=user_id, display_name=name)
+
+
+def test_board_lists_the_full_team_not_just_the_captain():
+    teams = [_team(1, "Alpha", "10", "paid")]
+    rosters = {1: [_member("11", "Bob"), _member("12", "Cara")]}
+    text = _text(create_registration_embed(_tournament(), teams, pot=1, rosters=rosters))
+
+    assert "👑 <@10>" in text
+    assert "<@11>" in text and "<@12>" in text
+
+
+def test_board_explains_the_crown():
+    """The crown is only legible if something says what it means."""
+    teams = [_team(1, "Alpha", "10", "paid")]
+    embed = create_registration_embed(_tournament(), teams, pot=1,
+                                      rosters={1: [_member("11")]})
+
+    assert embed.footer.text and "captain" in embed.footer.text.lower()
+
+
+def test_board_renders_a_team_with_no_teammates_yet():
+    """A captain who hasn't added anyone must not leave a dangling separator."""
+    teams = [_team(1, "Alpha", "10", "paid")]
+    text = _text(create_registration_embed(_tournament(), teams, pot=1, rosters={}))
+
+    assert "👑 <@10>" in text
+    assert "👑 <@10> ·" not in text
+
+
+def test_board_keeps_each_teams_members_on_its_own_line():
+    teams = [_team(1, "Alpha", "10", "paid"), _team(2, "Beta", "20", "paid")]
+    rosters = {1: [_member("11")], 2: [_member("21")]}
+    text = _text(create_registration_embed(_tournament(), teams, pot=2, rosters=rosters))
+
+    alpha_line = next(ln for ln in text.split("\n") if "Alpha" in ln)
+    assert "<@11>" in alpha_line and "<@21>" not in alpha_line
+
+
+def test_join_instructions_name_the_add_teammate_step():
+    """Registering only records the captain, so the roster step has to be told."""
+    text = _text(create_registration_embed(_tournament(fee=0), []))
+
+    assert "/tournament add_teammate" in text
+
+
+def test_large_roster_with_members_still_splits_under_the_cap():
+    """Members make each line ~3x longer, so the field-splitting has to hold."""
+    teams = []
+    rosters = {}
+    for i in range(1, 26):
+        teams.append(_team(i, f"Team Number Twenty-Five Roster Entry {i:02d}", str(1000 + i), "paid"))
+        rosters[i] = [_member(str(2000 + i)), _member(str(3000 + i)), _member(str(4000 + i))]
+
+    embed = create_registration_embed(_tournament(), teams, pot=10, rosters=rosters)
+
+    assert len(embed.fields) > 1
+    for f in embed.fields:
+        assert len(f.value) < 1024, f"field {f.name!r} is {len(f.value)} chars"
+    full_text = "".join(f.value for f in embed.fields)
+    for t in teams:
+        assert t.team_name in full_text

--- a/tests/test_roster_target.py
+++ b/tests/test_roster_target.py
@@ -1,0 +1,146 @@
+"""Which team a roster command edits.
+
+The no-`team` path used to take .first() on the captain lookup, so a captain who
+owned two teams had their edit land on whichever row came back first, with no
+error saying so. These tests pin the resolution rules down.
+"""
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.models_base import Base
+from services.tournament_service import create_tournament, register_team
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+    temp_db.close()
+    engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    await engine.dispose()
+    os.unlink(temp_db.name)
+
+
+def _ctx(author_id):
+    ctx = MagicMock()
+    ctx.author.id = author_id
+    ctx.followup.send = AsyncMock()
+    return ctx
+
+
+def _cog():
+    from cogs.tournament_commands import TournamentCog
+    return TournamentCog.__new__(TournamentCog)
+
+
+async def _resolve(ctx, session, tournament, team=None, manager=False):
+    with patch("cogs.tournament_commands.is_bot_manager",
+               new=AsyncMock(return_value=manager)):
+        return await _cog()._roster_target(ctx, session, tournament, team)
+
+
+def _reply(ctx):
+    return ctx.followup.send.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_captain_of_one_team_needs_no_team_argument(test_db):
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        alpha, _ = await register_team(session, t.id, "Alpha", "42")
+        await session.commit()
+
+        ctx = _ctx(42)
+        assert (await _resolve(ctx, session, t)).id == alpha.id
+        ctx.followup.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_captain_of_two_teams_is_asked_which_one(test_db):
+    """The bug: this used to silently pick Alpha and edit the wrong roster."""
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        await register_team(session, t.id, "Alpha", "42")
+        await session.commit()
+        await register_team(session, t.id, "Bravo", "42")
+        await session.commit()
+
+        ctx = _ctx(42)
+        assert await _resolve(ctx, session, t) is None
+        reply = _reply(ctx)
+        assert "Alpha" in reply and "Bravo" in reply and "team" in reply
+
+
+@pytest.mark.asyncio
+async def test_captain_of_nothing_is_told_to_register(test_db):
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+
+        ctx = _ctx(42)
+        assert await _resolve(ctx, session, t) is None
+        assert "/tournament register" in _reply(ctx)
+
+
+@pytest.mark.asyncio
+async def test_captain_may_name_their_own_team(test_db):
+    """Naming a team you own is how a multi-team captain picks one, so it must not
+    require the bot-manager role."""
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        await register_team(session, t.id, "Alpha", "42")
+        await session.commit()
+        bravo, _ = await register_team(session, t.id, "Bravo", "42")
+        await session.commit()
+
+        ctx = _ctx(42)
+        got = await _resolve(ctx, session, t, team="Bravo", manager=False)
+        assert got is not None and got.id == bravo.id
+
+
+@pytest.mark.asyncio
+async def test_non_manager_cannot_name_someone_elses_team(test_db):
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        await register_team(session, t.id, "Alpha", "99")
+        await session.commit()
+
+        ctx = _ctx(42)
+        assert await _resolve(ctx, session, t, team="Alpha", manager=False) is None
+        assert "<@99>" in _reply(ctx)
+
+
+@pytest.mark.asyncio
+async def test_manager_may_name_any_team(test_db):
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+        alpha, _ = await register_team(session, t.id, "Alpha", "99")
+        await session.commit()
+
+        ctx = _ctx(42)
+        got = await _resolve(ctx, session, t, team="Alpha", manager=True)
+        assert got is not None and got.id == alpha.id
+
+
+@pytest.mark.asyncio
+async def test_unknown_team_name_is_reported(test_db):
+    async with test_db() as session:
+        t = await create_tournament(session, "g1", "Spring", 3)
+        await session.commit()
+
+        ctx = _ctx(42)
+        assert await _resolve(ctx, session, t, team="Nope", manager=True) is None
+        assert "Nope" in _reply(ctx)

--- a/tests/test_roster_target.py
+++ b/tests/test_roster_target.py
@@ -4,29 +4,13 @@ The no-`team` path used to take .first() on the captain lookup, so a captain who
 owned two teams had their edit land on whichever row came back first, with no
 error saying so. These tests pin the resolution rules down.
 """
-import os
-import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import pytest_asyncio
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
 
-from database.models_base import Base
+from conftest import test_db  # noqa: F401  (fixture)
+from database.db_session import db_session
 from services.tournament_service import create_tournament, register_team
-
-
-@pytest_asyncio.fixture
-async def test_db():
-    temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
-    temp_db.close()
-    engine = create_async_engine(f"sqlite+aiosqlite:///{temp_db.name}")
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-    await engine.dispose()
-    os.unlink(temp_db.name)
 
 
 def _ctx(author_id):
@@ -52,8 +36,8 @@ def _reply(ctx):
 
 
 @pytest.mark.asyncio
-async def test_captain_of_one_team_needs_no_team_argument(test_db):
-    async with test_db() as session:
+async def test_captain_of_one_team_needs_no_team_argument(test_db):  # noqa: F811
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
         alpha, _ = await register_team(session, t.id, "Alpha", "42")
@@ -65,9 +49,9 @@ async def test_captain_of_one_team_needs_no_team_argument(test_db):
 
 
 @pytest.mark.asyncio
-async def test_captain_of_two_teams_is_asked_which_one(test_db):
+async def test_captain_of_two_teams_is_asked_which_one(test_db):  # noqa: F811
     """The bug: this used to silently pick Alpha and edit the wrong roster."""
-    async with test_db() as session:
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
         await register_team(session, t.id, "Alpha", "42")
@@ -82,8 +66,8 @@ async def test_captain_of_two_teams_is_asked_which_one(test_db):
 
 
 @pytest.mark.asyncio
-async def test_captain_of_nothing_is_told_to_register(test_db):
-    async with test_db() as session:
+async def test_captain_of_nothing_is_told_to_register(test_db):  # noqa: F811
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
 
@@ -93,10 +77,10 @@ async def test_captain_of_nothing_is_told_to_register(test_db):
 
 
 @pytest.mark.asyncio
-async def test_captain_may_name_their_own_team(test_db):
+async def test_captain_may_name_their_own_team(test_db):  # noqa: F811
     """Naming a team you own is how a multi-team captain picks one, so it must not
     require the bot-manager role."""
-    async with test_db() as session:
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
         await register_team(session, t.id, "Alpha", "42")
@@ -110,8 +94,8 @@ async def test_captain_may_name_their_own_team(test_db):
 
 
 @pytest.mark.asyncio
-async def test_non_manager_cannot_name_someone_elses_team(test_db):
-    async with test_db() as session:
+async def test_non_manager_cannot_name_someone_elses_team(test_db):  # noqa: F811
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
         await register_team(session, t.id, "Alpha", "99")
@@ -123,8 +107,8 @@ async def test_non_manager_cannot_name_someone_elses_team(test_db):
 
 
 @pytest.mark.asyncio
-async def test_manager_may_name_any_team(test_db):
-    async with test_db() as session:
+async def test_manager_may_name_any_team(test_db):  # noqa: F811
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
         alpha, _ = await register_team(session, t.id, "Alpha", "99")
@@ -136,8 +120,8 @@ async def test_manager_may_name_any_team(test_db):
 
 
 @pytest.mark.asyncio
-async def test_unknown_team_name_is_reported(test_db):
-    async with test_db() as session:
+async def test_unknown_team_name_is_reported(test_db):  # noqa: F811
+    async with db_session() as session:
         t = await create_tournament(session, "g1", "Spring", 3)
         await session.commit()
 

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -159,3 +159,19 @@ async def test_start_freezes_the_board():
         await TournamentCog.start.callback(cog, ctx)
 
     cog._refresh_board.assert_awaited_once_with(1, closed=True)
+
+
+def test_roster_commands_are_registered():
+    from cogs.tournament_commands import TournamentCog
+
+    subcommands = {cmd.name for cmd in TournamentCog.tournament.subcommands}
+    assert {"add_teammate", "remove_teammate"} <= subcommands
+
+
+def test_roster_commands_are_open_to_captains():
+    """Captains manage their own roster; the bot-manager gate lives on the optional
+    `team` argument instead, so the command itself must not carry the check."""
+    from cogs.tournament_commands import TournamentCog
+
+    assert is_bot_manager not in TournamentCog.add_teammate_cmd.checks
+    assert is_bot_manager not in TournamentCog.remove_teammate_cmd.checks

--- a/tests/test_tournament_cog_smoke.py
+++ b/tests/test_tournament_cog_smoke.py
@@ -136,9 +136,14 @@ async def test_refresh_board_swallows_a_discord_failure():
 
 @pytest.mark.asyncio
 async def test_start_freezes_the_board():
-    """/tournament start closes registration, so the board refresh it triggers
-    must be told closed=True — otherwise the board keeps inviting registrations
-    after the schedule has already been seeded."""
+    """/tournament start must refresh the board, so it stops inviting registrations
+    once the schedule is seeded.
+
+    It no longer passes a closed flag: the board derives open-vs-closed from the
+    tournament's own status, which start has already moved off "registration".
+    That is what keeps a later roster edit -- which also refreshes the board --
+    from flipping it back to open. The rendering half is covered by
+    test_board_of_a_started_tournament_refreshes_as_closed."""
     from cogs.tournament_commands import TournamentCog
 
     cog = TournamentCog(MagicMock())
@@ -158,7 +163,7 @@ async def test_start_freezes_the_board():
                AsyncMock(return_value=res)):
         await TournamentCog.start.callback(cog, ctx)
 
-    cog._refresh_board.assert_awaited_once_with(1, closed=True)
+    cog._refresh_board.assert_awaited_once_with(1)
 
 
 def test_roster_commands_are_registered():

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -25,11 +25,12 @@ from services.tournament_service import (
     create_tournament,
     finish_tournament,
     find_current_match,
-    find_participant_for_captain,
+    find_participants_for_captain,
     get_active_tournament,
     get_rosters,
     get_standings_data,
     list_participants,
+    other_teams_for_user,
     register_team,
     remove_team,
     remove_teammate,
@@ -750,8 +751,8 @@ async def test_add_teammate_rejects_the_captain(test_db):
 
 
 @pytest.mark.asyncio
-async def test_add_teammate_rejects_a_player_on_another_team(test_db):
-    """A player may only appear on one roster per tournament."""
+async def test_add_teammate_allows_a_player_on_another_team(test_db):
+    """Players may be shared between teams; the overlap is reported, not blocked."""
     async with test_db() as session:
         tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
         bravo, _ = await register_team(session, tournament.id, "Bravo", "99")
@@ -759,9 +760,13 @@ async def test_add_teammate_rejects_a_player_on_another_team(test_db):
 
         await add_teammate(session, alpha, "7", "Bob")
         await session.commit()
+        _, created = await add_teammate(session, bravo, "7", "Bob")
+        await session.commit()
 
-        with pytest.raises(ValueError, match="Alpha"):
-            await add_teammate(session, bravo, "7", "Bob")
+        assert created is True
+        rosters = await get_rosters(session, tournament.id)
+        assert [m.user_id for m in rosters[alpha.id]] == ["7"]
+        assert [m.user_id for m in rosters[bravo.id]] == ["7"]
 
 
 @pytest.mark.asyncio
@@ -830,13 +835,52 @@ async def test_remove_teammate_reports_when_the_player_was_not_on_the_roster(tes
 
 
 @pytest.mark.asyncio
-async def test_find_participant_for_captain(test_db):
+async def test_find_participants_for_captain(test_db):
     async with test_db() as session:
         tournament, participant = await _tournament_with_team(session, "Alpha", "42")
 
-        found = await find_participant_for_captain(session, tournament.id, "42")
-        assert found is not None and found.id == participant.id
-        assert await find_participant_for_captain(session, tournament.id, "99") is None
+        found = await find_participants_for_captain(session, tournament.id, "42")
+        assert [p.id for p in found] == [participant.id]
+        assert await find_participants_for_captain(session, tournament.id, "99") == []
+
+
+@pytest.mark.asyncio
+async def test_find_participants_for_captain_returns_every_team_they_own(test_db):
+    """One user may register several teams. Returning only the first silently sent
+    roster edits to the wrong team."""
+    async with test_db() as session:
+        tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
+        bravo, _ = await register_team(session, tournament.id, "Bravo", "42")
+        await session.commit()
+
+        found = await find_participants_for_captain(session, tournament.id, "42")
+        assert [p.team_name for p in found] == ["Alpha", "Bravo"]
+
+
+@pytest.mark.asyncio
+async def test_other_teams_for_user_reports_roster_and_captaincy(test_db):
+    """The overlap note has to see both ways of being on a team."""
+    async with test_db() as session:
+        tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
+        bravo, _ = await register_team(session, tournament.id, "Bravo", "99")
+        charlie, _ = await register_team(session, tournament.id, "Charlie", "55")
+        await session.commit()
+        await add_teammate(session, charlie, "7", "Bob")
+        await session.commit()
+
+        # rostered on Charlie
+        others = await other_teams_for_user(session, tournament.id, "7", alpha.id)
+        assert [p.team_name for p in others] == ["Charlie"]
+        # captains Bravo -- and Bravo having its own members must not duplicate it
+        # in the result (the outer join emits one row per member).
+        await add_teammate(session, bravo, "81", "One")
+        await add_teammate(session, bravo, "82", "Two")
+        await session.commit()
+        others = await other_teams_for_user(session, tournament.id, "99", alpha.id)
+        assert [p.team_name for p in others] == ["Bravo"]
+        # the excluded team is never reported back at itself
+        others = await other_teams_for_user(session, tournament.id, "7", charlie.id)
+        assert others == []
 
 
 @pytest.mark.asyncio
@@ -878,15 +922,16 @@ async def test_remove_team_also_deletes_its_roster(test_db):
 
 
 @pytest.mark.asyncio
-async def test_add_teammate_rejects_another_teams_captain(test_db):
-    """A captain is on their own team even with no roster row to say so."""
+async def test_add_teammate_allows_another_teams_captain(test_db):
+    """Captaining Bravo no longer bars you from playing for Alpha too."""
     async with test_db() as session:
         tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
         await register_team(session, tournament.id, "Bravo", "99")
         await session.commit()
 
-        with pytest.raises(ValueError, match="Bravo"):
-            await add_teammate(session, alpha, "99", "Cap Two")
+        _, created = await add_teammate(session, alpha, "99", "Cap Two")
+        await session.commit()
+        assert created is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -946,3 +946,39 @@ async def test_remove_teammate_rejects_a_completed_tournament(test_db):
 
         with pytest.raises(ValueError, match="completed"):
             await remove_teammate(session, participant, "7")
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_survives_losing_the_insert_race(test_db):
+    """Two adds of the same player to the same team can interleave: both read an
+    empty roster, then one insert wins and the other violates uq_participant_member.
+    The loser must report the uncontended-duplicate result, not raise at the user.
+
+    The stale read is simulated by inserting the row behind add_teammate's lookup.
+    """
+    async with test_db() as session:
+        _, participant = await _tournament_with_team(session)
+
+        real_execute = session.execute
+        state = {"raced": False}
+
+        async def execute_then_race(stmt, *a, **kw):
+            result = await real_execute(stmt, *a, **kw)
+            if not state["raced"]:
+                # after add_teammate's "is he already on it?" lookup comes back empty,
+                # a concurrent add lands the row
+                state["raced"] = True
+                session.execute = real_execute
+                session.add(TournamentTeamMember(
+                    participant_id=participant.id, user_id="7", display_name="Winner"))
+                await session.flush()
+            return result
+
+        session.execute = execute_then_race
+        member, created = await add_teammate(session, participant, "7", "Loser")
+        await session.commit()
+
+        assert created is False
+        assert member.display_name == "Winner"  # the row that actually won
+        rows = (await session.execute(select(TournamentTeamMember))).scalars().all()
+        assert len(rows) == 1

--- a/tests/test_tournament_service.py
+++ b/tests/test_tournament_service.py
@@ -16,18 +16,23 @@ from models.tournament import (
     TournamentMatch,
     TournamentParticipant,
     TournamentRound,
+    TournamentTeamMember,
 )
 from services.tournament_service import (
     add_match,
+    add_teammate,
     advance_round,
     create_tournament,
     finish_tournament,
     find_current_match,
+    find_participant_for_captain,
     get_active_tournament,
+    get_rosters,
     get_standings_data,
     list_participants,
     register_team,
     remove_team,
+    remove_teammate,
     set_result,
     start_tournament,
 )
@@ -688,3 +693,211 @@ async def test_list_participants_in_registration_order(test_db):
 
         participants = await list_participants(session, tournament.id)
         assert [p.team_name for p in participants] == ["Bravo", "Alpha", "Charlie"]
+
+
+# ---- team rosters ---------------------------------------------------------------
+
+async def _tournament_with_team(session, team="Alpha", captain="42"):
+    """A registration-open tournament with one registered team."""
+    tournament = await create_tournament(session, "g1", "Spring", 3)
+    await session.commit()
+    participant, _ = await register_team(session, tournament.id, team, captain)
+    await session.commit()
+    return tournament, participant
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_puts_the_player_on_the_roster(test_db):
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+
+        member, created = await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+
+        assert created is True
+        assert member.user_id == "7"
+        assert member.display_name == "Bob"
+        rosters = await get_rosters(session, tournament.id)
+        assert [m.user_id for m in rosters[participant.id]] == ["7"]
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_is_idempotent(test_db):
+    """Re-adding someone already on the roster is a no-op, not a duplicate row."""
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+
+        await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+        member, created = await add_teammate(session, participant, "7", "Bob Renamed")
+        await session.commit()
+
+        assert created is False
+        rosters = await get_rosters(session, tournament.id)
+        assert len(rosters[participant.id]) == 1
+        # The stored snapshot is not overwritten by a later add.
+        assert member.display_name == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_rejects_the_captain(test_db):
+    """The captain is already on the team via captain_user_id."""
+    async with test_db() as session:
+        _, participant = await _tournament_with_team(session, captain="42")
+
+        with pytest.raises(ValueError, match="captain"):
+            await add_teammate(session, participant, "42", "Cap")
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_rejects_a_player_on_another_team(test_db):
+    """A player may only appear on one roster per tournament."""
+    async with test_db() as session:
+        tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
+        bravo, _ = await register_team(session, tournament.id, "Bravo", "99")
+        await session.commit()
+
+        await add_teammate(session, alpha, "7", "Bob")
+        await session.commit()
+
+        with pytest.raises(ValueError, match="Alpha"):
+            await add_teammate(session, bravo, "7", "Bob")
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_allows_the_same_player_in_a_different_tournament(test_db):
+    """The one-team rule is scoped per tournament, not globally."""
+    async with test_db() as session:
+        _, alpha = await _tournament_with_team(session, "Alpha", "42")
+        await add_teammate(session, alpha, "7", "Bob")
+        await session.commit()
+
+        other = await create_tournament(session, "g2", "Autumn", 3)
+        await session.commit()
+        echo, _ = await register_team(session, other.id, "Echo", "55")
+        await session.commit()
+
+        _, created = await add_teammate(session, echo, "7", "Bob")
+        await session.commit()
+        assert created is True
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_rejects_a_completed_tournament(test_db):
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+        tournament.status = "completed"
+        await session.commit()
+
+        with pytest.raises(ValueError, match="completed"):
+            await add_teammate(session, participant, "7", "Bob")
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_allowed_after_the_tournament_starts(test_db):
+    """Rosters stay editable mid-event; only a finished tournament is frozen."""
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+        tournament.status = "active"
+        await session.commit()
+
+        _, created = await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+        assert created is True
+
+
+@pytest.mark.asyncio
+async def test_remove_teammate_takes_the_player_off_the_roster(test_db):
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+        await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+
+        removed = await remove_teammate(session, participant, "7")
+        await session.commit()
+
+        assert removed is True
+        rosters = await get_rosters(session, tournament.id)
+        assert rosters.get(participant.id, []) == []
+
+
+@pytest.mark.asyncio
+async def test_remove_teammate_reports_when_the_player_was_not_on_the_roster(test_db):
+    async with test_db() as session:
+        _, participant = await _tournament_with_team(session)
+
+        assert await remove_teammate(session, participant, "7") is False
+
+
+@pytest.mark.asyncio
+async def test_find_participant_for_captain(test_db):
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session, "Alpha", "42")
+
+        found = await find_participant_for_captain(session, tournament.id, "42")
+        assert found is not None and found.id == participant.id
+        assert await find_participant_for_captain(session, tournament.id, "99") is None
+
+
+@pytest.mark.asyncio
+async def test_get_rosters_groups_by_participant_and_stays_in_its_tournament(test_db):
+    async with test_db() as session:
+        tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
+        bravo, _ = await register_team(session, tournament.id, "Bravo", "99")
+        await session.commit()
+        other = await create_tournament(session, "g2", "Autumn", 3)
+        await session.commit()
+        echo, _ = await register_team(session, other.id, "Echo", "55")
+        await session.commit()
+
+        await add_teammate(session, alpha, "7", "Bob")
+        await add_teammate(session, alpha, "8", "Cara")
+        await add_teammate(session, bravo, "9", "Dan")
+        await add_teammate(session, echo, "10", "Eve")
+        await session.commit()
+
+        rosters = await get_rosters(session, tournament.id)
+        assert sorted(m.user_id for m in rosters[alpha.id]) == ["7", "8"]
+        assert [m.user_id for m in rosters[bravo.id]] == ["9"]
+        assert echo.id not in rosters
+
+
+@pytest.mark.asyncio
+async def test_remove_team_also_deletes_its_roster(test_db):
+    """Dropping a team must not leave its members orphaned behind it."""
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session, "Alpha", "42")
+        await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+
+        await remove_team(session, tournament.id, "Alpha")
+        await session.commit()
+
+        left = (await session.execute(select(TournamentTeamMember))).scalars().all()
+        assert left == []
+
+
+@pytest.mark.asyncio
+async def test_add_teammate_rejects_another_teams_captain(test_db):
+    """A captain is on their own team even with no roster row to say so."""
+    async with test_db() as session:
+        tournament, alpha = await _tournament_with_team(session, "Alpha", "42")
+        await register_team(session, tournament.id, "Bravo", "99")
+        await session.commit()
+
+        with pytest.raises(ValueError, match="Bravo"):
+            await add_teammate(session, alpha, "99", "Cap Two")
+
+
+@pytest.mark.asyncio
+async def test_remove_teammate_rejects_a_completed_tournament(test_db):
+    """Rosters of a finished tournament are a record, so removal is frozen too."""
+    async with test_db() as session:
+        tournament, participant = await _tournament_with_team(session)
+        await add_teammate(session, participant, "7", "Bob")
+        await session.commit()
+        tournament.status = "completed"
+        await session.commit()
+
+        with pytest.raises(ValueError, match="completed"):
+            await remove_teammate(session, participant, "7")


### PR DESCRIPTION
Tournaments recorded only a captain, so the rest of a team existed nowhere in the database and the registration board could only name one person per team.

## What changed

- **New `tournament_team_members` table**, scoped to the tournament participant. `teams.TeamName` is unique across the whole database with **no guild column**, and tournaments run in four guilds — a roster hung off the team row would merge two servers that pick the same name (there are already teams called `Echo` and `Foxtrot`) and would rewrite a finished tournament's roster when that team re-entered a later one.
- **`/tournament add_teammate @player`** and **`/tournament remove_teammate @player`**, captain-owned.
- **The registration board shows the whole team** inline per line — 👑 captain, then members — rather than a line per player, which at 25 teams would quadruple the row count and push the embed past Discord's limits. `/tournament status` renders the same way.
- **Players may be on several teams** in one tournament, and **a user may captain several teams**. Neither was ever a schema rule — `uq_participant_member` is on `(participant_id, user_id)`.
- **`team_registration` is dropped** (separate migration). It was the old league's version of this idea, keyed 1:1 to the globally-unique team name; its last reader went with `league.py` in `81318df`.

## Design notes

**The captain is not stored in the roster.** `captain_user_id` is what escrow charges and what payouts pay, so duplicating it would give money-bearing state two places to disagree. `add_teammate` rejects the team's own captain instead.

**Sharing a player is reported, not blocked** — the reply says "Also on **Bravo** in this tournament", so the overlap stays visible without being forbidden.

**A captain of several teams is asked which one.** `register_team` keys uniqueness on the team, never the captain, so owning two teams was always possible; the roster lookup previously ended in `.first()` and silently edited whichever came back first. It now returns every team they own. A captain may also name a team they own with `team:` — the bot-manager gate applies only to teams they don't captain.

**Two migrations, deliberately.** `rosters01` adds the table (additive, cleanly reversible); `dropteamreg01` drops the legacy one (destructive). Production runs `alembic upgrade head` from `ExecStartPre` with **no backup step** — documented in this branch's CLAUDE.md fix — so an unguarded `DROP TABLE` gets its own reviewable step, and reverting the feature no longer resurrects an orphan table.

## Review findings fixed

A simplify pass and a Codex review pass both ran. Four defects fixed, each with a regression test verified by reverting the fix and watching it fail:

1. **The board reverted to "Registration open"** on any roster edit during an active tournament — rosters stay editable after the start, and the refresh took `closed` from the caller. It's now derived from `tournament.status` and the flag is gone from the call chain.
2. **A large roster overflowed Discord's 1024-char field cap** (measured: 1464 chars). Members share one line and the chunker only splits *between* lines, so it couldn't help — the exact failure the chunker exists to prevent. Capped at 20 names with "+N more".
3. **`add_teammate` was select-then-insert**, so a racing add hit `uq_participant_member` and surfaced as an unhandled `IntegrityError`. The insert now runs in a SAVEPOINT and a lost race returns the existing row as an ordinary duplicate.
4. **The destructive drop was bundled** into the feature migration (above), and a new test file had copied conftest's `test_db` fixture, dropping its restore-the-prior-binding teardown.

## Testing

- 1145 passed, 9 skipped; `pyrefly check` 0 errors.
- Both migrations applied and reversed **independently** against a real database, from a correct `lbgroups01` baseline.
- Driven end-to-end in the test guild twice. The second pass reproduced the multi-team case live: one captain owning Alpha and Bravo, `add_teammate` with no `team` correctly answering "You captain Alpha, Bravo", and `@aber` rostered on both teams with the overlap noted.
- The E2E also caught what tests couldn't: Discord's command picker still described `team` as "Bot managers only", which stopped being true.

Not proven live: a captain naming their own team **without** the bot-manager role — the test account is a manager in that guild. Covered by unit test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw