### PR TITLE
Give ephemeral settle views their own dispatch slot

### DIFF
--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -232,10 +232,17 @@ class CounterpartySelectView(View):
         # Limit to 25 options (Discord limit)
         options = options[:25]
 
+        # No custom_id: py-cord registers ephemeral views with message_id=None,
+        # so its dispatch key (component_type, message_id, custom_id) has only the
+        # custom_id left to tell instances apart. A fixed one puts every live
+        # instance in ONE process-wide slot, where each new view silently evicts the
+        # last — the evicted view's selections then land on the newest instance (wrong
+        # balances) and, once that stops, on nothing at all. An auto-generated id per
+        # instance gives each view its own slot. Persistent views keep fixed ids;
+        # they are re-registered by id after a restart.
         select = Select(
             placeholder="Select who to settle with...",
             options=options,
-            custom_id="counterparty_select"
         )
         select.callback = self.select_callback
         self.add_item(select)
@@ -610,10 +617,10 @@ class TransferCreditorSelectView(View):
 
         options = options[:25]
 
+        # Ephemeral view — see the note on CounterpartySelectView's select.
         select = Select(
             placeholder="Select whose debt to reduce...",
             options=options,
-            custom_id="transfer_creditor_select"
         )
         select.callback = self.select_callback
         self.add_item(select)
@@ -700,10 +707,10 @@ class DebtorSelectView(View):
 
         options = options[:25]
 
+        # Ephemeral view — see the note on CounterpartySelectView's select.
         select = Select(
             placeholder="Select who to transfer debt from...",
             options=options,
-            custom_id="debtor_select"
         )
         select.callback = self.select_callback
         self.add_item(select)

--- a/tests/test_settle_view_dispatch.py
+++ b/tests/test_settle_view_dispatch.py
@@ -1,0 +1,257 @@
+"""Ephemeral settle-flow views must dispatch per-instance, not per-class.
+
+Same failure mode as the quiz views (see test_quiz_view_dispatch.py), in a
+different module. py-cord's ViewStore keys live views by
+(component_type, message_id, custom_id), and an ephemeral view sent via
+interaction.response.send_message is registered with message_id=None — so
+any custom_id shared between two live instances collapses them into ONE
+process-wide dispatch slot. add_view() overwrites that slot, so the newest
+registration silently evicts the older one, and the evicted message's
+components dispatch to nothing: Discord shows "This interaction failed"
+and the buttons are dead forever.
+
+REPRODUCED — prod incident, 2026-08-12 23:37:28 (Lotus Lounge): a
+counterparty selection was dispatched to a DIFFERENT user's view instance,
+which logged the nonsensical "User 204717025363230720 selected counterparty
+204717025363230720, balance: 0" (their own id was never an option in their
+own menu) and then crashed building the next view: "In
+data.components.0.components.0.options: Must be between 1 and 25 in length"
+— the misrouted balance of 0 with no card positions yields an entity select
+with zero options. Both halves of that chain have a test below.
+
+NOT EXPLAINED BY THIS MECHANISM — prod incident, 2026-08-13 16:11:00: a
+settlement confirmation was sent successfully and the user's Confirm click
+produced no log line at all (neither the confirm handler's first statement
+nor Cancel's); they retried 14s later, and the same pair had failed
+identically the previous evening. test_concurrent_settlement_confirms_...
+below PASSES against current code, which rules the collision out for that
+dialog: py-cord generates a per-instance custom_id for decorator-declared
+buttons. Note ViewStore.dispatch() returns silently when no view matches, so
+a dropped interaction and one that never arrived are indistinguishable in
+logs — separating them needs an on_interaction listener logging arrivals.
+
+Only PERSISTENT views (timeout=None, re-registered on restart) may pin a
+custom_id; ephemeral views must let py-cord generate one per instance.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+import discord
+from discord.ui.item import Item
+from discord.ui.view import View, ViewStore
+
+import debt_views.settle_views as sv
+from debt_views.settle_views import (
+    CounterpartySelectView,
+    DebtorSelectView,
+    SettleEntitySelectView,
+    SettlementConfirmView,
+    TransferCreditorSelectView,
+)
+
+SELECT = discord.ComponentType.string_select.value
+BUTTON = discord.ComponentType.button.value
+
+GUILD = SimpleNamespace(id=1, get_member=lambda _id: None)
+
+# Views started under a running loop spawn a timeout task; stop them after
+# each test so pytest doesn't report pending tasks at teardown.
+_LIVE_VIEWS = []
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _stop_views():
+    """Async so teardown runs while the loop is still open (View.stop()
+    cancels the timeout task)."""
+    yield
+    for view in _LIVE_VIEWS:
+        view.stop()
+    _LIVE_VIEWS.clear()
+
+
+def _track(view):
+    _LIVE_VIEWS.append(view)
+    return view
+
+
+def _counterparty_view(user_id, counterparty_id):
+    with patch.object(sv, "get_member_name_plain", lambda g, i: f"player-{i}"):
+        return _track(CounterpartySelectView(
+            user_id=user_id,
+            guild_id="g1",
+            balances={counterparty_id: -20},
+            guild=GUILD,
+        ))
+
+
+def _confirm_view(user_id, counterparty_id):
+    return _track(SettlementConfirmView(
+        user_id=user_id,
+        guild_id="g1",
+        payer_id=counterparty_id,
+        payee_id=user_id,
+        amount=20,
+    ))
+
+
+def _entity_view(user_id, counterparty_id, net_balance=-20, positions=None):
+    return _track(SettleEntitySelectView(
+        user_id=user_id,
+        guild_id="g1",
+        counterparty_id=counterparty_id,
+        net_balance=net_balance,
+        counterparty_name_plain="them",
+        counterparty_name_decorated="them",
+        positions=positions if positions is not None else [],
+    ))
+
+
+def _transfer_creditor_view(user_id, counterparty_id):
+    with patch.object(sv, "get_member_name_plain", lambda g, i: f"player-{i}"):
+        return _track(TransferCreditorSelectView(
+            user_id=user_id,
+            guild_id="g1",
+            creditors_with_transfers=[(counterparty_id, 20, [("d1", 20, 20)])],
+            guild=GUILD,
+        ))
+
+
+def _debtor_view(user_id, counterparty_id):
+    with patch.object(sv, "get_member_name_plain", lambda g, i: f"player-{i}"):
+        return _track(DebtorSelectView(
+            user_id=user_id,
+            guild_id="g1",
+            creditor_id=counterparty_id,
+            creditor_name_plain="them",
+            creditor_name_decorated="them",
+            transferable_debtors=[("d1", 20, 20)],
+            guild=GUILD,
+        ))
+
+
+def _ephemeral_settle_views(user_id, counterparty_id):
+    """One instance of every per-user ephemeral view in the settle flow —
+    extend when adding a new one so the per-instance-id invariant covers it.
+
+    All three views this branch touched are here: leaving two of them out would have
+    let a partial revert pass, since only the counterparty select was exercised.
+    """
+    return [
+        _counterparty_view(user_id, counterparty_id),
+        _entity_view(user_id, counterparty_id),
+        _confirm_view(user_id, counterparty_id),
+        _transfer_creditor_view(user_id, counterparty_id),
+        _debtor_view(user_id, counterparty_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_settle_views_have_per_instance_component_ids():
+    """No dispatchable component may share a custom_id across two fresh
+    instances — a shared id is a shared, evictable dispatch slot."""
+    for a, b in zip(_ephemeral_settle_views("u1", "c1"),
+                    _ephemeral_settle_views("u2", "c2")):
+        ids_a = {c.custom_id for c in a.children if c.is_dispatchable()}
+        ids_b = {c.custom_id for c in b.children if c.is_dispatchable()}
+        shared = ids_a & ids_b
+        assert not shared, (
+            f"{type(a).__name__} shares dispatch ids across instances: {shared}")
+
+
+def _dispatched_to(store, component_type, custom_id, message_id, routed):
+    routed.clear()
+    store.dispatch(component_type, custom_id, SimpleNamespace(
+        message=SimpleNamespace(id=message_id), data={"values": []}))
+    return routed[0] if routed else None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_counterparty_selects_dispatch_independently():
+    """Two users picking a counterparty at the same time: each selection
+    must reach the view holding that user's balances. Prod incident 1 —
+    the misroute is what let one user's menu answer another user's view."""
+    routed = []
+    with patch.object(View, "_dispatch_item",
+                      lambda self, item, i: routed.append(self)), \
+         patch.object(Item, "refresh_state", lambda self, i: None):
+        store = ViewStore(state=SimpleNamespace())
+        view_a = _counterparty_view("u1", "c1")
+        view_b = _counterparty_view("u2", "c2")
+        store.add_view(view_a, message_id=None)   # as ephemeral sends do
+        store.add_view(view_b, message_id=None)
+
+        id_a = next(c.custom_id for c in view_a.children if c.is_dispatchable())
+        id_b = next(c.custom_id for c in view_b.children if c.is_dispatchable())
+
+        assert _dispatched_to(store, SELECT, id_a, 111, routed) is view_a
+        assert _dispatched_to(store, SELECT, id_b, 222, routed) is view_b
+
+
+@pytest.mark.asyncio
+async def test_concurrent_settlement_confirms_dispatch_independently():
+    """Two settlement confirmations live at once (two users, or one user
+    settling with two counterparties in a row): each Confirm must reach its
+    own view.
+
+    This PASSES against current code — decorator-declared buttons already get
+    a per-instance custom_id. Kept as a guard so nobody "fixes" the confirm
+    dialog by pinning an id, and as the record that eviction is NOT the cause
+    of the 2026-08-13 dead-Confirm report.
+    """
+    routed = []
+    with patch.object(View, "_dispatch_item",
+                      lambda self, item, i: routed.append(self)), \
+         patch.object(Item, "refresh_state", lambda self, i: None):
+        store = ViewStore(state=SimpleNamespace())
+        view_a = _confirm_view("u1", "c1")
+        view_b = _confirm_view("u2", "c2")
+        store.add_view(view_a, message_id=None)
+        store.add_view(view_b, message_id=None)
+
+        def confirm_id(v):
+            return next(c.custom_id for c in v.children
+                        if getattr(c, "label", "") == "Confirm Settlement")
+
+        assert _dispatched_to(store, BUTTON, confirm_id(view_a), 111, routed) is view_a
+        assert _dispatched_to(store, BUTTON, confirm_id(view_b), 222, routed) is view_b
+
+
+
+@pytest.mark.asyncio
+async def test_an_ephemeral_send_really_registers_without_a_message_id():
+    """The library contract that makes custom_id load-bearing here.
+
+    Everything else in this file assumes ephemeral views are registered with
+    message_id=None. If that were wrong — if they were keyed by message id like
+    ordinary sends — the custom_id would not matter and none of this could happen.
+    So it is pinned against py-cord itself (2.6.1) rather than restated as an
+    assumption: store_view defaults message_id to None, ViewStore keys on the
+    3-tuple, and with message_id None the custom_id is the only thing left
+    separating two live instances.
+
+    The last assertion is the fix: two instances must occupy TWO slots. Before the
+    fix they shared one, and the newer silently evicted the older.
+    """
+    import inspect
+
+    from discord.state import ConnectionState
+
+    sig = inspect.signature(ConnectionState.store_view)
+    assert sig.parameters["message_id"].default is None, (
+        "store_view no longer defaults message_id to None — re-check the analysis")
+
+    store = ViewStore(state=SimpleNamespace())
+    view_a = _counterparty_view("u1", "c1")
+    view_b = _counterparty_view("u2", "c2")
+    store.add_view(view_a, message_id=None)
+    store.add_view(view_b, message_id=None)
+
+    assert all(k[1] is None for k in store._views), (
+        "ephemeral slots key on message_id None, which is what leaves custom_id "
+        "as the only discriminator")
+    assert len(store._views) == 2, (
+        "each ephemeral view needs its own dispatch slot; sharing one means the "
+        "newer silently evicts the older")


### PR DESCRIPTION
Three deleted lines are the fix. Everything else is the regression test and the reasoning.

## The bug

py-cord routes every component click by one key in one process-wide dict (`ui/view.py:599`):

```python
self._views[(item.type.value, message_id, item.custom_id)] = (view, item)
```

A view sent with `ephemeral=True` registers with **`message_id=None`** — the message doesn't exist yet at send time — so `custom_id` is the only thing separating two live instances. That line is a plain dict assignment, so the newer registration **silently evicts** the older. The evicted view's selections then dispatch to the newer instance (someone else's balances), and once that instance stops, to nothing at all: "This interaction failed", permanently.

`CounterpartySelectView`, `TransferCreditorSelectView` and `DebtorSelectView` are all `timeout=300` ephemeral views that carried a fixed `custom_id`, so every live instance shared one slot.

## Evidence this is happening

**Production logs** — 294 view creations across 39 users:

- **120 collision windows** — two *different* users with the settle flow open inside the 300s view timeout, some 3 and 20 seconds apart
- **3 impossible self-selections** — `User X selected counterparty X`, on 2026-08-01, 08-03 and 08-12. A user is never an option in their own menu, so that can only happen if the click landed on another instance's view. The 08-12 one is the incident that got reported; it was the third.

That count is conservative: py-cord's `remove_view` pops a 2-tuple against a 3-tuple keyspace, so stopped views are never actually removed and a timed-out view keeps holding its slot until the process restarts.

**Reproduced end-to-end** in the test guild. Two views live with divergent state, then using the older one's dropdown:

```
14:20:33  User … selected counterparty 144605755826372608, balance: 0     ← misroute (real balance 5)
14:20:33  Error in select callback: 400 Bad Request (error code: 50035)   ← empty select, flow dies
```

Post-fix, identical steps and data: `balance: 5`, no error. That also shows the two known settle bugs are one chain — the misroute produces the zero balance, which produces the empty select.

## The fix

Drop the hardcoded `custom_id` so py-cord assigns `os.urandom(16).hex()` per instance, and each view keeps its own slot. Same fix `d2feec1` applied to the quiz views; these were missed at the time.

Deliberately **not** touched: `PublicSettleDebtsView`'s ids (`timeout=None`, re-registered by id at startup via `bot.add_view` in `bot.py`) and `SettleDebtsButton`'s per-session `settle_debts:{session_id}`. Persistent views need stable ids — that's how their buttons survive a restart.

## Tests

`tests/test_settle_view_dispatch.py` drives py-cord's real `ViewStore`, not a mock of it: per-instance id uniqueness across all three changed views, correct routing for two concurrent instances, and the library contract the whole analysis rests on — that `store_view` defaults `message_id` to `None`.

Verified by reverting: restoring any one hardcoded id fails the suite, including a partial revert of just the two views that an earlier version of the test didn't cover.

Full suite green, `pyrefly check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw