### PR TITLE
Pause the draft when a player drops mid-draft (shadow by default)

### DIFF
--- a/cogs/draft_control.py
+++ b/cogs/draft_control.py
@@ -8,7 +8,11 @@ from discord.ui import View, Button
 from datetime import datetime, timedelta
 from sqlalchemy import select, and_, desc, update
 from database.db_session import db_session
-from services.draft_setup_manager import DraftSetupManager, create_rooms_and_pairings_with_fallback
+from services.draft_setup_manager import (
+    DraftSetupManager,
+    PAUSED_DRAFT_OPTIONS,
+    create_rooms_and_pairings_with_fallback,
+)
 
 # Store active unpause ready checks
 ACTIVE_UNPAUSE_CHECKS = {}
@@ -1096,9 +1100,7 @@ class DraftControlCog(commands.Cog):
             
             await ctx.followup.send(
                 f"⏸️ **Draft paused** by {ctx.author.mention}.\n\n"
-                f"• Use `/unpause` to resume when everyone is ready.\n"
-                f"• Use `/replace_with_bots` to replace disconnected users with bots.\n"
-                f"• Use `/scrap` to start a vote to cancel the draft."
+                f"{PAUSED_DRAFT_OPTIONS}"
             )
                 
         except Exception as e:

--- a/config.py
+++ b/config.py
@@ -24,6 +24,20 @@ def is_test_mode() -> bool:
     """Returns True if TEST_MODE env var is set to a truthy value."""
     return os.environ.get("TEST_MODE", "false").lower() in ("true", "1", "yes")
 
+def is_disconnect_autopause_enabled() -> bool:
+    """Whether the bot may actually pause a draft when a player drops mid-draft.
+
+    Off by default, which runs the whole decision in shadow: the bot works out what
+    it would do and logs it, but emits nothing to Draftmancer and says nothing in
+    Discord. Draftmancer only ever delivers 'userDisconnected' to a session's
+    non-playing owner, and no DraftBot build has ever subscribed to it — so the first
+    evidence that it arrives at all, and how often, comes from those logs. Acting on
+    an event we have never observed would mean pausing real drafts to find out.
+
+    Set DISCONNECT_AUTOPAUSE=true once the logs show it firing when expected.
+    """
+    return os.environ.get("DISCONNECT_AUTOPAUSE", "false").lower() in ("true", "1", "yes")
+
 class Config:
     def __init__(self):
         # Base configuration for all guilds

--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import socketio
+from collections import Counter
 from loguru import logger
 from functools import wraps
 import random
@@ -10,7 +11,8 @@ import pytz
 import discord
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
-from config import get_draftmancer_websocket_url, get_draftmancer_base_url, get_draftmancer_session_url, is_test_mode
+from config import (get_draftmancer_websocket_url, get_draftmancer_base_url,
+                    get_draftmancer_session_url, is_disconnect_autopause_enabled, is_test_mode)
 from database.db_session import db_session
 from models.draft_session import DraftSession
 from models.match import MatchResult
@@ -59,6 +61,20 @@ else:
     DRAFT_PICK_TIMER_SECONDS = 60
     DRAFT_LOG_UNLOCK_TIMER_MINUTES = 180
 OWNERSHIP_CLAIM_TIMEOUT = 3.0  # Seconds to wait for ownership claim confirmation
+# How long a mid-draft disconnect must last before the bot says anything in Discord.
+# Short drops are common and self-correcting; announcing every one of them would
+# train players to ignore the message that matters.
+DISCONNECT_NOTICE_DELAY = 15
+# Prefix for the decision log of a shadow run, so a whole evaluation can be
+# pulled out of production logs with one grep.
+SHADOW = "[autopause-shadow]"
+# What a paused table can do next. Shared with cogs/draft_control.py's /pause so
+# the bot-triggered and human-triggered pause messages cannot drift apart.
+PAUSED_DRAFT_OPTIONS = (
+    "\u2022 Use `/unpause` to resume once everyone is ready.\n"
+    "\u2022 Use `/replace_with_bots` to replace disconnected users with bots.\n"
+    "\u2022 Use `/scrap` to start a vote to cancel the draft."
+)
 SOCKET_OPERATION_DELAY = 0.5  # Seconds between socket operations
 CONNECTION_CHECK_INTERVAL = 10  # Seconds between connection check iterations
 SETTINGS_OPERATION_DELAY = 1  # Seconds after setting operations
@@ -201,6 +217,13 @@ class DraftSetupManager:
         self.seating_order_set = False
         self.seated_user_ids = set()   # Draftmancer ids we actually seated
         self.disconnected_users = {}   # uid -> name, from Draftmancer mid-draft
+
+        # Auto-pause on a mid-draft disconnect
+        self._paused_for_disconnect = False   # this pause is ours, so ours to lift
+        self._disconnect_notice_task = None
+        self._disconnect_notice_sent = False
+        self._disconnect_started_at = None
+        self.disconnect_notice_delay = DISCONNECT_NOTICE_DELAY
         self.last_db_check_time = None
         self.db_check_cooldown = 15
         self.expected_user_count = 0
@@ -275,7 +298,14 @@ class DraftSetupManager:
         logger.info(f"Draft ended event received: {data}")
         self.drafting = False
         self.draftPaused = False
-        
+        # A draft can end with someone still disconnected — /scrap, or the rest of the
+        # table replacing them with bots and playing on. "Please reconnect" after that
+        # is noise about a draft that no longer exists, so the notice is dropped even
+        # if it had already committed to sending.
+        self._paused_for_disconnect = False
+        self._disconnect_notice_sent = False
+        self._cancel_disconnect_notice()
+
         if self.draft_cancelled:
             logger.info("Draft was manually cancelled - no additional announcement needed")
             self.draft_cancelled = False  # Reset the flag for future drafts
@@ -338,6 +368,10 @@ class DraftSetupManager:
     async def _on_draft_resumed(self, *args):
         self.logger.info("Draft resumed event received")
         self.draftPaused = False
+        # Every resume lands here, whoever caused it — our own emit, or a player's
+        # /unpause. Either way the disconnect pause is over and is not ours to lift
+        # a second time.
+        self._paused_for_disconnect = False
 
     async def _on_resume_on_reconnection(self, *args):
         """Draftmancer's signal that the LAST disconnected player is back.
@@ -351,8 +385,11 @@ class DraftSetupManager:
         Draftmancer respects our pause here: resumeOnReconnection only restarts the
         countdowns `if (!this.draftPaused)`, so a draft the bot paused stays paused.
         """
+        was_out = bool(self.disconnected_users)
         self.disconnected_users = {}
         self.logger.info("Draftmancer reports the last disconnected player reconnected")
+        if was_out:
+            await self._resume_after_disconnect()
         
     def _register_socket_handlers(self):
         """Subscribe to the events Draftmancer actually emits.
@@ -434,10 +471,9 @@ class DraftSetupManager:
         #
         # Two limits on it. Only for someone we actually seated, so an unseated extra
         # wandering off cannot throw away a good seating. And only before the draft is
-        # under way: past that point this flag is the latch that stops anything
-        # touching the seating again — nothing in check_session_stage_and_organize
-        # checks self.drafting — so clearing it on a mid-draft disconnect would let a
-        # reconnect re-emit setSeating into a live draft, which is worse than the bug.
+        # under way — check_session_stage_and_organize refuses to seat a live draft,
+        # but the record of who we seated is still worth keeping accurate rather than
+        # discarding the moment a mid-draft connection wobbles.
         #
         # Asks "is anyone we seated missing" rather than "did the count drop". The two
         # are not the same: one seated player leaving while a newcomer arrives in the
@@ -489,29 +525,211 @@ class DraftSetupManager:
             await self.check_session_stage_and_organize()
 
     async def _on_user_disconnected(self, data=None):
-        """Draftmancer telling us WHO dropped, which sessionUsers cannot.
+        """Draftmancer telling us WHO dropped, which sessionUsers cannot — and the
+        cue to pause, because a drop mid-draft stalls the whole table.
 
         Emitted only while a draft is running (Session.remUser), and it carries the
-        names — where a sessionUsers count going 6 -> 5 leaves the bot to infer who is
-        gone. Production shows this is common rather than exceptional: 58 same-session
-        drop-and-return flaps in three days, a median of 6 seconds apart.
+        names, where a sessionUsers count going 6 -> 5 would leave the bot to infer
+        who is gone. In fact sessionUsers does not fire at all here: mid-draft
+        remUser takes the drafting branch, which holds the seat open in
+        disconnectedUsers and broadcasts only this event.
 
-        Recording, not acting: the seating recovery deliberately does nothing during a
-        draft, and this fires only during one. It exists so the next incident can be
-        read from the logs, and so anything that needs to know who is missing has a
-        source that names them.
+        Holding the seat is what stalls everyone else. Draftmancer stops the absent
+        player's countdown and no one else's, so the table drafts on until a pack
+        reaches the empty seat and then waits, with no timer left to expire. Our
+        sessions are not `managed`, so remUser's 30-second replace-with-bots
+        fallback never fires for us and the wait has no end.
+
+        A count change is not enough to act on, which is why this is the handler that
+        does: only the transitions matter, nobody -> someone and someone -> nobody.
+        A second player dropping while one is already out changes nothing — the draft
+        is paused and the room has been told.
+
+        Deliberately not gated on self.drafting. The event's own existence is the
+        evidence a draft is running, and self.drafting is only ever set by the bot's
+        own start-draft call — so a bot restarted mid-draft has it False, and gating
+        on it would switch the pause off exactly when nobody is watching.
         """
         disconnected = (data or {}).get('disconnectedUsers') or {}
+        previously_out = bool(self.disconnected_users)
         self.disconnected_users = {
             uid: info.get('userName') for uid, info in disconnected.items()
         }
+
         if self.disconnected_users:
             self.logger.info(
                 f"Draftmancer reports disconnected mid-draft: "
                 f"{sorted(n for n in self.disconnected_users.values() if n)}"
             )
+            if not previously_out:
+                await self._pause_for_disconnect()
         else:
             self.logger.info("Draftmancer reports everyone reconnected")
+            if previously_out:
+                await self._resume_after_disconnect()
+
+    async def _pause_for_disconnect(self):
+        """Pause the draft and start the clock on telling the room.
+
+        With DISCONNECT_AUTOPAUSE unset this takes every decision and logs it while
+        performing neither side effect. draftPaused especially is left alone: the
+        seating recovery reads it and /unpause refuses to run without it, so setting
+        it without a real pause would have the rest of the bot believe a draft is
+        paused while Draftmancer plays on.
+        """
+        live = is_disconnect_autopause_enabled()
+        self._disconnect_notice_sent = False
+        self._disconnect_started_at = datetime.now()
+        who = sorted(n for n in self.disconnected_users.values() if n) or ["a player"]
+
+        if self.draftPaused:
+            # Already paused by a participant's /pause. Theirs to lift, not ours —
+            # leaving _paused_for_disconnect False is what stops us undoing it.
+            self.logger.info("Draft already paused; not claiming it for the disconnect")
+        else:
+            self._paused_for_disconnect = True
+            if live:
+                await self.socket_client.emit('pauseDraft')
+                self.draftPaused = True
+                self.logger.info(f"Paused the draft: {who} dropped mid-draft")
+            else:
+                self.logger.info(f"{SHADOW} would pause the draft: {who} dropped mid-draft")
+
+        self._cancel_disconnect_notice()
+        self._disconnect_notice_task = asyncio.create_task(self._announce_disconnect())
+
+    def _disconnect_duration(self):
+        """Seconds the current disconnect has lasted, for the shadow-run write-up.
+
+        The number that decides whether the grace window is set anywhere near right,
+        and it has never been measurable: nothing subscribed to userDisconnected
+        before this, so no build has ever known how long a mid-draft drop lasts.
+        """
+        if not self._disconnect_started_at:
+            return -1
+        return round((datetime.now() - self._disconnect_started_at).total_seconds(), 1)
+
+    async def _announce_disconnect(self):
+        """Ask the missing player to come back, once the drop has lasted."""
+        try:
+            await asyncio.sleep(self.disconnect_notice_delay)
+        except asyncio.CancelledError:
+            return  # back inside the grace window; nobody needs telling
+
+        # Surviving the sleep is the point of no return: the reconnect that would
+        # have cancelled this task can no longer arrive first. Recording it before
+        # the message goes out, rather than after, keeps the two halves from
+        # disagreeing if the send is slow or fails — the draft then stays paused for
+        # /unpause, which is where it would have been without this feature anyway.
+        self._disconnect_notice_sent = True
+
+        try:
+            channel = await self._get_draft_channel()
+            if not channel:
+                return
+            # Built in both modes on purpose: rendering it is what proves the channel
+            # lookup, the sign_ups read and the mention resolution all work before
+            # anything is posted for real.
+            text = await self._disconnect_notice_text()
+            if is_disconnect_autopause_enabled():
+                # Draftmancer takes any setUserName a client sends, and an unresolved
+                # name goes into this message as raw text — so "@everyone" is a name
+                # somebody can pick. Only the mentions this code built are allowed to
+                # ping; everything else renders inert.
+                await channel.send(
+                    text,
+                    allowed_mentions=discord.AllowedMentions(
+                        everyone=False, roles=False, users=True
+                    ),
+                )
+            else:
+                self.logger.info(
+                    f"{SHADOW} would post to channel {self.draft_channel_id} after "
+                    f"{self._disconnect_duration()}s: {text!r}"
+                )
+        except Exception as e:
+            self.logger.error(f"Failed to announce a mid-draft disconnect: {e}")
+
+    async def _disconnect_notice_text(self):
+        """Name the missing players, mentioning them where that is unambiguous.
+
+        sign_ups is keyed by Discord id with the display name as the value, so the
+        lookup runs backwards — and two players can share a display name (the case
+        resolve_seating_ids exists for). A wrong ping is worse than no ping, so a
+        duplicate name is named in plain text instead.
+        """
+        draft_session = await self._get_draft_session_from_db()
+        sign_ups = (draft_session.sign_ups if draft_session else None) or {}
+
+        name_counts = Counter(sign_ups.values())
+        mentions = {
+            name: discord_id for discord_id, name in sign_ups.items()
+            if name_counts[name] == 1
+        }
+
+        who = []
+        for name in sorted(n for n in self.disconnected_users.values() if n):
+            discord_id = mentions.get(name)
+            who.append(f"<@{discord_id}>" if discord_id else name)
+
+        session_url = get_draftmancer_session_url(self.draft_id)
+        return (
+            f"⏸️ **Draft paused** — {', '.join(who) or 'a player'} dropped out of "
+            f"Draftmancer, which stalls the table.\n\n"
+            f"Rejoin here to carry on: {session_url}\n\n"
+            f"• Use `/unpause` to resume once everyone is back.\n"
+            f"• Use `/replace_with_bots` to replace disconnected users with bots.\n"
+            f"• Use `/scrap` to start a vote to cancel the draft."
+        )
+
+    async def _resume_after_disconnect(self):
+        """Everyone is back. Resume only if nobody was ever told to do it themselves.
+
+        Once the notice has gone out, resuming belongs to the players: /unpause runs
+        a ready check across the table, which is worth more than the bot deciding on
+        its own that six people are ready. Before the notice, no such message exists
+        to act on, so a silent pause would strand the draft on a command nobody knows
+        to run.
+        """
+        told_them = self._disconnect_notice_sent
+        self._cancel_disconnect_notice()
+        lasted = self._disconnect_duration()
+
+        if not self._paused_for_disconnect:
+            self.logger.info(f"Everyone is back after {lasted}s; the pause was not ours to lift")
+            return
+        if told_them:
+            # Hand ownership over for good. Leaving this set would let a LATER brief
+            # drop, while the draft is still paused waiting on /unpause, take the
+            # not-told path and resume a pause that a ready check was supposed to lift.
+            self._paused_for_disconnect = False
+            self.logger.info(f"Everyone is back after {lasted}s; leaving the draft paused for /unpause")
+            return
+
+        if is_disconnect_autopause_enabled():
+            await self.socket_client.emit('resumeDraft')
+            self.draftPaused = False
+            self._paused_for_disconnect = False
+            self.logger.info(f"Resumed the draft: the disconnect lasted {lasted}s, inside the grace window")
+        else:
+            self._paused_for_disconnect = False
+            self.logger.info(
+                f"{SHADOW} would resume the draft: the disconnect lasted {lasted}s, "
+                f"inside the {self.disconnect_notice_delay}s grace window"
+            )
+
+    def _cancel_disconnect_notice(self):
+        """Drop a notice that has not yet committed to being sent.
+
+        Deliberately will not cancel past the point of no return: once the grace
+        window has elapsed the task may be mid-send, and killing it there would leave
+        _disconnect_notice_sent True with nothing actually posted — the draft paused,
+        the room never told why.
+        """
+        task = self._disconnect_notice_task
+        if task and not task.done() and not self._disconnect_notice_sent:
+            task.cancel()
+            self._disconnect_notice_task = None
 
     # ============== Helper Methods ==============
 
@@ -1691,10 +1909,23 @@ class DraftSetupManager:
             self.logger.exception(f"Error starting draft: {e}")
             
     async def check_session_stage_and_organize(self):
-        """Check database for session stage and organize seating if appropriate"""
+        """Check database for session stage and organize seating if appropriate.
+
+        This is the only route to emit('setSeating'), so the "never re-seat a draft
+        that is under way" rule belongs here rather than in each caller. It used to
+        rest entirely on seating_order_set staying True, which made that flag a latch
+        nobody could clear safely — and the moment a second caller had reason to clear
+        it, the rule had to be re-derived from scratch at that call site.
+        """
         if self.seating_order_set or self.seating_attempts >= 4:
             return  # Already set or max attempts reached
-            
+        if self.drafting or self.draftPaused or self._should_disconnect:
+            self.logger.info(
+                "Not organizing seating: the draft is already under way or shutting down"
+            )
+            return
+
+
         try:
             # Fetch draft session from database
             draft_session = await DraftSession.get_by_session_id(self.session_id)
@@ -2160,6 +2391,11 @@ class DraftSetupManager:
             reason: Optional description of why cleanup is happening (for logging)
         """
         self.logger.info(f"[LIFECYCLE] === CLEANUP START === Reason: {reason}")
+        # A pending disconnect notice outlives this object otherwise: /mutiny or an
+        # ownership loss during the grace window would still post "please reconnect"
+        # for a draft this manager no longer runs.
+        self._disconnect_notice_sent = False   # nothing was posted, so let it be dropped
+        self._cancel_disconnect_notice()
         self.logger.info(f"[LIFECYCLE] Manager instance ID: {id(self)}")
         self.logger.info(f"[LIFECYCLE] Socket connected before cleanup: {self.socket_client.connected}")
         self.logger.info(f"[LIFECYCLE] Session in ACTIVE_MANAGERS before cleanup: {self.session_id in ACTIVE_MANAGERS}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,3 +95,22 @@ class StubUser:
 def embed_field(embed, name):
     """The named field of an embed, or None when it wasn't rendered."""
     return next((f for f in embed.fields if f.name == name), None)
+
+
+def make_manager(**kwargs):
+    """A DraftSetupManager with its socket mocked out.
+
+    Four test files had grown their own copy of this. The constructor's signature is
+    the thing that keeps changing (packs_per_player, cards_per_pack, friendly_id have
+    all been added to it), so the copies are what a signature change has to chase.
+    Pass constructor kwargs through; layer test-specific state on the result.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from services.draft_setup_manager import DraftSetupManager
+
+    mgr = DraftSetupManager(session_id="s", draft_id="d", cube_id="c", guild_id="g", **kwargs)
+    mgr.socket_client = MagicMock()
+    mgr.socket_client.connected = True
+    mgr.socket_client.emit = AsyncMock(return_value=True)
+    return mgr

--- a/tests/test_draft_settings_emit.py
+++ b/tests/test_draft_settings_emit.py
@@ -1,22 +1,6 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
-from services.draft_setup_manager import DraftSetupManager
-
-
-def make_manager(packs_per_player=4, cards_per_pack=10):
-    mgr = DraftSetupManager(
-        session_id="s",
-        draft_id="d",
-        cube_id="c",
-        guild_id="g",
-        packs_per_player=packs_per_player,
-        cards_per_pack=cards_per_pack,
-    )
-    mgr.socket_client = MagicMock()
-    mgr.socket_client.connected = True
-    mgr.socket_client.emit = AsyncMock(return_value=True)
-    return mgr
+from conftest import make_manager
 
 
 @pytest.mark.asyncio

--- a/tests/test_log_capture.py
+++ b/tests/test_log_capture.py
@@ -18,6 +18,7 @@ def _manager():
     m.session_type = "premade"
     m.guild_id = "42"
     m.logger = MagicMock()
+    m._disconnect_notice_task = None  # _on_end_draft drops any pending disconnect notice
     return m
 
 

--- a/tests/test_pause_on_disconnect.py
+++ b/tests/test_pause_on_disconnect.py
@@ -1,0 +1,424 @@
+"""A player dropping mid-draft stalls the table, so the bot pauses and says so.
+
+Draftmancer keeps a disconnected player's seat: Session.remUser moves them into
+disconnectedUsers and stops only THEIR countdown, so everyone else drafts on until
+a pack reaches the empty seat and the table waits — with no timer running out to
+end it. DraftBot sessions are not `managed`, so the 30-second replace-with-bots
+timeout in remUser never applies to us; the stall is open-ended.
+
+/pause, /unpause and /replace_with_bots already exist (cogs/draft_control.py) — what
+was missing is that a human had to NOTICE the drop and run /pause. That is what
+these tests pin down: the bot pauses on the event Draftmancer already sends, and
+asks the player in Discord to come back.
+
+Resume stays human, through the existing /unpause and its ready check, with one
+exception: a drop that resolves before the notice is even posted resumes itself.
+Nobody was told, so nobody needs to act — and it means a brief blip cannot leave a
+table silently paused waiting on a command no one knows to run.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from conftest import make_manager
+
+
+def _autopause(enabled):
+    return patch("services.draft_setup_manager.is_disconnect_autopause_enabled",
+                 return_value=enabled)
+
+
+@pytest.fixture(autouse=True)
+def _flag_on():
+    """Everything below describes the bot with DISCONNECT_AUTOPAUSE=true.
+
+    It ships off: Draftmancer only delivers userDisconnected to a session's
+    non-playing owner and no build has ever subscribed to it, so the event is
+    unobserved in production. Shadow mode — the shipping default — has its own tests
+    at the end, and they are the ones that matter until the logs say otherwise.
+    """
+    with _autopause(True):
+        yield
+
+GREGG = {"id-gregg": {"userName": "gregg / keezles"}}
+GREGG_AND_LSV = {**GREGG, "id-lsv": {"userName": "LSV"}}
+SIGN_UPS = {"discord-gregg": "gregg / keezles", "discord-lsv": "LSV"}
+
+
+def _manager(*, notice_delay=30):
+    mgr = make_manager()
+    mgr.logger = MagicMock()
+    mgr.drafting = True
+    # Real time would make these tests wait; the delay itself is not what they check.
+    mgr.disconnect_notice_delay = notice_delay
+
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    mgr._get_draft_channel = AsyncMock(return_value=channel)
+
+    row = MagicMock()
+    row.sign_ups = dict(SIGN_UPS)
+    mgr._get_draft_session_from_db = AsyncMock(return_value=row)
+    return mgr
+
+
+def _channel(mgr):
+    return mgr._get_draft_channel.return_value
+
+
+def _logged(mgr):
+    """The manager's own log lines. loguru does not route through caplog, so the
+    shadow run is graded by replacing the bound logger outright."""
+    return " ".join(str(c.args[0]) for c in mgr.logger.info.call_args_list)
+
+
+def _emitted(mgr):
+    return [call.args[0] for call in mgr.socket_client.emit.await_args_list]
+
+
+async def _drop(mgr, disconnected):
+    await mgr._on_user_disconnected({"owner": "id-bot", "disconnectedUsers": disconnected})
+
+
+async def _everyone_back(mgr):
+    """How the LAST player returning actually reaches the bot.
+
+    Not `_drop(mgr, {})`. Session.reconnectUser deletes the user from
+    disconnectedUsers and only calls broadcastDisconnectedUsers() while someone is
+    still missing; when the map empties it calls resumeOnReconnection instead. An
+    empty userDisconnected payload is never sent, so testing with one tested a
+    situation that cannot occur.
+    """
+    await mgr._on_resume_on_reconnection({"title": "Player reconnected", "text": "..."})
+
+
+async def _let_the_notice_run(mgr):
+    """Await the pending notice instead of sleeping, so the test is deterministic."""
+    if mgr._disconnect_notice_task:
+        await mgr._disconnect_notice_task
+
+
+@pytest.mark.asyncio
+async def test_a_mid_draft_disconnect_pauses_the_draft():
+    mgr = _manager()
+
+    await _drop(mgr, GREGG)
+
+    assert "pauseDraft" in _emitted(mgr)
+    assert mgr.draftPaused is True
+
+
+@pytest.mark.asyncio
+async def test_a_blip_that_resolves_before_the_notice_resumes_itself_silently():
+    """The one case the bot resumes on its own. Nobody was told the draft paused, so
+    leaving it paused would strand the table waiting on an /unpause no one knows to
+    run."""
+    mgr = _manager(notice_delay=30)  # long enough that nothing is ever posted
+
+    await _drop(mgr, GREGG)
+    await _everyone_back(mgr)  # back again
+
+    assert _emitted(mgr) == ["pauseDraft", "resumeDraft"]
+    assert mgr.draftPaused is False
+    _channel(mgr).send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_disconnect_that_outlasts_the_window_asks_them_to_reconnect():
+    mgr = _manager(notice_delay=0)
+
+    await _drop(mgr, GREGG)
+    await _let_the_notice_run(mgr)
+
+    _channel(mgr).send.assert_awaited_once()
+    message = _channel(mgr).send.await_args.args[0]
+    # a mention, so the person who has to act actually gets pinged
+    assert "<@discord-gregg>" in message
+    assert "/unpause" in message
+
+
+@pytest.mark.asyncio
+async def test_a_return_after_the_notice_leaves_the_pause_standing():
+    """Once players have been told, resuming is theirs to do — /unpause runs a ready
+    check, which is the point of making it manual."""
+    mgr = _manager(notice_delay=0)
+
+    await _drop(mgr, GREGG)
+    await _let_the_notice_run(mgr)
+    await _everyone_back(mgr)
+
+    assert "resumeDraft" not in _emitted(mgr)
+    assert mgr.draftPaused is True
+
+
+@pytest.mark.asyncio
+async def test_a_pause_the_bot_did_not_start_is_never_auto_resumed():
+    """A participant's /pause is not the bot's to undo, whatever happens to the
+    connection afterwards."""
+    mgr = _manager(notice_delay=30)
+    mgr.draftPaused = True  # someone ran /pause first
+
+    await _drop(mgr, GREGG)
+    await _everyone_back(mgr)
+
+    assert "resumeDraft" not in _emitted(mgr)
+    assert mgr.draftPaused is True
+
+
+@pytest.mark.asyncio
+async def test_a_second_player_dropping_does_not_pause_or_announce_again():
+    mgr = _manager(notice_delay=0)
+
+    await _drop(mgr, GREGG)
+    await _drop(mgr, GREGG_AND_LSV)
+    await _let_the_notice_run(mgr)
+
+    assert _emitted(mgr).count("pauseDraft") == 1
+    _channel(mgr).send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_display_name_is_named_but_not_mentioned():
+    """sign_ups is keyed by discord id and two players can share a display name, so a
+    name lookup can pick the wrong person. Better an unpinged right name than a
+    pinged wrong one."""
+    mgr = _manager(notice_delay=0)
+    row = MagicMock()
+    row.sign_ups = {"discord-sam-1": "Sam", "discord-sam-2": "Sam"}
+    mgr._get_draft_session_from_db = AsyncMock(return_value=row)
+
+    await _drop(mgr, {"id-sam": {"userName": "Sam"}})
+    await _let_the_notice_run(mgr)
+
+    message = _channel(mgr).send.await_args.args[0]
+    assert "Sam" in message
+    assert "<@discord-sam-1>" not in message and "<@discord-sam-2>" not in message
+
+
+@pytest.mark.asyncio
+async def test_a_notice_that_fails_to_send_still_leaves_the_pause_standing():
+    """If Discord refuses the message the players are stuck with a paused draft and no
+    explanation — bad, but recoverable with /unpause. Silently resuming instead would
+    put the table back under way while someone is still missing, which is the state
+    this whole feature exists to avoid."""
+    mgr = _manager(notice_delay=0)
+    _channel(mgr).send.side_effect = RuntimeError("missing permissions")
+
+    await _drop(mgr, GREGG)
+    await _let_the_notice_run(mgr)
+    await _everyone_back(mgr)
+
+    assert "resumeDraft" not in _emitted(mgr)
+    assert mgr.draftPaused is True
+
+
+@pytest.mark.asyncio
+async def test_the_draft_ending_drops_a_pending_notice():
+    """The draft can end while someone is still disconnected — /scrap, or the others
+    replacing them with bots and finishing. Posting "please reconnect" after that is
+    noise about a draft that is over."""
+    mgr = _manager(notice_delay=30)
+    mgr.draft_cancelled = True  # the /scrap path, which skips the rooms-and-pairings work
+    await _drop(mgr, GREGG)
+    task = mgr._disconnect_notice_task
+
+    await mgr._on_end_draft({})
+
+    await asyncio.sleep(0)  # let the cancellation land
+    assert task.cancelled() or task.done()
+    _channel(mgr).send.assert_not_awaited()
+
+
+# ---- shadow mode: the shipping default -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_touches_neither_draftmancer_nor_discord():
+    """The whole point of shipping off: work out the decision, do none of it.
+
+    draftPaused is checked explicitly because it is not private bookkeeping — the
+    seating recovery reads it and /unpause refuses to run without it. Setting it
+    without a real pause would leave the rest of the bot believing a draft was paused
+    while Draftmancer played on, which is a worse failure than the one being guarded
+    against.
+    """
+    mgr = _manager(notice_delay=0)
+
+    with _autopause(False):
+        await _drop(mgr, GREGG)
+        await _let_the_notice_run(mgr)
+
+    assert _emitted(mgr) == [], "shadow mode must not talk to Draftmancer"
+    _channel(mgr).send.assert_not_awaited()
+    assert mgr.draftPaused is False
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_still_renders_the_notice_it_would_have_sent():
+    """Rendering it is what proves the channel lookup, the sign_ups read and the
+    mention resolution work — before any of it is trusted with a live draft."""
+    mgr = _manager(notice_delay=0)
+
+    with _autopause(False):
+        await _drop(mgr, GREGG)
+        await _let_the_notice_run(mgr)
+
+    logged = _logged(mgr)
+    assert "[autopause-shadow]" in logged
+    assert "<@discord-gregg>" in logged, "the shadow log should carry the real message"
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_records_how_long_the_disconnect_lasted():
+    """The number that decides whether 15s is anywhere near right. Nothing has ever
+    measured it, because nothing subscribed to the event that reports it."""
+    mgr = _manager(notice_delay=30)
+
+    with _autopause(False):
+        await _drop(mgr, GREGG)
+        await _everyone_back(mgr)
+
+    logged = _logged(mgr)
+    assert "would resume" in logged
+    assert "lasted" in logged
+
+
+def test_the_flag_ships_off():
+    """The guarantee that deploying this stack changes nothing for players.
+
+    Asserted against the real config function rather than the patch used above, so
+    that a mistake in the default cannot hide behind the test fixture.
+    """
+    import os
+
+    from config import is_disconnect_autopause_enabled
+
+    with patch.dict(os.environ):
+        os.environ.pop("DISCONNECT_AUTOPAUSE", None)
+        assert is_disconnect_autopause_enabled() is False
+
+        os.environ["DISCONNECT_AUTOPAUSE"] = "true"
+        assert is_disconnect_autopause_enabled() is True
+
+
+# ---- what the Codex review caught ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_real_reconnect_event_resumes_a_blip():
+    """The bug the old tests hid: they fed `userDisconnected: {}`, which upstream
+    never sends. In production the blip would never have been noticed, the notice
+    would have fired 15s later for a player already back, and the draft would have
+    stayed paused waiting on an /unpause nobody expected to need."""
+    mgr = _manager(notice_delay=30)
+
+    await _drop(mgr, GREGG)
+    await _everyone_back(mgr)
+
+    assert _emitted(mgr) == ["pauseDraft", "resumeDraft"]
+    assert mgr.draftPaused is False
+    assert mgr.disconnected_users == {}
+
+
+@pytest.mark.asyncio
+async def test_a_later_blip_cannot_resume_a_pause_handed_to_the_players():
+    """Once the room has been told to use /unpause, that is the only way back — a
+    second brief drop must not quietly hand the draft back to the bot's own
+    resume path and lift a pause a ready check was supposed to lift."""
+    mgr = _manager(notice_delay=0)
+
+    await _drop(mgr, GREGG)
+    await _let_the_notice_run(mgr)      # players told; resume is theirs now
+    await _everyone_back(mgr)
+    assert mgr.draftPaused is True
+
+    # ...and later someone drops briefly again while the draft is still paused
+    mgr.disconnect_notice_delay = 30
+    await _drop(mgr, GREGG)
+    await _everyone_back(mgr)
+
+    assert "resumeDraft" not in _emitted(mgr)
+    assert mgr.draftPaused is True
+
+
+@pytest.mark.asyncio
+async def test_a_notice_mid_send_is_not_cancelled():
+    """_disconnect_notice_sent flips the moment the grace window elapses, so between
+    that and the message landing there is a window where cancelling would leave the
+    flag claiming the room was told while nothing was ever posted — a paused draft
+    and no explanation.
+
+    Suspends the task INSIDE channel.send to sit in that window deliberately; an
+    earlier version of this test let the task finish first, so `not task.done()`
+    short-circuited and it proved nothing.
+    """
+    mgr = _manager(notice_delay=0)
+    release = asyncio.Event()
+
+    async def blocking_send(*args, **kwargs):
+        await release.wait()
+
+    _channel(mgr).send = AsyncMock(side_effect=blocking_send)
+
+    await _drop(mgr, GREGG)
+    for _ in range(10):          # let it clear the sleep and reach the send
+        await asyncio.sleep(0)
+    assert mgr._disconnect_notice_sent is True, "should be past the point of no return"
+    task = mgr._disconnect_notice_task
+    assert not task.done(), "should be suspended inside the send"
+
+    mgr._cancel_disconnect_notice()
+    await asyncio.sleep(0)
+
+    assert not task.cancelled(), "cancelling mid-send drops the message but keeps the flag"
+
+    release.set()
+    await task
+    _channel(mgr).send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_manager_being_torn_down_stops_talking():
+    """/mutiny hands the session to a human and drops the manager. A notice still
+    pending from before that would post about a draft this manager no longer runs."""
+    mgr = _manager(notice_delay=30)
+    mgr.socket_client.connected = False
+    await _drop(mgr, GREGG)
+    task = mgr._disconnect_notice_task
+
+    await mgr._cleanup_and_disconnect("mutiny command")
+
+    await asyncio.sleep(0)
+    assert task.cancelled() or task.done()
+    _channel(mgr).send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_player_named_everyone_cannot_ping_the_server():
+    """Draftmancer accepts any setUserName, and an unresolved name is inserted as raw
+    text. Without allowed_mentions the bot would happily @everyone on their behalf."""
+    mgr = _manager(notice_delay=0)
+    row = MagicMock()
+    row.sign_ups = {"discord-someone": "someone else"}   # no match -> raw name used
+    mgr._get_draft_session_from_db = AsyncMock(return_value=row)
+
+    await _drop(mgr, {"id-x": {"userName": "@everyone"}})
+    await _let_the_notice_run(mgr)
+
+    kwargs = _channel(mgr).send.await_args.kwargs
+    mentions = kwargs.get("allowed_mentions")
+    assert mentions is not None, "raw Draftmancer names need an allowed_mentions guard"
+    assert mentions.everyone is False and mentions.roles is False
+
+
+def test_the_pause_command_can_resolve_the_shared_copy():
+    """/pause interpolates PAUSED_DRAFT_OPTIONS into its reply. Sharing the constant
+    without importing it left the command raising NameError *after* it had already
+    paused Draftmancer — the draft stops, the player sees an error. Nothing else in
+    the suite exercises pause_command, so this asserts the name resolves in the
+    module that uses it."""
+    import cogs.draft_control as draft_control
+
+    assert isinstance(getattr(draft_control, "PAUSED_DRAFT_OPTIONS", None), str)
+    assert "/unpause" in draft_control.PAUSED_DRAFT_OPTIONS

--- a/tests/test_reseat_after_leave.py
+++ b/tests/test_reseat_after_leave.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.draft_setup_manager import DraftSetupManager
+from conftest import make_manager
 
 SEATS = ["Adham", "Birb", "LSV", "gregg", "Mack", "Mark R"]
 
@@ -28,16 +28,21 @@ def _users(names):
 
 
 def _manager(sign_ups):
-    mgr = DraftSetupManager(session_id="s", draft_id="d", cube_id="c", guild_id="g")
-    mgr.socket_client = MagicMock()
-    mgr.socket_client.connected = True
-    mgr.socket_client.emit = AsyncMock(return_value=True)
+    mgr = make_manager()
     mgr.expected_user_count = len(sign_ups)
     mgr.desired_seating_order = list(sign_ups)
     mgr.draft_channel_id = "chan"
     # Discord I/O is not what this is about.
     mgr.update_status_message_after_user_change = AsyncMock()
     return mgr
+
+
+def _already_seated(mgr, seats=SEATS):
+    """The state the bot is in once it has seated the table."""
+    mgr.session_users = _users(seats)
+    mgr.users_count = len(seats)
+    mgr.seating_order_set = True
+    mgr.seated_user_ids = {f"id-{n}" for n in seats}
 
 
 def _db_session(sign_ups):
@@ -87,11 +92,7 @@ async def test_a_player_leaving_after_seating_clears_the_seated_flag():
     """The narrower contract the recovery depends on: once a seated player is gone,
     the bot must stop believing the seating it sent is still valid."""
     mgr = _manager(SEATS)
-    # the state the bot is in once it has seated everyone
-    mgr.session_users = _users(SEATS)
-    mgr.users_count = len(SEATS)
-    mgr.seating_order_set = True
-    mgr.seated_user_ids = {f"id-{n}" for n in SEATS}
+    _already_seated(mgr)
 
     with patch("services.draft_setup_manager.DraftSession.get_by_session_id",
                new=AsyncMock(return_value=_db_session(SEATS))):
@@ -110,10 +111,7 @@ async def test_a_seated_player_swapped_for_a_newcomer_is_noticed():
     it and reproduce the original incident with no way back.
     """
     mgr = _manager(SEATS)
-    mgr.session_users = _users(SEATS)
-    mgr.users_count = len(SEATS)
-    mgr.seating_order_set = True
-    mgr.seated_user_ids = {f"id-{n}" for n in SEATS}
+    _already_seated(mgr)
 
     swapped = [n for n in SEATS if n != "gregg"] + ["latecomer"]
     assert len(swapped) == len(SEATS), "the point of this test is that the count holds"
@@ -123,6 +121,43 @@ async def test_a_seated_player_swapped_for_a_newcomer_is_noticed():
         await mgr._on_session_users(_users(swapped))
 
     assert mgr.seating_order_set is False
+
+
+@pytest.mark.asyncio
+async def test_the_seating_machinery_itself_refuses_to_seat_a_live_draft():
+    """The invariant belongs to check_session_stage_and_organize, not to its callers.
+
+    It is the only route to emit('setSeating'), and it used to rest entirely on
+    seating_order_set being True — which made that flag a latch nobody could clear
+    safely. This branch adds a second caller that clears it, and any future one would
+    otherwise have to re-derive the same three-flag guard or silently re-seat a draft
+    already in progress.
+
+    The second half of the test is what stops the first half being vacuous: with
+    drafting cleared and nothing else changed, the same call does seat.
+    """
+    mgr = _manager(SEATS)
+    _already_seated(mgr)
+    mgr.seating_order_set = False  # something invalidated the seating
+    mgr.drafting = True
+    mgr._get_draft_channel = AsyncMock(return_value=None)
+
+    attempts = []
+
+    async def fake_attempt(desired_seating_order):
+        attempts.append(list(desired_seating_order))
+
+    mgr.attempt_seating_order = fake_attempt
+
+    with patch("services.draft_setup_manager.DraftSession.get_by_session_id",
+               new=AsyncMock(return_value=_db_session(SEATS))):
+        await mgr.check_session_stage_and_organize()
+        assert not attempts, "seating a draft that is already under way scrambles it"
+
+        mgr.drafting = False
+        await mgr.check_session_stage_and_organize()
+
+    assert attempts, "with the draft not under way the same call must seat"
 
 
 @pytest.mark.asyncio
@@ -157,15 +192,12 @@ async def test_an_unseated_arrival_does_not_reset_anything():
 
 @pytest.mark.asyncio
 async def test_a_disconnect_during_the_draft_does_not_disturb_the_seating():
-    """The dangerous case. Nothing in check_session_stage_and_organize checks
-    self.drafting — seating_order_set IS the latch that stops the seating being
-    touched again — so clearing it mid-draft would let a reconnect re-emit
-    setSeating into a live draft. Worse than the bug this branch fixes."""
+    """The dangerous case: re-emitting setSeating into a live draft would be worse
+    than the bug this fixes. check_session_stage_and_organize now refuses to seat
+    while self.drafting, so this is the second of two locks — the bot also keeps its
+    record of who it seated rather than throwing it away on a mid-draft wobble."""
     mgr = _manager(SEATS)
-    mgr.session_users = _users(SEATS)
-    mgr.users_count = len(SEATS)
-    mgr.seating_order_set = True
-    mgr.seated_user_ids = {f"id-{n}" for n in SEATS}
+    _already_seated(mgr)
     mgr.drafting = True
 
     with patch("services.draft_setup_manager.DraftSession.get_by_session_id",
@@ -178,10 +210,7 @@ async def test_a_disconnect_during_the_draft_does_not_disturb_the_seating():
 @pytest.mark.asyncio
 async def test_a_paused_draft_is_left_alone_too():
     mgr = _manager(SEATS)
-    mgr.session_users = _users(SEATS)
-    mgr.users_count = len(SEATS)
-    mgr.seating_order_set = True
-    mgr.seated_user_ids = {f"id-{n}" for n in SEATS}
+    _already_seated(mgr)
     mgr.draftPaused = True
 
     with patch("services.draft_setup_manager.DraftSession.get_by_session_id",
@@ -235,10 +264,7 @@ async def test_flapping_cannot_reseat_without_limit():
     on every departure would let someone leaving and rejoining drive setSeating
     forever."""
     mgr = _manager(SEATS)
-    mgr.session_users = _users(SEATS)
-    mgr.users_count = len(SEATS)
-    mgr.seating_order_set = True
-    mgr.seated_user_ids = {f"id-{n}" for n in SEATS}
+    _already_seated(mgr)
     mgr.seating_attempts = 3
 
     with patch("services.draft_setup_manager.DraftSession.get_by_session_id",

--- a/tests/test_socket_event_names.py
+++ b/tests/test_socket_event_names.py
@@ -87,13 +87,14 @@ def test_the_last_player_returning_is_subscribed():
 # ---- the handlers behind those names --------------------------------------------
 
 import pytest
-from unittest.mock import AsyncMock, patch
+
+from conftest import make_manager
 
 
 def _manager():
-    mgr = DraftSetupManager(session_id="s", draft_id="d", cube_id="c", guild_id="g")
-    mgr.socket_client = MagicMock()
-    return mgr
+    # make_manager's mocked emit matters here: a disconnect now pauses the draft as
+    # well as recording it — see test_pause_on_disconnect.py for that behaviour.
+    return make_manager()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Re-targets the work from #417, which was merged into `socket-event-names` instead of `main`. #416 merged to `main` seconds earlier, so `main` has the socket-event-name fixes but not this commit. Content is unchanged — the single commit `4ef112c`, whose parent is already on `main`.

Full description in #417. In brief:

A mid-draft disconnect stalls the whole table and nothing ends it — Draftmancer holds the absent player's seat and stops only their countdown, and DraftBot sessions aren't `managed`, so the 30-second replace-with-bots fallback never applies. The bot now pauses and asks the player to reconnect.

**Ships off**, behind `DISCONNECT_AUTOPAUSE`. Draftmancer only delivers `userDisconnected` to a session's non-playing owner and no build has ever subscribed to it, so the event is unobserved in production. Shadow mode takes every decision and logs it while emitting nothing and posting nothing — notably leaving `draftPaused` alone, since the seating recovery reads it and `/unpause` refuses to run without it. It also records how long each disconnect lasts, which is what will decide whether the 15-second window is right.

Includes the fixes from the Codex review of #417: the missing `PAUSED_DRAFT_OPTIONS` import that would have crashed `/pause`, routing `resumeOnReconnection` (the only event that signals everyone is back — an empty `userDisconnected` payload is never sent), clearing `_paused_for_disconnect` when resume passes to players, not cancelling a notice past the point of no return, dropping pending notices on manager teardown, and `allowed_mentions` so a player named `@everyone` can't ping the server.

1210 passed / 10 skipped, `pyrefly check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw