### PR TITLE
Tell players how to pay with tix, where they find out they owe

### DIFF
--- a/debt_views/helpers.py
+++ b/debt_views/helpers.py
@@ -5,6 +5,8 @@ This module contains shared utilities to reduce code duplication
 across debt_commands.py and settle_views.py.
 """
 import discord
+
+from helpers.money_gate import add_wallet_howto
 import aiohttp
 from sqlalchemy import select
 
@@ -231,6 +233,13 @@ def build_guild_debt_embed_pages(guild: discord.Guild, rows: list, per_page: int
 
         pages.append(embed)
 
+    # Last page only: the block is identical on every page, and repeating it through a
+    # long paginated list pushes the debts themselves off the screen.
+    # Only when tix are actually owed: build_debt_pair_lines also emits card-only
+    # pairs, which contribute lines but no tix, and the wallet does not settle those.
+    if total:
+        add_wallet_howto(pages[-1], guild.id)
+
     return pages
 
 
@@ -294,5 +303,10 @@ def build_user_balance_embed(guild: discord.Guild, balances: dict,
             value="\n".join(owed_to_you_lines),
             inline=False
         )
+
+    # Only when they actually owe: the block explains settling a debt, which is noise
+    # for a player who is purely owed money.
+    if you_owe_lines:
+        add_wallet_howto(embed, guild.id)
 
     return embed

--- a/helpers/money_gate.py
+++ b/helpers/money_gate.py
@@ -31,6 +31,50 @@ _custodian_cache: str | None = None
 _background_tasks: set = set()
 
 
+WALLET_HOWTO_TITLE = "💡 Paying with tix"
+
+
+def wallet_howto(guild_id, *, brief=False) -> str | None:
+    """How to pay with tix, in the one place the wording lives.
+
+    It appears wherever a player is confronted with tix they owe — the bet outcomes
+    of a finished staked draft, their own balances, the guild debt summary — and once
+    before they bet at all. Written once here because four copies drift, and because
+    the middle line is the part nobody guesses: funding a wallet settles debts by
+    itself, on any inflow, not just a deposit.
+
+    Returns None where there is no wallet to use. Staked drafts only run on money
+    servers, but debts do not: a card loan via /lend books one on a free server too,
+    so the debt panels render there. Pointing those players at a command the bot
+    refuses is worse than saying nothing, and this is the check they'd each otherwise
+    have to remember.
+    """
+    if not is_money_server(str(guild_id)):
+        return None
+    if brief:
+        return ("Bets settle from your tix wallet — `/wallet deposit <n>` covers "
+                "what you owe automatically.")
+    return (
+        "`/wallet deposit <n>` — credits your wallet, and pays your oldest debts automatically\n"
+        "`/wallet show` — your balance and recent activity\n"
+        "`/wallet pay @player <n>` — send tix straight to someone"
+    )
+
+
+def add_wallet_howto(embed, guild_id) -> bool:
+    """Append the how-to to an embed, where there is a wallet to explain.
+
+    The three embed call sites otherwise each repeat fetch-check-add and import both
+    the text and its title; this leaves them one line and one import. Returns whether
+    anything was added, for callers that care.
+    """
+    text = wallet_howto(guild_id)
+    if not text:
+        return False
+    embed.add_field(name=WALLET_HOWTO_TITLE, value=text, inline=False)
+    return True
+
+
 def gate_read(ctx) -> str | None:
     """Wallet must be used in a money server. Returns an error string, or None."""
     if not ctx.guild:

--- a/tests/test_debt_leaderboard.py
+++ b/tests/test_debt_leaderboard.py
@@ -60,3 +60,59 @@ def test_field_on_every_page():
     assert len(pages) == 2
     assert pages[0].fields[0].name == "🏆 Most Outstanding"
     assert pages[1].fields[0].name == "🏆 Most Outstanding"
+
+
+# ---- the wallet how-to block on the debt panels ---------------------------------
+
+def _money_server(value=True):
+    """Patch the real gate, not the helper under test: patching add_wallet_howto would
+    make the silent-on-free-servers test assert that a stubbed no-op does nothing."""
+    return patch("helpers.money_gate.is_money_server", return_value=value)
+
+
+def test_guild_summary_carries_the_wallet_howto_once_on_the_last_page():
+    """Identical on every page, so repeating it through a long list would push the
+    debts themselves off screen."""
+    rows = [_row(f"p{i}", "alice", -10) for i in range(25)]
+    with _patch_names(), _money_server():
+        pages = build_guild_debt_embed_pages(_guild(), rows, per_page=10)
+
+    assert len(pages) > 1
+    carrying = [i for i, p in enumerate(pages)
+                if any("wallet deposit" in f.value for f in p.fields)]
+    assert carrying == [len(pages) - 1]
+
+
+def test_debt_panels_stay_silent_where_there_is_no_wallet():
+    """Card loans book debts on free servers too, and /wallet is refused there."""
+    from debt_views.helpers import build_user_balance_embed
+
+    rows = [_row("bob", "alice", -10)]
+    with _patch_names(), _money_server(False):
+        pages = build_guild_debt_embed_pages(_guild(), rows)
+        balances = build_user_balance_embed(_guild(), {"alice": -10})
+
+    for embed in (*pages, balances):
+        assert not any("wallet" in f.value.lower() for f in embed.fields)
+
+
+def test_personal_balances_panel_carries_the_wallet_howto():
+    from debt_views.helpers import build_user_balance_embed
+
+    with _patch_names(), _money_server():
+        embed = build_user_balance_embed(_guild(), {"alice": -10})
+
+    assert any("wallet deposit" in f.value for f in embed.fields)
+
+
+def test_a_player_who_is_only_owed_money_is_not_told_how_to_pay():
+    """The block explains settling a debt. Someone with nothing to settle doesn't
+    need it taking up their panel."""
+    from debt_views.helpers import build_user_balance_embed
+
+    with _patch_names(), _money_server():
+        owes = build_user_balance_embed(_guild(), {"alice": -10})
+        owed = build_user_balance_embed(_guild(), {"alice": 10})
+
+    assert any("wallet deposit" in f.value for f in owes.fields)
+    assert not any("wallet deposit" in f.value for f in owed.fields)

--- a/tests/test_wallet_howto.py
+++ b/tests/test_wallet_howto.py
@@ -1,0 +1,71 @@
+"""The one place that tells players how to pay with tix.
+
+The copy lives in a single helper because it appears on four surfaces; the thing it
+has to get right is not appearing on the servers where /wallet is refused.
+"""
+from unittest.mock import patch
+
+from helpers.money_gate import WALLET_HOWTO_TITLE, wallet_howto
+
+GUILD = "g1"
+
+
+def _on_money_server(value=True):
+    return patch("helpers.money_gate.is_money_server", return_value=value)
+
+
+def test_nothing_on_a_server_without_the_wallet():
+    """Card loans put debts on free servers too, so the debt panels render there —
+    and /wallet is refused there. Telling someone to run it would be worse than
+    saying nothing."""
+    with _on_money_server(False):
+        assert wallet_howto(GUILD) is None
+        assert wallet_howto(GUILD, brief=True) is None
+
+
+def test_names_the_command_that_settles_a_debt():
+    with _on_money_server():
+        text = wallet_howto(GUILD)
+
+    assert "/wallet deposit" in text
+    # the part nobody guesses: funding a wallet pays what you owe by itself
+    assert "automatic" in text.lower()
+
+
+def test_the_brief_form_is_one_line():
+    """It sits above a dropdown on the staked sign-up prompt, so a block would bury
+    the control it is introducing."""
+    with _on_money_server():
+        brief = wallet_howto(GUILD, brief=True)
+
+    assert "\n" not in brief
+    assert "/wallet deposit" in brief
+
+
+def test_the_title_is_shared_so_the_panels_match():
+    assert "tix" in WALLET_HOWTO_TITLE.lower()
+
+
+def test_the_copy_only_names_commands_that_exist():
+    """The instructions said `/wallet` for a balance, but the bot registers a wallet
+    GROUP whose balance subcommand is `show` — so the one line telling a player how to
+    look at their own tix named something they cannot run. Pin the copy to the real
+    command surface rather than to the cog's docstring, which has the same error.
+
+    Checks every backticked /wallet token, not just those with a word after them: a
+    bare `/wallet` is exactly the failure this exists to catch.
+    """
+    import re
+
+    from cogs.wallet_cog import WalletCommands
+
+    registered = {c.name for c in WalletCommands.wallet.subcommands}
+    with _on_money_server():
+        copy = f"{wallet_howto(GUILD)} {wallet_howto(GUILD, brief=True)}"
+
+    snippets = re.findall(r"`(/wallet[^`]*)`", copy)
+    assert snippets, "the copy should name at least one wallet command"
+    for snippet in snippets:
+        parts = snippet.split()
+        assert len(parts) >= 2, f"{snippet!r} names the group, not a runnable command"
+        assert parts[1] in registered, f"{snippet!r} is not a registered command"

--- a/utils.py
+++ b/utils.py
@@ -24,6 +24,7 @@ from debt_views.settle_views import PublicSettleDebtsView
 from models.debt_summary_message import DebtSummaryMessage
 from loguru import logger
 from config import is_cleanup_exempt, is_test_mode
+from helpers.money_gate import add_wallet_howto
 from leaderboard_config import AUTO_UPDATE_CATEGORIES
 from services.crown_roles import update_crown_roles_for_guild
 
@@ -615,6 +616,9 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                                 color=discord_color  # Match main embed color
                             )
                             bet_embed.set_footer(text=f"Total bets settled: {outcome_total} tix")
+                            # These outcomes become debt ledger entries just below, so
+                            # this is where a loser first learns they owe someone.
+                            add_wallet_howto(bet_embed, draft_session.guild_id)
 
                             # Create debt ledger entries for stake outcomes
                             try:

--- a/views.py
+++ b/views.py
@@ -15,6 +15,7 @@ from models import SignUpHistory
 from sqlalchemy import update, select, and_
 from sqlalchemy.orm import selectinload
 from helpers.utils import get_cube_thumbnail_url
+from helpers.money_gate import wallet_howto
 from helpers.display_names import get_display_name, get_display_name_by_id
 from helpers.debt_warning import format_staked_sign_ups, DEBT_WARNING_AGE_DAYS
 from helpers.draft_footer import apply_draft_footer_from_session
@@ -478,8 +479,14 @@ class PersistentView(discord.ui.View):
                     min_stake=draft_session.min_stake,
                     has_draftmancer_role=has_draftmancer_role  
                 )
+                # Say how a bet is actually paid BEFORE it is placed, not only after
+                # it is lost.
+                howto = wallet_howto(draft_session.guild_id, brief=True)
+                prompt = f"Min Bet for queue is {draft_session.min_stake}. Select your max bet:"
+                if howto:
+                    prompt += f"\n-# {howto}"
                 await interaction.response.send_message(
-                    f"Min Bet for queue is {draft_session.min_stake}. Select your max bet:",
+                    prompt,
                     view=stake_options_view,
                     ephemeral=True
                 )


### PR DESCRIPTION
A staked draft's outcomes become debt ledger entries, and those debts are settled from the tix wallet — but nothing said so. A player learned they owed someone and was left to find `/wallet` on their own.

The copy appears on the four surfaces where it's actionable:

- **Bet Outcomes** embed of a finished staked draft — the moment the debt is created
- **Your Outstanding Balances** — but only when you actually owe; it explains settling a debt, which is noise for someone purely owed money
- **Guild Debt Summary** — last page only, and only when tix are owed
- **The staked sign-up prompt** — one small-text line, so how a bet gets paid is said *before* it's placed, not only after it's lost

```
💡 Paying with tix
/wallet deposit <n> — credits your wallet, and pays your oldest debts automatically
/wallet show — your balance and recent activity
/wallet pay @player <n> — send tix straight to someone
```

## Notes

**Written once**, in `helpers/money_gate.py`, beside the gate it depends on — that module exists so "rules and their user-facing wording can't drift between cogs".

**The gate is the load-bearing part.** Staked drafts only run on money servers, so Bet Outcomes is always safe — but the debt panels aren't: `/lend` books card-loan debts on free servers, where `/wallet` is refused. `wallet_howto` returns `None` there and `add_wallet_howto` adds nothing, so no call site has to remember the asymmetry. Pointing those players at a refused command would be worse than saying nothing.

**The middle line is the part nobody guesses** — funding a wallet settles debts by itself, on any inflow, not just a deposit.

## Review findings fixed

Three passes: two quality agents and a Codex correctness review. Four things changed as a result.

1. **The copy named a command that doesn't exist.** It said `/wallet` for a balance, but the bot registers a *group* whose balance subcommand is `show` — the instruction for checking your own tix couldn't be followed. Inherited from `wallet_cog.py`'s module docstring, which has the same error. A new test now pins the copy to the registered command surface.
2. **Card-only debts triggered tix instructions.** `build_debt_pair_lines` emits card-only pairs as lines that contribute nothing to the tix total, so a money server with only card loans showed "Paying with tix" with none owed.
3. **The balances panel showed it to pure creditors.** Now gated on owing.
4. **The fetch-check-add triple repeated at three sites**, each importing two symbols. Collapsed into `add_wallet_howto(embed, guild_id)`.

Codex separately confirmed the gating holds on all four surfaces, that the added field is 187 characters and so poses no risk to Discord's 1024/6000 limits, and that the copy's behavioural claims match the code (inflows settle oldest-first; `/wallet pay` routes through `on_inflow`).

## Testing

- 1174 passed, 9 skipped; `pyrefly check` 0 errors.
- 9 new tests: the gate in both directions, brief-form single-line, last-page-only placement, the creditor case, and the copy-vs-registered-commands check.
- Each was verified by breaking the thing it covers and watching it fail. That mattered: my first version of the command-surface test passed even with the broken copy, because its regex couldn't match a bare `/wallet` — the exact case it existed for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw