### PR TITLE
Don't send a select with no options when there's nothing to settle

### DIFF
--- a/debt_views/settle_views.py
+++ b/debt_views/settle_views.py
@@ -268,6 +268,28 @@ class CounterpartySelectView(View):
                 self.guild_id, self.user_id, counterparty_id=counterparty_id
             )
 
+            # Nothing to settle: Discord rejects a select with no options (400, code
+            # 50035), so building the flow from here would kill it outright.
+            #
+            # The picker lists anyone with a non-zero tix balance OR an open card
+            # loan (merge_counterparty_entries), so a card-only counterparty appears
+            # with a balance of 0 — and reaching this means their last card came back
+            # between the menu being drawn and clicked. Note `balance` is the value
+            # captured when the view was built while `positions` is live, so this
+            # deliberately does not claim to notice a tix settlement made meanwhile.
+            # /settle checks the same condition itself, against live values, before it
+            # builds any view.
+            if not build_entity_choices(balance, positions):
+                logger.info(
+                    f"[CounterpartySelect] Nothing left to settle between "
+                    f"{self.user_id} and {counterparty_id}")
+                await interaction.response.edit_message(
+                    content=(f"There's nothing left to settle with "
+                             f"**{get_member_name_plain(self.guild, counterparty_id)}**. "
+                             f"`/debts summary` shows where you stand."),
+                    embed=None, view=None)
+                return
+
             name_decorated = get_member_name(self.guild, counterparty_id)
             name_plain = get_member_name_plain(self.guild, counterparty_id)
 

--- a/tests/test_settle_entity_step.py
+++ b/tests/test_settle_entity_step.py
@@ -1,0 +1,101 @@
+"""Choosing a counterparty who turns out to have nothing left to settle.
+
+Discord rejects a string select with no options (400, error code 50035). The settle
+flow's entity picker builds its options from the tix balance and any open card loans,
+so when both are empty it used to send an empty select and die on the spot — which is
+how prod incident 1 ended.
+
+The picker lists anyone with a non-zero tix balance OR an open card loan, so a
+card-only counterparty is offered with a balance of 0 (merge_counterparty_entries
+says as much). That is the reachable route here: their last card came back between
+the menu being drawn and clicked. /settle checks the same condition itself, against
+live values, before it builds anything.
+
+An error case rather than an ordinary one, so it is guarded rather than described in
+detail — there is nothing for the player to decide, only something to be told.
+"""
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import debt_views.settle_views as sv
+from debt_views.settle_views import CounterpartySelectView
+
+GUILD = SimpleNamespace(id=1, get_member=lambda _id: None)
+
+
+def _view(balances, positions_by_cp=None):
+    with patch.object(sv, "get_member_name_plain", lambda g, i: f"player-{i}"):
+        return CounterpartySelectView(
+            user_id="u1", guild_id="g1", balances=balances, guild=GUILD,
+            positions_by_cp=positions_by_cp)
+
+
+def _interaction(selected):
+    interaction = MagicMock()
+    interaction.data = {"values": [selected]}
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _flow(positions=None):
+    """The lookups the callback makes before it decides anything, as one context."""
+    stack = ExitStack()
+    stack.enter_context(patch.object(sv, "get_entries_since_last_settlement",
+                                     new=AsyncMock(return_value=[])))
+    stack.enter_context(patch.object(sv, "get_open_card_positions",
+                                     new=AsyncMock(return_value=positions or [])))
+    stack.enter_context(patch.object(sv, "get_member_name_plain", lambda g, i: "them"))
+    stack.enter_context(patch.object(sv, "get_member_name", lambda g, i: "**them**"))
+    return stack
+
+
+@pytest.mark.asyncio
+async def test_nothing_left_to_settle_says_so_instead_of_sending_an_empty_select():
+    """Built the way the picker really produces a zero-tix counterparty: no tix
+    balance at all, listed only because a card was out on loan. get_all_balances_for
+    never returns a zero, so a `{"c1": 0}` balances dict would be testing a state the
+    code cannot reach."""
+    view = _view({}, positions_by_cp={"c1": [{"card_name": "Black Lotus", "net": -1}]})
+    interaction = _interaction("c1")
+
+    with _flow():
+        await view.select_callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["view"] is None, "a picker with nothing to pick is rejected by Discord"
+    assert "nothing left to settle" in kwargs["content"].lower()
+    view.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_real_balance_still_gets_the_picker():
+    """Non-vacuity: the guard must not swallow the ordinary case."""
+    view = _view({"c1": -5})
+    interaction = _interaction("c1")
+
+    with _flow():
+        await view.select_callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs.get("view") is not None, "there is 5 tix to settle here"
+    view.stop()
+
+
+@pytest.mark.asyncio
+async def test_an_open_card_loan_alone_is_enough_to_settle():
+    """Zero tix but an outstanding card is still something to settle, so the balance
+    on its own is the wrong thing to branch on."""
+    view = _view({}, positions_by_cp={"c1": [{"card_name": "Black Lotus", "net": -1}]})
+    interaction = _interaction("c1")
+    positions = [{"card_name": "Black Lotus", "net": -1}]
+
+    with _flow(positions=positions):
+        await view.select_callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs.get("view") is not None
+    view.stop()


### PR DESCRIPTION
22 production lines in one function, purely additive: if the condition never fires, behaviour is identical to today.

## The bug

Discord rejects a string select with no options — **400, error code 50035**. The settle flow's entity picker builds its options from the tix balance plus any open card loans, so when both are empty it built one anyway and the flow died on the spot.

Caught live in the test guild while reproducing #420:

```
14:20:33  User … selected counterparty 144605755826372608, balance: 0
14:20:33  Error in select callback: 400 Bad Request (error code: 50035): Invalid Form Body
```

Those two lines are one chain. The dispatch misroute fixed in #420 made a view look up a counterparty it didn't know, get `0`, and then build an empty select. **#420 removes the common cause; this handles the condition itself.**

## Still reachable after #420

Not dead code. `merge_counterparty_entries` deliberately lists counterparties you only exchange *cards* with — their tix balance is `0`, which its own docstring says outright. So the reachable route is a card-only counterparty whose last card came back between the menu being drawn and clicked.

## The fix

One guard in `CounterpartySelectView.select_callback`, placed right after `get_open_card_positions` and before the breakdown embed is built — so the work that would have been thrown away isn't done either:

```python
if not build_entity_choices(balance, positions):
    ...
    await interaction.response.edit_message(content=..., embed=None, view=None)
    return
```

Treated as the error case it is, rather than a state worth describing at length. `/settle` already checks the same condition itself, against live values, before it builds any view — so there's nothing here for the player to decide, only something to be told.

**One honest limitation, stated in the code comment rather than papered over:** `balance` is the value captured when the view was built while `positions` is fetched live, so this deliberately does not claim to notice a tix settlement made while the menu sat open. The message is worded accordingly — it says what's true now, not how it came to be true.

## Tests

Three, in `tests/test_settle_entity_step.py`, built the way the picker really produces a zero-tix counterparty — `balances={}` plus `positions_by_cp` — because `get_all_balances_for` never returns a zero, so a `{"c1": 0}` dict would test a state the code cannot reach.

Covers the guard firing, the ordinary case still getting its picker, and a card-loan-only counterparty still being settleable. Verified by removing the guard: the first test fails.

Full suite green (1218 passed), `pyrefly check` 0 errors. Rebased on `main` post-#420 and re-run, since both touch `debt_views/settle_views.py` — different functions, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw