### PR TITLE
Payout knows the tournament by name, not only by id

### DIFF
--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -325,7 +325,13 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     ``allocations`` is [(place, captain_id, team_name, amount)]. For each, debits the prize
     wallet and credits the captain (an internal transfer, so vault==SUM(wallets) holds).
     Idempotent by source ``payout:<tid>:<place>`` — a re-run books nothing. Refuses to pay
-    more than the pool holds. Returns {ok, already_paid?, paid, total, pool} or {ok:False,error}."""
+    more than the pool holds. Returns {ok, already_paid?, paid, total, pool, tournament_name}
+    or {ok:False,error}.
+
+    ``tournament_name`` is reporting only, never money: it is what lets a caller tell a
+    human WHICH event paid. The id alone is enough to move the tix and no longer enough
+    once the result reaches a log line or a player. It is None if the tournament row is
+    gone — a missing name must not fail a payout."""
     prize_id = prize_wallet_id(tournament_id)
 
     async def _do():
@@ -333,6 +339,8 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
             if await _already_paid(session, tournament_id):
                 return {"ok": True, "already_paid": True}
 
+            tournament = await session.get(Tournament, tournament_id)
+            t_name = tournament.name if tournament is not None else None
             pool = await _pool(session, guild_id, tournament_id)
             total = sum(amount for _, _, _, amount in allocations)
             if total > pool:
@@ -347,9 +355,10 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
                     f"payout:{tournament_id}:{place}",
                     notes=f"tournament prize (place {place}): {team_name}")
             await session.flush()
-            logger.info(f"payout: tournament {tournament_id} distributed {total} tix to "
+            logger.info(f"payout: '{t_name}' ({tournament_id}) distributed {total} tix to "
                         f"{len(allocations)} team(s)")
-            return {"ok": True, "paid": allocations, "total": total, "pool": pool}
+            return {"ok": True, "paid": allocations, "total": total, "pool": pool,
+                    "tournament_name": t_name}
 
     async with wallet_service.MONEY_LOCK:
         return await with_db_retry(_do)

--- a/tests/test_escrow_pending_entries.py
+++ b/tests/test_escrow_pending_entries.py
@@ -181,3 +181,39 @@ async def test_open_registration_boards_is_the_watchdog_backstop(test_db):  # no
 
     assert open_paid in boards and free_id in boards   # every open board gets re-rendered
     assert started_id not in boards                    # a started tournament is frozen
+
+
+# ---- payout identifies the tournament by name, not just id ----------------------
+
+@pytest.mark.asyncio
+async def test_payout_reports_the_tournament_name(test_db):  # noqa: F811
+    """execute_payout knew the tournament only as an integer id, so its log line and its
+    result could not say which event paid. Callers that report a payout to a human — the
+    operator reading logs, and a prize DM — need the name."""
+    t_id, _ = await _paid_tournament(fee=2, status="active", team="Roto Chaff")
+    await wallet_service.credit_done(GUILD, CAPTAIN, 2, job_id="j-pool")
+    await escrow.secure_from_wallet(GUILD, CAPTAIN, 1, t_id, 2, "Roto Chaff")
+
+    res = await escrow.execute_payout(GUILD, t_id, [(1, CAPTAIN, "Roto Chaff", 2)])
+
+    assert res["ok"]
+    assert res["tournament_name"] == "Fee Cup"
+
+
+@pytest.mark.asyncio
+async def test_payout_name_is_absent_when_the_row_cannot_be_read(test_db):  # noqa: F811
+    """The name is reporting, not money: if the row can't be read the payout still pays.
+
+    Nothing deletes a Tournament today, so this reaches the None branch the only way it
+    can be reached — by removing the row, which the test database permits because FK
+    enforcement is off. It pins the defensive behaviour, not a race that happens."""
+    t_id, _ = await _paid_tournament(fee=2, status="active")
+    await wallet_service.credit_done(GUILD, CAPTAIN, 2, job_id="j-pool2")
+    await escrow.secure_from_wallet(GUILD, CAPTAIN, 1, t_id, 2, "Pending Squad")
+    async with db_session() as session:
+        await session.delete(await session.get(Tournament, t_id))
+
+    res = await escrow.execute_payout(GUILD, t_id, [(1, CAPTAIN, "Pending Squad", 2)])
+
+    assert res["ok"]
+    assert res["tournament_name"] is None


### PR DESCRIPTION
`execute_payout` took a `tournament_id` and never resolved it, so the only thing it could tell a human was a number. Its log line read:

```
payout: tournament 3 distributed 150 tix to 2 team(s)
```

and its result carried nothing a caller could put in front of a player. One `session.get` in the transaction it already opens fixes both:

```
payout: 'Lotus League 2026' (3) distributed 150 tix to 2 team(s)
```

## Notes

**Reporting only, never money.** The id alone is enough to move the tix; the name exists for the moment a result reaches a log line or a player. A missing row yields `None` rather than failing a payout — the guard covers a wrong or stale `tournament_id`, since nothing in the codebase deletes a `Tournament`.

**Placement.** The read sits after the `_already_paid` short-circuit and inside `_do()`, so it's skipped entirely on a re-run and is safe under `with_db_retry` (a pure read). It adds one indexed lookup by primary key per payout confirmation — O(1), not per-allocation.

**Why its own branch.** It stands alone: naming the event in the operator's log is worth having regardless of anything downstream. A stacked branch builds a prize DM on top of the returned name, but nothing here depends on that.

## Testing

- 1147 passed, 9 skipped; `pyrefly check` 0 errors.
- Two new tests: the name is threaded into the result, and an unreadable row degrades to `None` instead of failing the payout.
- Reviewed twice — the second pass found only a test docstring that framed the `None` case as a deletion race, which it isn't; the test now says it pins defensive behaviour and how it reaches that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw