### PR TITLE
Settle debts on every inflow, not only on deposit

### DIFF
--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -114,7 +114,10 @@ class WalletCommands(commands.Cog):
                 # just committed to that entry, so its fee shouldn't be siphoned to a
                 # creditor on the way in.
                 completed = await escrow.sweep_pending_entries(player_id)
-                drawn = await resolution.auto_draw(guild_id, player_id)
+                # settle_inflow, not auto_draw: a raise here would abort _finish before
+                # the followup below, leaving a player whose deposit landed with no
+                # confirmation at all. Deposit is an inflow like the rest.
+                drawn = await resolution.settle_inflow(guild_id, player_id)
                 bal = await wallet_service.get_balance(guild_id, player_id)
                 # Completed entries AND ones this captain is still short on — see
                 # escrow.open_boards_for_captain.

--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -110,14 +110,12 @@ class WalletCommands(commands.Cog):
         async def _finish():
             res = await resolution.finish_deposit(job_id, guild_id, player_id, amount, username)
             if res.get("ok"):
-                # Complete any pending tournament entry BEFORE auto-draw: the player
-                # just committed to that entry, so its fee shouldn't be siphoned to a
-                # creditor on the way in.
-                completed = await escrow.sweep_pending_entries(player_id)
-                # settle_inflow, not auto_draw: a raise here would abort _finish before
-                # the followup below, leaving a player whose deposit landed with no
-                # confirmation at all. Deposit is an inflow like the rest.
-                drawn = await resolution.settle_inflow(guild_id, player_id)
+                # Entry before debts, and never raising past this point: both rules
+                # live in settle_deposit_inflow, which the watchdog's late-job path
+                # uses too. A raise here would abort _finish before the followup
+                # below, leaving a player whose deposit landed with no confirmation.
+                completed, drawn = await resolution.settle_deposit_inflow(
+                    guild_id, player_id)
                 bal = await wallet_service.get_balance(guild_id, player_id)
                 # Completed entries AND ones this captain is still short on — see
                 # escrow.open_boards_for_captain.

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -170,6 +170,24 @@ async def _return_in_flight(guild_id: str, player_id: str, n: int, key: str):
     await settle_inflow(guild_id, player_id)
 
 
+async def settle_deposit_inflow(guild_id: str, player_id: str):
+    """Apply a landed deposit, in the order the player intended.
+
+    Their own pending tournament entry has first claim: they committed to it, so the fee
+    shouldn't be siphoned to a creditor on the way in. Whatever is left then settles
+    against what they owe. Returns (completed_entries, settlements).
+
+    Both deposit completion paths go through here — the live /wallet deposit followup and
+    the watchdog's resume of a job that finished late. The resume path used to book the
+    credit and stop, so a deposit that completed slowly was never drawn against debts at
+    all; keeping the order in one function is what stops the two paths disagreeing again.
+    """
+    from services import tournament_escrow_service as escrow
+    completed = await escrow.sweep_pending_entries(player_id)
+    drawn = await settle_inflow(guild_id, player_id)
+    return completed, drawn
+
+
 async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, *,
                          commit: bool = True, wait_minutes: int = 0) -> dict:
     """Transfer ``n`` tix from the player to ``system:in-flight`` (atomic funds check),
@@ -255,11 +273,14 @@ async def resume_pending_jobs() -> int:
     async def _resume(job: MtgoJob):
         try:
             if job.kind == "deposit":
-                # Booking the credit is all that's needed: anything waiting on those
-                # funds (a pending tournament entry) is completed by the escrow sweep
-                # on the same watchdog tick.
-                await finish_deposit(job.job_id, job.guild_id, job.player_id,
-                                     job.amount, job.mtgo_user)
+                res = await finish_deposit(job.job_id, job.guild_id, job.player_id,
+                                           job.amount, job.mtgo_user)
+                if res.get("ok"):
+                    # A job that finished late lands here instead of in the command's
+                    # own followup, so it has to apply the deposit the same way — the
+                    # watchdog's own escrow sweep runs before these pollers finish, so
+                    # it cannot be relied on to catch this player's entry.
+                    await settle_deposit_inflow(job.guild_id, job.player_id)
             elif job.kind == "withdraw":
                 await finish_withdraw(job.job_id, job.guild_id, job.player_id,
                                       job.amount, job.mtgo_user)

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -166,6 +166,8 @@ async def _return_in_flight(guild_id: str, player_id: str, n: int, key: str):
     await wallet_service.pay(
         guild_id, wallet_service.SYSTEM_IN_FLIGHT, player_id, n,
         source=f"return:{key}", notes=f"withdraw {n} tix returned")
+    # Funds are back with the player — an inflow like any other.
+    await settle_inflow(guild_id, player_id)
 
 
 async def start_withdraw(guild_id: str, player_id: str, mtgo_user: str, n: int, *,
@@ -316,7 +318,10 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     from notification_service import notify_wallet, notify_payment_received
     await notify_wallet(notify_payment_received, guild_id, to_player, from_player, amount,
                         note=notes)
-    return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id]}
+    # Then apply it to anything they owe. Settling AFTER the notification above keeps the
+    # two DMs in the order the money actually moved: received, then auto-applied.
+    drawn = await settle_inflow(guild_id, to_player)
+    return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id], "settled": drawn}
 
 
 # ---------------------------------------------------------------------------
@@ -385,13 +390,49 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
         return await with_db_retry(_do)
 
 
+async def settle_inflow(guild_id: str, player_id: str) -> list[dict]:
+    """Run ``auto_draw`` for a holder who has just RECEIVED tix. Call this from every
+    inflow path, not just deposits.
+
+    Deposits alone are not enough: a payout, a refund, a player-to-player payment or a
+    returned withdraw all credit a wallet without going near the deposit path, so a debtor
+    could be paid a tournament prize and withdraw it straight back out while their creditor
+    was still owed. Settlement on the way IN is what makes the debt collectable.
+
+    TWO RULES, both load-bearing:
+
+    * **Never call this while holding ``MONEY_LOCK``.** It reaches ``settle_debt_from_wallet``,
+      which takes that lock, and the lock is not reentrant — see the note on its definition.
+      So call it AFTER the ``async with wallet_service.MONEY_LOCK:`` block that moved the
+      money, never inside one.
+    * **Never let it break the inflow.** The transfer has already committed by the time we
+      get here; failing to settle afterwards must not turn a successful payout into an
+      error. Failures are logged and swallowed.
+
+    Synthetic holders (prize wallets, in-flight) are skipped — they hold claims but have no
+    debts, and drawing against them is meaningless."""
+    if wallet_service.is_system_account(player_id):
+        return []
+    try:
+        return await auto_draw(guild_id, player_id)
+    except Exception as e:  # noqa: BLE001 - settlement must never fail the inflow itself
+        logger.error(f"settle_inflow: auto_draw failed for {player_id} after an inflow: {e}")
+        return []
+
+
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:
     """Apply a player's wallet balance to their outstanding debts, oldest debt first,
     until the wallet is exhausted or the debts are cleared. Returns the settlements made.
 
-    Called after a deposit (fresh funds) or after a debt is booked (funds already there).
+    Prefer ``settle_inflow`` from inflow paths — it adds the system-account guard and the
+    never-break-the-caller contract. Call this directly only where those do not apply.
+
     Each settlement is atomic and re-checks the live debt, so a concurrent or repeated run
-    simply draws against whatever remains — it converges, never over-pays."""
+    simply draws against whatever remains — it converges, never over-pays.
+
+    NOTE it deliberately does NOT cascade: paying a creditor may leave THEM able to settle
+    their own debts, but chaining that here would recurse through an unbounded number of
+    parties inside one command. Each creditor settles on their own next inflow instead."""
     available = await wallet_service.get_balance(guild_id, player_id)
     if available <= 0:
         return []

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -166,8 +166,36 @@ async def _return_in_flight(guild_id: str, player_id: str, n: int, key: str):
     await wallet_service.pay(
         guild_id, wallet_service.SYSTEM_IN_FLIGHT, player_id, n,
         source=f"return:{key}", notes=f"withdraw {n} tix returned")
-    # Funds are back with the player — an inflow like any other.
-    await settle_inflow(guild_id, player_id)
+    # An inflow like any other; no DM, the withdrawing player is watching their own
+    # command's reply.
+    await on_inflow(guild_id, player_id)
+
+
+async def on_inflow(guild_id: str, player_id: str, notifier=None, *args, **kwargs) -> list:
+    """Call this from every path that puts tix into somebody's wallet. The only thing
+    such a path should have to know.
+
+    It owns the whole concept: tell the recipient, then apply the money to what they
+    owe. That order is not incidental -- it is what makes their two DMs read in the
+    order the money actually moved ("you received 5", then "3 went to your creditor").
+    Skipping system holders and never raising come with it, from settle_inflow.
+
+    ``notifier`` is a notification_service notify_* function, called as
+    ``notifier(bot, guild_id, player_id, *args, **kwargs)`` -- the shape every wallet
+    notifier already has. Omit it where the recipient already sees the outcome
+    synchronously (a returned withdraw, a deposit's own confirmation message).
+
+    WHY THIS IS A CALL AND NOT A HOOK on wallet_service's writers, which would remove
+    the need to remember it entirely: a debt settlement is itself a credit to the
+    creditor, written by transfer_in from INSIDE the caller's MONEY_LOCK. Firing this
+    there would re-enter a non-reentrant lock, and would turn every settlement into a
+    cascade down the creditor chain that auto_draw deliberately refuses to do. So the
+    inflow paths call it, and this docstring is the reason a new one should too.
+    """
+    if notifier is not None:
+        from notification_service import notify_wallet
+        await notify_wallet(notifier, guild_id, player_id, *args, **kwargs)
+    return await settle_inflow(guild_id, player_id)
 
 
 async def settle_deposit_inflow(guild_id: str, player_id: str):
@@ -184,7 +212,7 @@ async def settle_deposit_inflow(guild_id: str, player_id: str):
     """
     from services import tournament_escrow_service as escrow
     completed = await escrow.sweep_pending_entries(player_id)
-    drawn = await settle_inflow(guild_id, player_id)
+    drawn = await on_inflow(guild_id, player_id)
     return completed, drawn
 
 
@@ -336,12 +364,9 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     except ValueError as e:
         return {"ok": False, "error": str(e)}
     # Receiving money is the case you are least likely to be watching for.
-    from notification_service import notify_wallet, notify_payment_received
-    await notify_wallet(notify_payment_received, guild_id, to_player, from_player, amount,
-                        note=notes)
-    # Then apply it to anything they owe. Settling AFTER the notification above keeps the
-    # two DMs in the order the money actually moved: received, then auto-applied.
-    drawn = await settle_inflow(guild_id, to_player)
+    from notification_service import notify_payment_received
+    drawn = await on_inflow(guild_id, to_player, notify_payment_received,
+                            from_player, amount, note=notes)
     return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id], "settled": drawn}
 
 

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -295,11 +295,17 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
                         f"(refunded {refunded})")
             result = {"team_name": dropped_name, "refunded": refunded}
 
-    # AFTER the lock (see execute_payout).
+    # AFTER the lock (see execute_payout): settling reaches settle_debt_from_wallet, which
+    # takes MONEY_LOCK and it is not reentrant, and DMs are network I/O. Neither belongs
+    # inside the lock.
     if refunded:
         from notification_service import notify_wallet, notify_entry_refund
+        from services import mtgo_resolution_service as resolution
         await notify_wallet(notify_entry_refund, guild_id, captain_id, refunded,
                             team_name=dropped_name)
+        # A refund is an inflow, so it settles like any other — after the DM above, so
+        # the two read in the order the money moved.
+        await resolution.settle_inflow(guild_id, captain_id)
     return result
 
 
@@ -373,13 +379,20 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     async with wallet_service.MONEY_LOCK:
         result = await with_db_retry(_do)
 
-    # AFTER the lock: DMs are network I/O and have no business holding the money lock.
+    # AFTER the lock, and in ONE pass over allocations rather than a loop per concern:
+    # settling reaches settle_debt_from_wallet, which takes MONEY_LOCK itself and the lock
+    # is not reentrant, and DMs are network I/O. A prize is an inflow, so a winner who owes
+    # someone pays them from it rather than being able to withdraw it first.
+    # Imported here, not at module scope: mtgo_resolution_service imports this module the
+    # same deferred way (see its sweep at resume time), so both directions stay lazy.
     # Skipped on the already_paid short-circuit, so a re-run cannot re-announce prizes.
     if result.get("ok") and not result.get("already_paid"):
         from notification_service import notify_wallet, notify_tournament_payout
+        from services import mtgo_resolution_service as resolution
         for place, captain_id, team_name, amount in allocations:
             if amount > 0:
                 await notify_wallet(notify_tournament_payout, guild_id, captain_id,
                                     amount, place=place, team_name=team_name,
                                     tournament_name=result.get("tournament_name"))
+                await resolution.settle_inflow(guild_id, captain_id)
     return result

--- a/services/tournament_escrow_service.py
+++ b/services/tournament_escrow_service.py
@@ -299,13 +299,10 @@ async def drop_with_refund(tournament_id: int, team_name: str) -> dict:
     # takes MONEY_LOCK and it is not reentrant, and DMs are network I/O. Neither belongs
     # inside the lock.
     if refunded:
-        from notification_service import notify_wallet, notify_entry_refund
+        from notification_service import notify_entry_refund
         from services import mtgo_resolution_service as resolution
-        await notify_wallet(notify_entry_refund, guild_id, captain_id, refunded,
-                            team_name=dropped_name)
-        # A refund is an inflow, so it settles like any other — after the DM above, so
-        # the two read in the order the money moved.
-        await resolution.settle_inflow(guild_id, captain_id)
+        await resolution.on_inflow(guild_id, captain_id, notify_entry_refund,
+                                   refunded, team_name=dropped_name)
     return result
 
 
@@ -387,12 +384,12 @@ async def execute_payout(guild_id: str, tournament_id: int, allocations: list) -
     # same deferred way (see its sweep at resume time), so both directions stay lazy.
     # Skipped on the already_paid short-circuit, so a re-run cannot re-announce prizes.
     if result.get("ok") and not result.get("already_paid"):
-        from notification_service import notify_wallet, notify_tournament_payout
+        from notification_service import notify_tournament_payout
         from services import mtgo_resolution_service as resolution
         for place, captain_id, team_name, amount in allocations:
             if amount > 0:
-                await notify_wallet(notify_tournament_payout, guild_id, captain_id,
-                                    amount, place=place, team_name=team_name,
-                                    tournament_name=result.get("tournament_name"))
-                await resolution.settle_inflow(guild_id, captain_id)
+                await resolution.on_inflow(
+                    guild_id, captain_id, notify_tournament_payout, amount,
+                    place=place, team_name=team_name,
+                    tournament_name=result.get("tournament_name"))
     return result

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -142,3 +142,32 @@ async def test_settle_inflow_never_breaks_the_inflow(test_db, monkeypatch):  # n
     monkeypatch.setattr(resolution, "auto_draw", boom)
 
     assert await resolution.settle_inflow(GUILD, PAYER) == []
+
+
+@pytest.mark.asyncio
+async def test_a_deposit_pays_the_players_own_entry_before_their_creditors(test_db):  # noqa: F811
+    """Order matters, and the amounts here make the two orders disagree: owing 5 with a
+    2-tix entry pending and 5 arriving, entry-first completes the entry and pays the
+    creditor 3, while debt-first hands the creditor all 5 and strands the entry.
+
+    The player committed to that entry, so it has first claim on funds they just put in.
+    """
+    from models.tournament import Tournament, TournamentParticipant
+    from database.db_session import db_session as _db
+
+    async with _db() as session:
+        t = Tournament(guild_id=GUILD, name="Fee Cup", total_rounds=0, format="manual",
+                       status="registration", entry_fee=2)
+        session.add(t)
+        await session.flush()
+        session.add(TournamentParticipant(tournament_id=t.id, team_id=1, team_name="Alpha",
+                                          captain_user_id=PAYER, status="pending"))
+    await _owe(PAYER, CRED, 5, "d1")
+    await ws.credit_done(GUILD, PAYER, 5, job_id="j-dep")
+
+    completed, drawn = await resolution.settle_deposit_inflow(GUILD, PAYER)
+
+    assert completed, "the pending entry should have been completed first"
+    assert await ws.get_balance(GUILD, CRED) == 3      # creditor got only what was left
+    assert await ws.get_balance(GUILD, PAYER) == 0
+    assert sum(d["amount"] for d in drawn) == 3

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -171,3 +171,54 @@ async def test_a_deposit_pays_the_players_own_entry_before_their_creditors(test_
     assert await ws.get_balance(GUILD, CRED) == 3      # creditor got only what was left
     assert await ws.get_balance(GUILD, PAYER) == 0
     assert sum(d["amount"] for d in drawn) == 3
+
+
+# ---- on_inflow: the one call every inflow path makes ----------------------------
+
+@pytest.mark.asyncio
+async def test_on_inflow_announces_then_settles(test_db):  # noqa: F811
+    """One function owns the whole concept, so a new inflow path cannot half-implement
+    it: the recipient is told, THEN the money is applied to their debts — that order is
+    what makes their two DMs read as "received", then "auto-applied"."""
+    import notification_service
+    from unittest.mock import AsyncMock, patch
+
+    await ws.credit_done(GUILD, PAYER, 5, job_id="j1")
+    await _owe(PAYER, CRED, 3, "d1")
+    order = []
+
+    async def fake_send(*a, **kw):
+        order.append("announced")
+        return True
+
+    real_settle = resolution.settle_inflow
+
+    async def watched_settle(*a, **kw):
+        order.append("settled")
+        return await real_settle(*a, **kw)
+
+    with patch.object(notification_service, "send_dm", new=AsyncMock(side_effect=fake_send)), \
+         patch("bot_registry.get_bot", return_value=object()), \
+         patch.object(resolution, "settle_inflow", new=watched_settle):
+        drawn = await resolution.on_inflow(
+            GUILD, PAYER, notification_service.notify_payment_received,
+            CRED2, 5, note="test")
+
+    # settling fires its own DMs (the auto-settlement pair), so "announced" recurs
+    # after "settled" -- what matters is that the inflow was announced FIRST.
+    assert order[0] == "announced"
+    assert order.index("settled") == 1
+    assert sum(d["amount"] for d in drawn) == 3
+    assert await ws.get_balance(GUILD, CRED) == 3
+
+
+@pytest.mark.asyncio
+async def test_on_inflow_without_an_announcement_still_settles(test_db):  # noqa: F811
+    """Paths where the recipient already sees the outcome (a returned withdraw, a
+    deposit's own confirmation) pass no notifier and must still settle."""
+    await ws.credit_done(GUILD, PAYER, 5, job_id="j1")
+    await _owe(PAYER, CRED, 3, "d1")
+
+    drawn = await resolution.on_inflow(GUILD, PAYER)
+
+    assert sum(d["amount"] for d in drawn) == 3

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -88,3 +88,57 @@ async def test_auto_draw_is_a_no_op_without_funds_or_debts(test_db):  # noqa: F8
     await ws.credit_done(GUILD, PAYER, 4, job_id="j5")
     assert await resolution.auto_draw(GUILD, PAYER) == []      # funds, no debts
     assert await ws.get_balance(GUILD, PAYER) == 4
+
+
+# ---- settling on every inflow, not just deposits --------------------------------
+
+@pytest.mark.asyncio
+async def test_a_payment_settles_the_recipients_debt_on_the_way_in(test_db):  # noqa: F811
+    """The point of the change: a debtor paid by another player has that money applied
+    to what they owe, instead of it landing spendable and the creditor staying unpaid."""
+    await ws.credit_done(GUILD, CRED2, 5, job_id="j1")
+    await _owe(PAYER, CRED, 3, "d1")
+
+    res = await resolution.pay(GUILD, CRED2, PAYER, 5)
+
+    assert res["ok"]
+    assert [d["amount"] for d in res["settled"]] == [3]
+    assert await ws.get_balance(GUILD, PAYER) == 2   # 5 in, 3 straight out to the creditor
+    assert await ws.get_balance(GUILD, CRED) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_returned_withdraw_settles_on_the_way_back(test_db):  # noqa: F811
+    """Tix coming back from a failed withdraw are an inflow like any other."""
+    await ws.credit_done(GUILD, PAYER, 5, job_id="j1")
+    await ws.pay(GUILD, PAYER, ws.SYSTEM_IN_FLIGHT, 5, source="wd:test", notes="withdraw")
+    await _owe(PAYER, CRED, 3, "d1")
+    assert await ws.get_balance(GUILD, PAYER) == 0   # nothing to draw against yet
+
+    await resolution._return_in_flight(GUILD, PAYER, 5, "test")
+
+    assert await ws.get_balance(GUILD, CRED) == 3
+    assert await ws.get_balance(GUILD, PAYER) == 2
+
+
+@pytest.mark.asyncio
+async def test_settle_inflow_skips_system_accounts(test_db):  # noqa: F811
+    """Prize wallets and in-flight hold claims but owe nothing; drawing against them
+    is meaningless, and would let a synthetic holder be treated as a debtor."""
+    await ws.credit_done(GUILD, PAYER, 5, job_id="j1")
+    await ws.pay(GUILD, PAYER, ws.SYSTEM_IN_FLIGHT, 5, source="wd:test", notes="withdraw")
+
+    assert await resolution.settle_inflow(GUILD, ws.SYSTEM_IN_FLIGHT) == []
+
+
+@pytest.mark.asyncio
+async def test_settle_inflow_never_breaks_the_inflow(test_db, monkeypatch):  # noqa: F811
+    """The money has already moved by the time this runs. A settlement failure must not
+    turn a completed transfer into an error -- which is also why the deposit path calls
+    settle_inflow: a raise there would abort before the user's confirmation is sent."""
+    async def boom(*a, **kw):
+        raise RuntimeError("ledger unavailable")
+
+    monkeypatch.setattr(resolution, "auto_draw", boom)
+
+    assert await resolution.settle_inflow(GUILD, PAYER) == []


### PR DESCRIPTION
> Stacked on #412 — base is `wallet-dm-notifications`, so this diff is only this branch's changes. Merge #412 first.

Debt settlement ran when a player deposited, and nowhere else. A tournament payout, an entry refund, a player-to-player payment and a returned withdraw all credit a wallet without going near the deposit path — so a debtor could be paid a prize and withdraw it straight back out while their creditor was still owed. Settling on the way **in** is what makes a debt collectable.

## `on_inflow` — the one call an inflow path makes

Every path that puts tix in a wallet now calls one function, which owns the whole concept: tell the recipient, then apply the money to what they owe, skipping system holders, never raising.

```python
_return_in_flight   await on_inflow(guild_id, player_id)
deposit             await on_inflow(guild_id, player_id)
pay()               await on_inflow(guild_id, to_player, notify_payment_received, from_player, amount, note=notes)
drop_with_refund    await resolution.on_inflow(guild_id, captain_id, notify_entry_refund, refunded, team_name=…)
execute_payout      await resolution.on_inflow(guild_id, captain_id, notify_tournament_payout, amount, place=…, …)
```

The ordering isn't incidental: announcing before settling is what makes a recipient's two DMs read in the order their money moved — *"you received 5"*, then *"3 went to your creditor"*.

**Why a call and not a hook** on `wallet_service`'s writers, which would remove the need to remember it at all — two reasons, both verified rather than assumed:

- A debt settlement is itself a credit to the creditor, written by `transfer_in` from **inside** the caller's `MONEY_LOCK`. Firing there would re-enter a lock documented as non-reentrant.
- It would make every settlement cascade down the creditor chain, which `auto_draw` explicitly refuses to do.

That reasoning lives in `on_inflow`'s docstring so the next person doesn't re-derive it — or implement the hook.

## The gap this closed on the way

`finish_deposit` has two callers. The live `/wallet deposit` followup settled; `resume_pending_jobs` — the watchdog path for a job that finishes later than the command's ~14-minute poll — booked the credit and stopped. A slow deposit landed and was never drawn against debts, on the one path where the player isn't watching. Its comment claimed the escrow sweep on the same tick would cover it; it can't, because `_resume` spawns pollers fire-and-forget and the sweep runs before they finish.

`settle_deposit_inflow` now holds the order both paths need — the player's own pending entry first (they committed to it; its fee shouldn't be siphoned to a creditor on the way in), then their debts.

## Testing

- 1165 passed, 9 skipped; `pyrefly check` 0 errors.
- The branch arrived with no tests; it now has coverage for a payment settling the recipient's debt, a returned withdraw doing the same, the system-account skip, the never-raise contract, `on_inflow`'s announce-then-settle order, and the deposit ordering.
- The behavioural ones were verified by removing the code under test and watching them fail. The deposit-ordering test uses amounts where the two orders genuinely disagree (owing 5, a 2-tix entry pending, 5 arriving), so an inverted order strands the entry.
- Driven end-to-end against the live Discord API with a real `/wallet pay`: `pay → on_inflow → notify → settle → auto_draw`, three DMs delivered, balances reconciling, system total unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw