### PR TITLE
DM people when their wallet moves

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -3,6 +3,8 @@ Notification service for sending DMs and other notifications to users.
 """
 
 import asyncio
+import functools
+
 import discord
 from loguru import logger
 from helpers.display_names import get_member_name_plain
@@ -220,9 +222,45 @@ async def send_settlement_notification_dm(
 #
 # Every one of these is best-effort: the money has already moved by the time we
 # are called, so a failed DM must never turn a completed transfer into an error.
-# send_dm already swallows Discord errors; the broad guards below cover the name
-# and guild lookups too.
+# send_dm already swallows Discord errors; @_best_effort covers the name and guild
+# lookups too, so each notifier below reads as its message and nothing else.
 # ---------------------------------------------------------------------------
+
+def _best_effort(fn):
+    """Swallow and log anything a wallet notifier raises.
+
+    The guard belongs here rather than only at the dispatcher, because these are
+    called directly too (notify_wallet is not the only entry point -- tests and any
+    caller holding a bot can call them). One decorator rather than a hand-copied
+    try/except per notifier, which is how one of them ends up subtly different."""
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await fn(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001 - a DM must never break the money path
+            logger.warning(f"{fn.__name__} failed: {e}")
+    return wrapper
+
+
+async def notify_wallet(fn_name: str, *args, **kwargs) -> None:
+    """Fire a wallet DM from a service that has no bot of its own, best-effort.
+
+    The bot comes from bot_registry the way draft_setup_manager does. Lives here, with
+    the notifiers it dispatches to, rather than inside one of the services that calls
+    it -- tournament_escrow_service and mtgo_resolution_service both need it, and a
+    sibling service reaching into another's private name is how that drifts.
+
+    Callers import this lazily: notification_service pulls in discord and a chain of
+    helpers, while the services are imported by tests and by alembic's env at
+    migration time, where a missing bot must not matter."""
+    try:
+        from bot_registry import get_bot
+        bot = get_bot()
+        if bot is None:   # no bot registered (tests, migrations, CLI) — nothing to do
+            return
+        await globals()[fn_name](bot, *args, **kwargs)
+    except Exception as e:  # noqa: BLE001 - notification must never break the money path
+        logger.warning(f"notify_wallet: {fn_name} failed: {e}")
 
 def _wallet_name(bot, guild_id: str, user_id: str) -> str:
     """Display name for a wallet party, falling back to "User <id>" when the guild
@@ -236,71 +274,63 @@ def _wallet_name(bot, guild_id: str, user_id: str) -> str:
     return f"User {user_id}"
 
 
+@_best_effort
 async def notify_payment_received(bot, guild_id: str, recipient_id: str, sender_id: str,
                                   amount: int, note: str = None):
     """Someone's tix landed in your wallet."""
-    try:
-        sender = _wallet_name(bot, guild_id, sender_id)
-        msg = f"💸 You received **{amount} tix** from {sender}."
-        if note:
-            msg += f" ({note})"
-        await send_dm(bot, recipient_id, msg, label=f"payment to {recipient_id}")
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"notify_payment_received failed for {recipient_id}: {e}")
+    sender = _wallet_name(bot, guild_id, sender_id)
+    msg = f"💸 You received **{amount} tix** from {sender}."
+    if note:
+        msg += f" ({note})"
+    await send_dm(bot, recipient_id, msg, label=f"payment to {recipient_id}")
 
 
+@_best_effort
 async def notify_auto_settlement(bot, guild_id: str, payer_id: str, creditor_id: str,
                                  amount: int, remaining: int = None):
     """A debt was settled automatically out of the payer's wallet. BOTH sides are told,
     because neither of them initiated it — that is the whole point of auto-draw."""
-    try:
-        payer = _wallet_name(bot, guild_id, payer_id)
-        creditor = _wallet_name(bot, guild_id, creditor_id)
+    payer = _wallet_name(bot, guild_id, payer_id)
+    creditor = _wallet_name(bot, guild_id, creditor_id)
 
-        owed = ""
-        if remaining is not None:
-            owed = (f" You still owe them **{remaining} tix**."
-                    if remaining > 0 else " That clears your debt with them.")
-        await send_dm(bot, payer_id,
-                      f"🤝 **{amount} tix** from your wallet went to {creditor} to settle "
-                      f"what you owed.{owed}",
-                      label=f"auto-settle payer {payer_id}")
+    owed = ""
+    if remaining is not None:
+        owed = (f" You still owe them **{remaining} tix**."
+                if remaining > 0 else " That clears your debt with them.")
+    await send_dm(bot, payer_id,
+                  f"🤝 **{amount} tix** from your wallet went to {creditor} to settle "
+                  f"what you owed.{owed}",
+                  label=f"auto-settle payer {payer_id}")
 
-        owed_c = ""
-        if remaining is not None:
-            owed_c = (f" They still owe you **{remaining} tix**."
-                      if remaining > 0 else " You are now fully settled.")
-        await send_dm(bot, creditor_id,
-                      f"🤝 You received **{amount} tix** from {payer} — automatically "
-                      f"applied from their wallet against what they owed you.{owed_c}",
-                      label=f"auto-settle creditor {creditor_id}")
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"notify_auto_settlement failed for {payer_id}->{creditor_id}: {e}")
+    owed_c = ""
+    if remaining is not None:
+        owed_c = (f" They still owe you **{remaining} tix**."
+                  if remaining > 0 else " You are now fully settled.")
+    await send_dm(bot, creditor_id,
+                  f"🤝 You received **{amount} tix** from {payer} — automatically "
+                  f"applied from their wallet against what they owed you.{owed_c}",
+                  label=f"auto-settle creditor {creditor_id}")
 
 
+@_best_effort
 async def notify_tournament_payout(bot, guild_id: str, captain_id: str, amount: int,
                                    place=None, tournament_name: str = None):
     """A prize landed in a captain's wallet."""
-    try:
-        where = f" for place {place}" if place is not None else ""
-        which = f" in **{tournament_name}**" if tournament_name else ""
-        await send_dm(bot, captain_id,
-                      f"🏆 You received **{amount} tix**{where}{which}.",
-                      label=f"payout {captain_id}")
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"notify_tournament_payout failed for {captain_id}: {e}")
+    where = f" for place {place}" if place is not None else ""
+    which = f" in **{tournament_name}**" if tournament_name else ""
+    await send_dm(bot, captain_id,
+                  f"🏆 You received **{amount} tix**{where}{which}.",
+                  label=f"payout {captain_id}")
 
 
+@_best_effort
 async def notify_entry_refund(bot, guild_id: str, captain_id: str, amount: int,
                               team_name: str = None):
     """An entry fee came back out of the prize pool."""
-    try:
-        which = f" for **{team_name}**" if team_name else ""
-        await send_dm(bot, captain_id,
-                      f"↩️ Your tournament entry fee of **{amount} tix**{which} has been refunded.",
-                      label=f"refund {captain_id}")
-    except Exception as e:  # noqa: BLE001
-        logger.warning(f"notify_entry_refund failed for {captain_id}: {e}")
+    which = f" for **{team_name}**" if team_name else ""
+    await send_dm(bot, captain_id,
+                  f"↩️ Your tournament entry fee of **{amount} tix**{which} has been refunded.",
+                  label=f"refund {captain_id}")
 
 
 async def send_ready_check_dms(bot_or_client, draft_session, guild_id, channel_id, channel_name, guild_name):

--- a/notification_service.py
+++ b/notification_service.py
@@ -314,12 +314,20 @@ async def notify_auto_settlement(bot, guild_id: str, payer_id: str, creditor_id:
 
 @_best_effort
 async def notify_tournament_payout(bot, guild_id: str, captain_id: str, amount: int,
-                                   place=None, tournament_name: str = None):
-    """A prize landed in a captain's wallet."""
+                                   place=None, tournament_name: str = None,
+                                   team_name: str = None):
+    """A prize landed in a captain's wallet.
+
+    Names the tournament AND the team. A captain can be entered in more than one event,
+    and the prize was won by a particular team of theirs, so either name alone leaves
+    them guessing which. Both are optional and each clause simply drops when its name is
+    missing -- execute_payout yields no tournament name if the row has been deleted, and
+    the DM should not read "in **None**"."""
     where = f" for place {place}" if place is not None else ""
+    with_team = f" with **{team_name}**" if team_name else ""
     which = f" in **{tournament_name}**" if tournament_name else ""
     await send_dm(bot, captain_id,
-                  f"🏆 You received **{amount} tix**{where}{which}.",
+                  f"🏆 You received **{amount} tix**{where}{with_team}{which}.",
                   label=f"payout {captain_id}")
 
 

--- a/notification_service.py
+++ b/notification_service.py
@@ -242,8 +242,13 @@ def _best_effort(fn):
     return wrapper
 
 
-async def notify_wallet(fn_name: str, *args, **kwargs) -> None:
-    """Fire a wallet DM from a service that has no bot of its own, best-effort.
+async def notify_wallet(notifier, *args, **kwargs) -> None:
+    """Supply the bot a notifier needs, from a service that has none. Best-effort.
+
+    Takes the notifier itself, not its name: the call sites already import this module
+    to reach notify_wallet, so importing the notifier alongside it costs nothing extra,
+    and a real reference is one that grep and rename can see and that fails at import
+    rather than becoming a swallowed KeyError at the moment of paying someone.
 
     The bot comes from bot_registry the way draft_setup_manager does. Lives here, with
     the notifiers it dispatches to, rather than inside one of the services that calls
@@ -252,15 +257,18 @@ async def notify_wallet(fn_name: str, *args, **kwargs) -> None:
 
     Callers import this lazily: notification_service pulls in discord and a chain of
     helpers, while the services are imported by tests and by alembic's env at
-    migration time, where a missing bot must not matter."""
+    migration time, where a missing bot must not matter.
+
+    The guard below is narrower than it looks: every notifier is already @_best_effort,
+    so what it actually covers is the bot lookup."""
     try:
         from bot_registry import get_bot
         bot = get_bot()
         if bot is None:   # no bot registered (tests, migrations, CLI) — nothing to do
             return
-        await globals()[fn_name](bot, *args, **kwargs)
+        await notifier(bot, *args, **kwargs)
     except Exception as e:  # noqa: BLE001 - notification must never break the money path
-        logger.warning(f"notify_wallet: {fn_name} failed: {e}")
+        logger.warning(f"notify_wallet: {getattr(notifier, '__name__', notifier)} failed: {e}")
 
 def _wallet_name(bot, guild_id: str, user_id: str) -> str:
     """Display name for a wallet party, falling back to "User <id>" when the guild
@@ -285,6 +293,17 @@ async def notify_payment_received(bot, guild_id: str, recipient_id: str, sender_
     await send_dm(bot, recipient_id, msg, label=f"payment to {recipient_id}")
 
 
+def _owed_clause(remaining, owes_phrase: str, settled_phrase: str) -> str:
+    """The "and here is where you stand now" tail of a settlement DM.
+
+    Both sides say the same thing from opposite ends, so the shape lives here once
+    rather than mirrored twice a few lines apart, where a later wording change would
+    have to be made in both and kept in step by eye."""
+    if remaining is None:
+        return ""
+    return f" {owes_phrase} **{remaining} tix**." if remaining > 0 else f" {settled_phrase}"
+
+
 @_best_effort
 async def notify_auto_settlement(bot, guild_id: str, payer_id: str, creditor_id: str,
                                  amount: int, remaining: int = None):
@@ -293,19 +312,13 @@ async def notify_auto_settlement(bot, guild_id: str, payer_id: str, creditor_id:
     payer = _wallet_name(bot, guild_id, payer_id)
     creditor = _wallet_name(bot, guild_id, creditor_id)
 
-    owed = ""
-    if remaining is not None:
-        owed = (f" You still owe them **{remaining} tix**."
-                if remaining > 0 else " That clears your debt with them.")
+    owed = _owed_clause(remaining, "You still owe them", "That clears your debt with them.")
     await send_dm(bot, payer_id,
                   f"🤝 **{amount} tix** from your wallet went to {creditor} to settle "
                   f"what you owed.{owed}",
                   label=f"auto-settle payer {payer_id}")
 
-    owed_c = ""
-    if remaining is not None:
-        owed_c = (f" They still owe you **{remaining} tix**."
-                  if remaining > 0 else " You are now fully settled.")
+    owed_c = _owed_clause(remaining, "They still owe you", "You are now fully settled.")
     await send_dm(bot, creditor_id,
                   f"🤝 You received **{amount} tix** from {payer} — automatically "
                   f"applied from their wallet against what they owed you.{owed_c}",

--- a/notification_service.py
+++ b/notification_service.py
@@ -208,6 +208,101 @@ async def send_settlement_notification_dm(
     await send_dm(bot, other_id, msg, label=f"settlement notify {other_id}")
 
 
+# ---------------------------------------------------------------------------
+# Wallet movements
+#
+# These follow send_settlement_notification_dm rather than _send_notification_dms:
+# they deliberately do NOT consult the DM notification preference. That preference
+# defaults to OFF and exists to damp draft-flow chatter (ready checks, teams
+# created); a movement of someone's tix is consequential and is usually something
+# they did NOT initiate, so it is reported regardless. If that judgement is wrong
+# it is a policy call to reverse here, not an oversight.
+#
+# Every one of these is best-effort: the money has already moved by the time we
+# are called, so a failed DM must never turn a completed transfer into an error.
+# send_dm already swallows Discord errors; the broad guards below cover the name
+# and guild lookups too.
+# ---------------------------------------------------------------------------
+
+def _wallet_name(bot, guild_id: str, user_id: str) -> str:
+    """Display name for a wallet party, falling back to "User <id>" when the guild
+    or member is not in cache (services run outside any guild context)."""
+    try:
+        guild = bot.get_guild(int(guild_id))
+        if guild is not None:
+            return get_member_name_plain(guild, user_id)
+    except Exception:  # noqa: BLE001 - naming must never break a notification
+        pass
+    return f"User {user_id}"
+
+
+async def notify_payment_received(bot, guild_id: str, recipient_id: str, sender_id: str,
+                                  amount: int, note: str = None):
+    """Someone's tix landed in your wallet."""
+    try:
+        sender = _wallet_name(bot, guild_id, sender_id)
+        msg = f"💸 You received **{amount} tix** from {sender}."
+        if note:
+            msg += f" ({note})"
+        await send_dm(bot, recipient_id, msg, label=f"payment to {recipient_id}")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"notify_payment_received failed for {recipient_id}: {e}")
+
+
+async def notify_auto_settlement(bot, guild_id: str, payer_id: str, creditor_id: str,
+                                 amount: int, remaining: int = None):
+    """A debt was settled automatically out of the payer's wallet. BOTH sides are told,
+    because neither of them initiated it — that is the whole point of auto-draw."""
+    try:
+        payer = _wallet_name(bot, guild_id, payer_id)
+        creditor = _wallet_name(bot, guild_id, creditor_id)
+
+        owed = ""
+        if remaining is not None:
+            owed = (f" You still owe them **{remaining} tix**."
+                    if remaining > 0 else " That clears your debt with them.")
+        await send_dm(bot, payer_id,
+                      f"🤝 **{amount} tix** from your wallet went to {creditor} to settle "
+                      f"what you owed.{owed}",
+                      label=f"auto-settle payer {payer_id}")
+
+        owed_c = ""
+        if remaining is not None:
+            owed_c = (f" They still owe you **{remaining} tix**."
+                      if remaining > 0 else " You are now fully settled.")
+        await send_dm(bot, creditor_id,
+                      f"🤝 You received **{amount} tix** from {payer} — automatically "
+                      f"applied from their wallet against what they owed you.{owed_c}",
+                      label=f"auto-settle creditor {creditor_id}")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"notify_auto_settlement failed for {payer_id}->{creditor_id}: {e}")
+
+
+async def notify_tournament_payout(bot, guild_id: str, captain_id: str, amount: int,
+                                   place=None, tournament_name: str = None):
+    """A prize landed in a captain's wallet."""
+    try:
+        where = f" for place {place}" if place is not None else ""
+        which = f" in **{tournament_name}**" if tournament_name else ""
+        await send_dm(bot, captain_id,
+                      f"🏆 You received **{amount} tix**{where}{which}.",
+                      label=f"payout {captain_id}")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"notify_tournament_payout failed for {captain_id}: {e}")
+
+
+async def notify_entry_refund(bot, guild_id: str, captain_id: str, amount: int,
+                              team_name: str = None):
+    """An entry fee came back out of the prize pool."""
+    try:
+        which = f" for **{team_name}**" if team_name else ""
+        await send_dm(bot, captain_id,
+                      f"↩️ Your tournament entry fee of **{amount} tix**{which} has been refunded.",
+                      label=f"refund {captain_id}")
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"notify_entry_refund failed for {captain_id}: {e}")
+
+
 async def send_ready_check_dms(bot_or_client, draft_session, guild_id, channel_id, channel_name, guild_name):
     """
     Send DM notifications to users who have DM notifications enabled for a ready check.

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -315,7 +315,7 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     # Receiving money is the case you are least likely to be watching for.
     from notification_service import notify_wallet, notify_payment_received
     await notify_wallet(notify_payment_received, guild_id, to_player, from_player, amount,
-                         note=notes)
+                        note=notes)
     return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
 
 
@@ -424,10 +424,15 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
             settlements.append(res)
             # Neither party asked for this — it fired off a deposit — so tell both.
             # Reports what is STILL owed after this leg, not the original debt.
-            from notification_service import notify_wallet, notify_auto_settlement
-            await notify_wallet(
-                notify_auto_settlement, guild_id, player_id, cp, pay_amt,
-                remaining=max(0, owed[cp] - pay_amt))
+            # Not on an idempotent replay: that moved no money, and announcing it would
+            # tell two people they were paid again. Mirrors execute_payout's
+            # already_paid guard. Unreachable while auto_draw passes no link_id, which
+            # is exactly when a guard is cheap to add.
+            if not res.get("idempotent"):
+                from notification_service import notify_wallet, notify_auto_settlement
+                await notify_wallet(
+                    notify_auto_settlement, guild_id, player_id, cp, pay_amt,
+                    remaining=max(0, owed[cp] - pay_amt))
         else:
             logger.warning(f"auto_draw: settle {player_id}->{cp} {pay_amt} skipped: {res.get('error')}")
     if settlements:

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -313,8 +313,8 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     except ValueError as e:
         return {"ok": False, "error": str(e)}
     # Receiving money is the case you are least likely to be watching for.
-    from notification_service import notify_wallet
-    await notify_wallet("notify_payment_received", guild_id, to_player, from_player, amount,
+    from notification_service import notify_wallet, notify_payment_received
+    await notify_wallet(notify_payment_received, guild_id, to_player, from_player, amount,
                          note=notes)
     return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
 
@@ -424,9 +424,9 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
             settlements.append(res)
             # Neither party asked for this — it fired off a deposit — so tell both.
             # Reports what is STILL owed after this leg, not the original debt.
-            from notification_service import notify_wallet
+            from notification_service import notify_wallet, notify_auto_settlement
             await notify_wallet(
-                "notify_auto_settlement", guild_id, player_id, cp, pay_amt,
+                notify_auto_settlement, guild_id, player_id, cp, pay_amt,
                 remaining=max(0, owed[cp] - pay_amt))
         else:
             logger.warning(f"auto_draw: settle {player_id}->{cp} {pay_amt} skipped: {res.get('error')}")

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -313,7 +313,8 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     except ValueError as e:
         return {"ok": False, "error": str(e)}
     # Receiving money is the case you are least likely to be watching for.
-    await _notify_wallet("notify_payment_received", guild_id, to_player, from_player, amount,
+    from notification_service import notify_wallet
+    await notify_wallet("notify_payment_received", guild_id, to_player, from_player, amount,
                          note=notes)
     return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
 
@@ -384,28 +385,6 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
         return await with_db_retry(_do)
 
 
-async def _notify_wallet(fn_name: str, *args, **kwargs) -> None:
-    """Fire a wallet DM from a service, best-effort.
-
-    Services have no bot, so it comes from bot_registry the way draft_setup_manager
-    does. Imports are deferred: notification_service pulls in discord and a chain of
-    helpers, and these services are imported by tests and by alembic's env at
-    migration time, where a missing bot must not matter.
-
-    NOTHING here may raise. The money has already moved by the time we are called —
-    a DM failure must never turn a completed transfer into an error, and must never
-    abort the loop that is still settling other creditors."""
-    try:
-        from bot_registry import get_bot
-        bot = get_bot()
-        if bot is None:   # no bot registered (tests, migrations, CLI) — nothing to do
-            return
-        import notification_service
-        await getattr(notification_service, fn_name)(bot, *args, **kwargs)
-    except Exception as e:  # noqa: BLE001 - notification must never break the money path
-        logger.warning(f"_notify_wallet: {fn_name} failed: {e}")
-
-
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
     """Apply a player's wallet balance to their outstanding debts, oldest debt first,
     until the wallet is exhausted or the debts are cleared. Returns the settlements made.
@@ -445,7 +424,8 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
             settlements.append(res)
             # Neither party asked for this — it fired off a deposit — so tell both.
             # Reports what is STILL owed after this leg, not the original debt.
-            await _notify_wallet(
+            from notification_service import notify_wallet
+            await notify_wallet(
                 "notify_auto_settlement", guild_id, player_id, cp, pay_amt,
                 remaining=max(0, owed[cp] - pay_amt))
         else:

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -310,9 +310,12 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     """Move tix between two wallets with no MTGO trade (a plain claim transfer)."""
     try:
         debit, credit = await wallet_service.pay(guild_id, from_player, to_player, amount, notes=notes)
-        return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
     except ValueError as e:
         return {"ok": False, "error": str(e)}
+    # Receiving money is the case you are least likely to be watching for.
+    await _notify_wallet("notify_payment_received", guild_id, to_player, from_player, amount,
+                         note=notes)
+    return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
 
 
 # ---------------------------------------------------------------------------
@@ -381,6 +384,28 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
         return await with_db_retry(_do)
 
 
+async def _notify_wallet(fn_name: str, *args, **kwargs) -> None:
+    """Fire a wallet DM from a service, best-effort.
+
+    Services have no bot, so it comes from bot_registry the way draft_setup_manager
+    does. Imports are deferred: notification_service pulls in discord and a chain of
+    helpers, and these services are imported by tests and by alembic's env at
+    migration time, where a missing bot must not matter.
+
+    NOTHING here may raise. The money has already moved by the time we are called —
+    a DM failure must never turn a completed transfer into an error, and must never
+    abort the loop that is still settling other creditors."""
+    try:
+        from bot_registry import get_bot
+        bot = get_bot()
+        if bot is None:   # no bot registered (tests, migrations, CLI) — nothing to do
+            return
+        import notification_service
+        await getattr(notification_service, fn_name)(bot, *args, **kwargs)
+    except Exception as e:  # noqa: BLE001 - notification must never break the money path
+        logger.warning(f"_notify_wallet: {fn_name} failed: {e}")
+
+
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
     """Apply a player's wallet balance to their outstanding debts, oldest debt first,
     until the wallet is exhausted or the debts are cleared. Returns the settlements made.
@@ -418,6 +443,11 @@ async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
         if res.get("ok"):
             available -= pay_amt
             settlements.append(res)
+            # Neither party asked for this — it fired off a deposit — so tell both.
+            # Reports what is STILL owed after this leg, not the original debt.
+            await _notify_wallet(
+                "notify_auto_settlement", guild_id, player_id, cp, pay_amt,
+                remaining=max(0, owed[cp] - pay_amt))
         else:
             logger.warning(f"auto_draw: settle {player_id}->{cp} {pay_amt} skipped: {res.get('error')}")
     if settlements:

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -380,5 +380,6 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
         for place, captain_id, team_name, amount in allocations:
             if amount > 0:
                 await notify_wallet("notify_tournament_payout", guild_id, captain_id,
-                                     amount, place=place, tournament_name=team_name)
+                                    amount, place=place, team_name=team_name,
+                                    tournament_name=result.get("tournament_name"))
     return result

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -297,8 +297,8 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
 
     # AFTER the lock (see execute_payout).
     if refunded:
-        from notification_service import notify_wallet
-        await notify_wallet("notify_entry_refund", guild_id, captain_id, refunded,
+        from notification_service import notify_wallet, notify_entry_refund
+        await notify_wallet(notify_entry_refund, guild_id, captain_id, refunded,
                              team_name=dropped_name)
     return result
 
@@ -376,10 +376,10 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     # AFTER the lock: DMs are network I/O and have no business holding the money lock.
     # Skipped on the already_paid short-circuit, so a re-run cannot re-announce prizes.
     if result.get("ok") and not result.get("already_paid"):
-        from notification_service import notify_wallet
+        from notification_service import notify_wallet, notify_tournament_payout
         for place, captain_id, team_name, amount in allocations:
             if amount > 0:
-                await notify_wallet("notify_tournament_payout", guild_id, captain_id,
+                await notify_wallet(notify_tournament_payout, guild_id, captain_id,
                                     amount, place=place, team_name=team_name,
                                     tournament_name=result.get("tournament_name"))
     return result

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -299,7 +299,7 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
     if refunded:
         from notification_service import notify_wallet, notify_entry_refund
         await notify_wallet(notify_entry_refund, guild_id, captain_id, refunded,
-                             team_name=dropped_name)
+                            team_name=dropped_name)
     return result
 
 

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -297,8 +297,8 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
 
     # AFTER the lock (see execute_payout).
     if refunded:
-        from services.mtgo_resolution_service import _notify_wallet
-        await _notify_wallet("notify_entry_refund", guild_id, captain_id, refunded,
+        from notification_service import notify_wallet
+        await notify_wallet("notify_entry_refund", guild_id, captain_id, refunded,
                              team_name=dropped_name)
     return result
 
@@ -376,9 +376,9 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     # AFTER the lock: DMs are network I/O and have no business holding the money lock.
     # Skipped on the already_paid short-circuit, so a re-run cannot re-announce prizes.
     if result.get("ok") and not result.get("already_paid"):
-        from services.mtgo_resolution_service import _notify_wallet
+        from notification_service import notify_wallet
         for place, captain_id, team_name, amount in allocations:
             if amount > 0:
-                await _notify_wallet("notify_tournament_payout", guild_id, captain_id,
+                await notify_wallet("notify_tournament_payout", guild_id, captain_id,
                                      amount, place=place, tournament_name=team_name)
     return result

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -287,10 +287,20 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
         async with db_session() as session:
             p = await remove_team(session, tournament_id, team_name)
             tournament = await session.get(Tournament, tournament_id)
-            refunded = await refund_entry(session, str(tournament.guild_id), tournament_id, p)
-            logger.info(f"escrow: dropped '{p.team_name}' from tournament {tournament_id} "
+            guild_id = str(tournament.guild_id)
+            captain_id = str(p.captain_user_id)
+            dropped_name = p.team_name
+            refunded = await refund_entry(session, guild_id, tournament_id, p)
+            logger.info(f"escrow: dropped '{dropped_name}' from tournament {tournament_id} "
                         f"(refunded {refunded})")
-            return {"team_name": p.team_name, "refunded": refunded}
+            result = {"team_name": dropped_name, "refunded": refunded}
+
+    # AFTER the lock (see execute_payout).
+    if refunded:
+        from services.mtgo_resolution_service import _notify_wallet
+        await _notify_wallet("notify_entry_refund", guild_id, captain_id, refunded,
+                             team_name=dropped_name)
+    return result
 
 
 async def _pool(session, guild_id: str, tournament_id: int) -> int:
@@ -361,4 +371,14 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
                     "tournament_name": t_name}
 
     async with wallet_service.MONEY_LOCK:
-        return await with_db_retry(_do)
+        result = await with_db_retry(_do)
+
+    # AFTER the lock: DMs are network I/O and have no business holding the money lock.
+    # Skipped on the already_paid short-circuit, so a re-run cannot re-announce prizes.
+    if result.get("ok") and not result.get("already_paid"):
+        from services.mtgo_resolution_service import _notify_wallet
+        for place, captain_id, team_name, amount in allocations:
+            if amount > 0:
+                await _notify_wallet("notify_tournament_payout", guild_id, captain_id,
+                                     amount, place=place, tournament_name=team_name)
+    return result

--- a/tests/test_wallet_notification_dms.py
+++ b/tests/test_wallet_notification_dms.py
@@ -80,13 +80,33 @@ async def test_auto_settlement_reports_a_cleared_debt():
 
 
 @pytest.mark.asyncio
-async def test_payout_and_refund_messages():
+async def test_payout_names_both_the_tournament_and_the_team():
+    """A captain can be in more than one tournament, and the prize is won BY a team --
+    naming only one of the two leaves the DM ambiguous about which event paid."""
     with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
         await notify_tournament_payout(_make_bot(), GUILD_ID, PAYER_ID, 100, place=1,
-                                       tournament_name="Team Rocket")
+                                       tournament_name="Lotus League 2026",
+                                       team_name="Roto Chaff")
+    payout = _sent(send)[0][1]
+    assert "100 tix" in payout and "place 1" in payout
+    assert "Lotus League 2026" in payout and "Roto Chaff" in payout
+
+
+@pytest.mark.asyncio
+async def test_payout_message_survives_a_missing_name():
+    """execute_payout yields tournament_name=None if the row is gone; the DM still sends."""
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_tournament_payout(_make_bot(), GUILD_ID, PAYER_ID, 100, place=1,
+                                       tournament_name=None, team_name="Roto Chaff")
+    payout = _sent(send)[0][1]
+    assert "100 tix" in payout and "Roto Chaff" in payout and "None" not in payout
+
+
+@pytest.mark.asyncio
+async def test_refund_message():
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
         await notify_entry_refund(_make_bot(), GUILD_ID, PAYER_ID, 20, team_name="Team Rocket")
-    payout, refund = [m for _, m in _sent(send)]
-    assert "100 tix" in payout and "place 1" in payout and "Team Rocket" in payout
+    refund = _sent(send)[0][1]
     assert "20 tix" in refund and "refunded" in refund
 
 

--- a/tests/test_wallet_notification_dms.py
+++ b/tests/test_wallet_notification_dms.py
@@ -137,7 +137,8 @@ async def test_notify_wallet_is_a_no_op_without_a_registered_bot():
     """Tests, migrations and CLI runs have no bot; the money path must not care."""
     from notification_service import notify_wallet
     with patch("bot_registry.get_bot", return_value=None):
-        await notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+        await notify_wallet(notification_service.notify_payment_received,
+                            GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
 
 
 @pytest.mark.asyncio
@@ -146,4 +147,5 @@ async def test_notify_wallet_swallows_a_broken_notifier():
     with patch("bot_registry.get_bot", return_value=MagicMock()), \
          patch.object(notification_service, "notify_payment_received",
                       new=AsyncMock(side_effect=RuntimeError("boom"))):
-        await notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+        await notify_wallet(notification_service.notify_payment_received,
+                            GUILD_ID, CREDITOR_ID, PAYER_ID, 25)

--- a/tests/test_wallet_notification_dms.py
+++ b/tests/test_wallet_notification_dms.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for wallet movement DM notifications.
+
+Covers the message content of the wallet notifiers, and the contract that matters
+most in money code: a failing DM must never propagate out of a money path. The
+transfer has already committed by the time these run.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import notification_service
+from notification_service import (
+    notify_auto_settlement,
+    notify_entry_refund,
+    notify_payment_received,
+    notify_tournament_payout,
+)
+
+GUILD_ID = "guild_1"
+PAYER_ID = "payer_A"
+CREDITOR_ID = "creditor_B"
+
+
+def _make_bot():
+    """A bot whose guild lookup yields no members, so names fall back to "User <id>"."""
+    bot = MagicMock()
+    guild = MagicMock()
+    guild.get_member.return_value = None
+    bot.get_guild.return_value = guild
+    return bot
+
+
+def _sent(mock_send):
+    """[(user_id, message)] for each send_dm call."""
+    return [(c.args[1], c.args[2]) for c in mock_send.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_payment_received_names_the_sender_and_amount():
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_payment_received(_make_bot(), GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+    (recipient, msg), = _sent(send)
+    assert recipient == CREDITOR_ID
+    assert "25 tix" in msg
+    assert PAYER_ID in msg          # falls back to "User payer_A"
+
+
+@pytest.mark.asyncio
+async def test_payment_received_includes_the_note_when_given():
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_payment_received(_make_bot(), GUILD_ID, CREDITOR_ID, PAYER_ID, 5,
+                                      note="draft payout")
+    (_, msg), = _sent(send)
+    assert "draft payout" in msg
+
+
+@pytest.mark.asyncio
+async def test_auto_settlement_tells_BOTH_parties():
+    """Neither side initiates an auto-draw, so both have to be told."""
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_auto_settlement(_make_bot(), GUILD_ID, PAYER_ID, CREDITOR_ID, 30,
+                                     remaining=20)
+    sent = _sent(send)
+    assert {u for u, _ in sent} == {PAYER_ID, CREDITOR_ID}
+    payer_msg = next(m for u, m in sent if u == PAYER_ID)
+    creditor_msg = next(m for u, m in sent if u == CREDITOR_ID)
+    assert "30 tix" in payer_msg and "30 tix" in creditor_msg
+    assert "still owe them" in payer_msg
+    assert "still owe you" in creditor_msg
+
+
+@pytest.mark.asyncio
+async def test_auto_settlement_reports_a_cleared_debt():
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_auto_settlement(_make_bot(), GUILD_ID, PAYER_ID, CREDITOR_ID, 30,
+                                     remaining=0)
+    sent = dict(_sent(send))
+    assert "clears your debt" in sent[PAYER_ID]
+    assert "fully settled" in sent[CREDITOR_ID]
+
+
+@pytest.mark.asyncio
+async def test_payout_and_refund_messages():
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_tournament_payout(_make_bot(), GUILD_ID, PAYER_ID, 100, place=1,
+                                       tournament_name="Team Rocket")
+        await notify_entry_refund(_make_bot(), GUILD_ID, PAYER_ID, 20, team_name="Team Rocket")
+    payout, refund = [m for _, m in _sent(send)]
+    assert "100 tix" in payout and "place 1" in payout and "Team Rocket" in payout
+    assert "20 tix" in refund and "refunded" in refund
+
+
+@pytest.mark.asyncio
+async def test_a_failing_dm_never_propagates():
+    """The money has already moved; a DM failure must not surface as an error."""
+    boom = AsyncMock(side_effect=RuntimeError("discord is down"))
+    with patch.object(notification_service, "send_dm", new=boom):
+        await notify_payment_received(_make_bot(), GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+        await notify_auto_settlement(_make_bot(), GUILD_ID, PAYER_ID, CREDITOR_ID, 5, remaining=0)
+        await notify_tournament_payout(_make_bot(), GUILD_ID, PAYER_ID, 100)
+        await notify_entry_refund(_make_bot(), GUILD_ID, PAYER_ID, 20)
+
+
+@pytest.mark.asyncio
+async def test_names_survive_a_bot_with_no_guild():
+    """Services run outside guild context; an uncached guild must not break the DM."""
+    bot = MagicMock()
+    bot.get_guild.return_value = None
+    with patch.object(notification_service, "send_dm", new=AsyncMock(return_value=True)) as send:
+        await notify_payment_received(bot, GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+    (_, msg), = _sent(send)
+    assert "25 tix" in msg
+
+
+@pytest.mark.asyncio
+async def test_notify_wallet_is_a_no_op_without_a_registered_bot():
+    """Tests, migrations and CLI runs have no bot; the money path must not care."""
+    from services.mtgo_resolution_service import _notify_wallet
+    with patch("bot_registry.get_bot", return_value=None):
+        await _notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+
+
+@pytest.mark.asyncio
+async def test_notify_wallet_swallows_a_broken_notifier():
+    from services.mtgo_resolution_service import _notify_wallet
+    with patch("bot_registry.get_bot", return_value=MagicMock()), \
+         patch.object(notification_service, "notify_payment_received",
+                      new=AsyncMock(side_effect=RuntimeError("boom"))):
+        await _notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)

--- a/tests/test_wallet_notification_dms.py
+++ b/tests/test_wallet_notification_dms.py
@@ -115,15 +115,15 @@ async def test_names_survive_a_bot_with_no_guild():
 @pytest.mark.asyncio
 async def test_notify_wallet_is_a_no_op_without_a_registered_bot():
     """Tests, migrations and CLI runs have no bot; the money path must not care."""
-    from services.mtgo_resolution_service import _notify_wallet
+    from notification_service import notify_wallet
     with patch("bot_registry.get_bot", return_value=None):
-        await _notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+        await notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
 
 
 @pytest.mark.asyncio
 async def test_notify_wallet_swallows_a_broken_notifier():
-    from services.mtgo_resolution_service import _notify_wallet
+    from notification_service import notify_wallet
     with patch("bot_registry.get_bot", return_value=MagicMock()), \
          patch.object(notification_service, "notify_payment_received",
                       new=AsyncMock(side_effect=RuntimeError("boom"))):
-        await _notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)
+        await notify_wallet("notify_payment_received", GUILD_ID, CREDITOR_ID, PAYER_ID, 25)


### PR DESCRIPTION
Tix moved in and out of players' wallets with nothing telling them. A prize landed, a debt was auto-settled out of their balance, an entry fee came back — all silent unless they went looking. This DMs the people involved.

Four notifications, all best-effort: **payment received**, **auto-settlement** (both sides), **tournament payout**, **entry refund**.

## Notes

**Deliberately ignores the DM notification preference.** That flag defaults off and exists to damp draft-flow chatter (ready checks, teams created). A movement of someone's tix is consequential and usually something they did *not* initiate. This matches the existing precedent — `send_debt_transfer_dms` and `send_settlement_notification_dm` don't consult it either. It's a policy call, reversible in one place if you disagree.

**Both sides are told on an auto-settlement**, because neither party initiated it — that's the whole point of auto-draw.

**Nothing here can break a money path.** The money has already moved by the time a notifier runs. `@_best_effort` swallows and logs at the notifier layer (they're called directly too, not only via the dispatcher), and `notify_wallet` covers the bot lookup. Every call site is verified **outside** `MONEY_LOCK`, which is documented non-reentrant.

**No DM fires when money didn't move**: gated on `if res.get("ok")`, `if refunded:`, `ok and not already_paid` with `amount > 0`, and — added in review — not on `settle_debt_from_wallet`'s idempotent-replay branch.

**Dispatch takes the function, not its name.** Call sites already import the module to reach `notify_wallet`, so importing the notifier beside it is free, and a real reference is one grep and rename can follow — a typo'd string was a `KeyError` swallowed by the guard, silently dropping a notification at the moment of paying someone.

## Testing

- 1158 passed, 9 skipped; `pyrefly check` 0 errors.
- 11 tests over message content, the both-sides settlement, missing-name fallbacks, the no-bot no-op, and the swallow guard.
- Driven end-to-end against the live Discord API with a real `/wallet pay`: three DMs delivered, balances reconciling, system total unchanged.

Reviewed twice. The second pass caught that the dispatcher tests were passing a *string* — left over from the string→function conversion — so `TypeError` was swallowed by `notify_wallet`'s own guard and both tests passed for the wrong reason, with the patched "broken notifier" never invoked. Fixed, and confirmed the test now fails when the guard is narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw