### PR TITLE
Catch two live views claiming one dispatch slot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -56,6 +56,13 @@ async def main():
     
     @bot.event
     async def on_ready():
+        # First thing in on_ready: the patch is class-level so it covers the
+        # ViewStore that already exists and every one a later reconnect builds, but
+        # installing it before anything registers a view means the first collision
+        # is also the first one reported.
+        from helpers.view_dispatch_guard import install_dispatch_collision_guard
+        install_dispatch_collision_guard()
+
         try:
             await bot.sync_commands()
             logger.info("Successfully synced commands")

--- a/helpers/view_dispatch_guard.py
+++ b/helpers/view_dispatch_guard.py
@@ -1,0 +1,115 @@
+"""Catch two live views claiming the same component dispatch slot.
+
+py-cord routes a component interaction by looking up
+``(component_type, message_id, custom_id)`` in one process-wide dict
+(``ViewStore.add_view``). An ephemeral view — anything sent with
+``interaction.response.send_message(..., ephemeral=True)`` — is registered with
+``message_id=None``, because the message does not exist yet at send time. That
+leaves ``custom_id`` as the only thing separating two live instances, and
+``add_view`` assigns into the dict unconditionally, so the newer registration
+silently evicts the older one. The evicted view's components then dispatch to the
+newer instance (wrong user's state) and, once that one stops, to nothing at all:
+"This interaction failed", permanently.
+
+This has been fixed by hand three times in this repo — the trophy quiz views
+(d2feec1), the settle selects, and the staked bet-cap panel — each time by
+removing a hardcoded ``custom_id`` from one batch of call sites, and each time
+missing the next batch. This guard exists so there is no next time: it watches the
+one place every registration passes through, rather than the many places
+components are built.
+
+It deliberately checks for the COLLISION rather than for hardcoded ids. A fixed
+``custom_id`` is only a problem when two live views end up holding it, and a
+single-instance fixed id is perfectly correct — so testing for the collision has
+no false positives on legitimate uses, and catches causes other than a hardcoded
+id (two persistent views accidentally sharing one, say).
+
+Loud where a human will see it, quiet where it would hurt: raises under
+TEST_MODE so a test fails on the spot, logs an error in production so a live
+draft is never taken down by the diagnostic.
+"""
+from functools import wraps
+from typing import Any
+
+from loguru import logger
+
+from config import is_test_mode
+
+
+class DispatchCollision(RuntimeError):
+    """Two live views registered the same component dispatch key."""
+
+
+def _is_benign_reregistration(incoming: Any, existing: Any) -> bool:
+    """Registering the same persistent view class again is normal, not a collision.
+
+    ``bot.add_view(PublicSettleDebtsView())`` runs inside on_ready, which fires again
+    on every gateway reconnect — a fresh instance, the same fixed ids, and
+    ``timeout=None`` so the previous one never reports itself finished. That is the
+    mechanism working as intended: persistent views are re-registered by id precisely
+    so buttons survive a restart.
+    """
+    return (incoming.timeout is None
+            and existing.timeout is None
+            and type(incoming) is type(existing))
+
+
+def _report(incoming: Any, existing: Any, custom_id: str,
+            message_id: int | None) -> None:
+    detail = (
+        f"Dispatch collision on custom_id={custom_id!r} (message_id={message_id}): "
+        f"{type(incoming).__name__} would evict a live {type(existing).__name__}. "
+        f"Whichever was registered first stops receiving its own clicks. If these are "
+        f"ephemeral views, drop the hardcoded custom_id so py-cord assigns a unique "
+        f"one per instance."
+    )
+    if is_test_mode():
+        raise DispatchCollision(detail)
+    logger.error(f"[ViewDispatch] {detail}")
+
+
+def install_dispatch_collision_guard() -> None:
+    """Wrap ViewStore.add_view to report a collision before it happens.
+
+    Safe to call more than once: on_ready runs again on every gateway reconnect, and
+    wrapping a wrapper would report the same collision twice.
+    """
+    from discord.ui.view import ViewStore
+
+    if getattr(ViewStore.add_view, "_draftbot_guarded", False):
+        return
+
+    original = ViewStore.add_view
+
+    @wraps(original)
+    def add_view(self: Any, view: Any, message_id: int | None = None) -> None:
+        # Detecting and reporting are kept apart on purpose. Only the detection is
+        # wrapped in a catch-all — a diagnostic must never break a live interaction —
+        # and _report is called outside it, because DispatchCollision is an Exception
+        # and would otherwise be swallowed by the very net meant to contain the
+        # detector's own bugs.
+        collision = None
+        try:
+            for item in view.children:
+                if not item.is_dispatchable():
+                    continue
+                found = self._views.get((item.type.value, message_id, item.custom_id))
+                if not found:
+                    continue
+                existing = found[0]
+                if existing is view or existing.is_finished():
+                    continue  # the slot is ours already, or its holder is done with it
+                if _is_benign_reregistration(view, existing):
+                    continue
+                collision = (view, existing, item.custom_id, message_id)
+                break
+        except Exception as e:
+            logger.warning(f"[ViewDispatch] collision check failed: {e}")
+
+        if collision is not None:
+            _report(*collision)
+        return original(self, view, message_id)
+
+    add_view._draftbot_guarded = True   # pyrefly: ignore [missing-attribute]
+    ViewStore.add_view = add_view
+    logger.info("[ViewDispatch] collision guard installed")

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -11,6 +11,7 @@ preset = "strict"
 project-includes = [
     "cogs/server_draft_stats.py",
     "helpers/utils.py",
+    "helpers/view_dispatch_guard.py",
     "ready_check.py",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,3 +114,40 @@ def make_manager(**kwargs):
     mgr.socket_client.connected = True
     mgr.socket_client.emit = AsyncMock(return_value=True)
     return mgr
+
+
+@pytest_asyncio.fixture
+async def live_views():
+    """Track discord.ui.View instances and stop them when the test ends.
+
+    A View started under a running loop spawns a timeout task; leaving it running
+    makes pytest report pending tasks at teardown, from whichever test happens to be
+    last. Async on purpose — View.stop() cancels that task, so teardown has to happen
+    while the loop is still open.
+
+    Written out three times across the view-dispatch tests before it landed here.
+    Yields a track(view) callable that returns the view, so it reads inline:
+    ``view = track(SomeView(...))``.
+    """
+    tracked = []
+
+    def track(view):
+        tracked.append(view)
+        return view
+
+    yield track
+    for view in tracked:
+        view.stop()
+
+
+def make_view_store():
+    """A bare py-cord ViewStore for exercising real dispatch registration.
+
+    The ConnectionState it normally holds is only needed for actually dispatching an
+    interaction, so a stand-in is enough for tests about the registration keyspace.
+    """
+    from types import SimpleNamespace
+
+    from discord.ui.view import ViewStore
+
+    return ViewStore(state=SimpleNamespace())

--- a/tests/test_view_dispatch_guard.py
+++ b/tests/test_view_dispatch_guard.py
@@ -1,0 +1,188 @@
+"""The guard that stops one live view evicting another's dispatch slot.
+
+py-cord keys component dispatch by (component_type, message_id, custom_id) in one
+process-wide dict, and ephemeral views register with message_id=None — so a fixed
+custom_id makes every live instance share a slot, and the newest silently evicts the
+rest. That has been fixed by hand three times here (quiz views, settle selects,
+staked bet-cap panel), each time by removing ids from one batch of call sites and
+missing the next batch.
+
+These tests pin the guard rather than any one batch: what it catches, what it
+deliberately does not, and — most importantly — that it is actually attached to
+py-cord's real registration path, since a diagnostic that silently stops running is
+worse than none at all.
+"""
+from unittest.mock import patch
+
+import discord
+import pytest
+import pytest_asyncio
+from discord.ui.view import View, ViewStore
+
+from conftest import make_view_store
+from helpers.view_dispatch_guard import (
+    DispatchCollision,
+    install_dispatch_collision_guard,
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _guard_installed():
+    """Install the guard for these tests, then put py-cord back as it was.
+
+    The guard patches the ViewStore CLASS, so without a teardown it stays installed
+    for the rest of the pytest session and arms the TEST_MODE raise for every file
+    that runs afterwards. That is a trap for exactly the test this bug class invites
+    next: a regression test for the following hand-fixed instance would want to
+    register two colliding views and assert on the eviction, and would instead fail
+    with an order-dependent DispatchCollision pointing at unrelated code.
+
+    Async so the teardown runs while the loop is still open — View.stop() cancels a
+    timeout task, which needs one.
+    """
+    original = ViewStore.add_view
+    install_dispatch_collision_guard()
+    yield
+    ViewStore.add_view = original
+
+
+def _view(track, custom_id, *, timeout=300, cls=None):
+    """A view holding one button, with or without a caller-supplied custom_id."""
+    view = (cls or View)(timeout=timeout)
+    kwargs = {"label": "x"}
+    if custom_id is not None:
+        kwargs["custom_id"] = custom_id
+    view.add_item(discord.ui.Button(**kwargs))
+    return track(view)
+
+
+def _as_test_mode(enabled=True):
+    """Pin the raise-vs-log decision instead of inheriting it from the developer's
+    .env. Without this the suite passes or fails depending on whether TEST_MODE
+    happens to be exported — which is how the first version of these tests silently
+    asserted nothing."""
+    return patch("helpers.view_dispatch_guard.is_test_mode", return_value=enabled)
+
+
+@pytest.mark.asyncio
+async def test_two_live_ephemeral_views_sharing_an_id_are_caught(live_views):
+    """The bug itself: same id, both alive, second would evict the first."""
+    store = make_view_store()
+    store.add_view(_view(live_views, "counterparty_select"), message_id=None)
+
+    with _as_test_mode(), pytest.raises(DispatchCollision) as excinfo:
+        store.add_view(_view(live_views, "counterparty_select"), message_id=None)
+
+    assert "counterparty_select" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_auto_generated_ids_never_collide(live_views):
+    """What the fix looks like: omit custom_id and py-cord assigns a unique one, so
+    any number of instances coexist."""
+    store = make_view_store()
+    for _ in range(3):
+        store.add_view(_view(live_views, None), message_id=None)
+
+    assert len(store._views) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_finished_view_does_not_hold_its_slot(live_views):
+    """py-cord's remove_view pops a 2-tuple against a 3-tuple keyspace, so stopped
+    views are never actually removed from the dict. Reporting those as collisions
+    would make the guard noise the moment anyone's menu timed out."""
+    store = make_view_store()
+    stale = _view(live_views, "settle_debts")
+    store.add_view(stale, message_id=None)
+    stale.stop()
+
+    with _as_test_mode():   # armed to raise, so silence here is meaningful
+        store.add_view(_view(live_views, "settle_debts"), message_id=None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_re_registering_a_persistent_view_is_not_a_collision(live_views):
+    """bot.add_view(PublicSettleDebtsView()) runs inside on_ready, which fires again
+    on every gateway reconnect: a fresh instance, the same fixed ids, timeout=None so
+    the previous never reports itself finished. That is persistence working, not the
+    bug, and flagging it would fire on every reconnect."""
+    store = make_view_store()
+
+    class Persistent(View):
+        pass
+
+    with _as_test_mode():   # armed to raise, so silence here is meaningful
+        store.add_view(_view(live_views, "public_settle_debts_button", timeout=None, cls=Persistent),
+                       message_id=None)
+        store.add_view(_view(live_views, "public_settle_debts_button", timeout=None, cls=Persistent),
+                       message_id=None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_two_different_persistent_views_sharing_an_id_are_still_caught(live_views):
+    """Persistence excuses re-registering the same view, not two different views
+    laying claim to one id — that is the same lost update by another route."""
+    store = make_view_store()
+
+    class A(View):
+        pass
+
+    class B(View):
+        pass
+
+    store.add_view(_view(live_views, "shared", timeout=None, cls=A), message_id=None)
+    with _as_test_mode(), pytest.raises(DispatchCollision):
+        store.add_view(_view(live_views, "shared", timeout=None, cls=B), message_id=None)
+
+
+@pytest.mark.asyncio
+async def test_views_on_real_messages_are_keyed_apart_by_message_id(live_views):
+    """Non-ephemeral sends carry a real message id, so the same custom_id on two
+    different messages is not a collision — this is how persistent buttons work."""
+    store = make_view_store()
+    with _as_test_mode():   # armed to raise, so silence here is meaningful
+        store.add_view(_view(live_views, "settle_debts:1"), message_id=111)
+        store.add_view(_view(live_views, "settle_debts:1"), message_id=222)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_the_guard_is_attached_to_pycords_real_registration_path(live_views):
+    """The failure mode this exists to prevent: a py-cord upgrade moves or renames
+    add_view, the wrapper quietly stops being reached, and the bug returns with the
+    tests still green. Asserting the attribute on the live class means an upgrade
+    breaks this test rather than the guard."""
+    assert getattr(ViewStore.add_view, "_draftbot_guarded", False), (
+        "the guard is no longer wrapping ViewStore.add_view")
+
+
+@pytest.mark.asyncio
+async def test_installing_twice_does_not_stack_wrappers(live_views):
+    """on_ready runs again on reconnect; wrapping a wrapper would report twice and
+    make the log read like two separate bugs.
+
+    Asserts the function object is unchanged rather than trusting a return value —
+    "the wrapper was not wrapped again" is the property that actually matters.
+    """
+    already_installed = ViewStore.add_view
+
+    install_dispatch_collision_guard()
+
+    assert ViewStore.add_view is already_installed
+
+
+@pytest.mark.asyncio
+async def test_production_logs_the_collision_but_does_not_raise(live_views):
+    """A diagnostic must never be the thing that breaks a live draft. In production
+    the collision is a logged error, not an exception thrown into a component
+    callback."""
+    store = make_view_store()
+    store.add_view(_view(live_views, "dup"), message_id=None)
+
+    with _as_test_mode(False), patch("helpers.view_dispatch_guard.logger") as log:
+        store.add_view(_view(live_views, "dup"), message_id=None)  # must not raise
+
+    # ...but it must still say so: silence in production would mean the collision
+    # goes unnoticed exactly where it costs a player their interaction.
+    log.error.assert_called_once()
+    assert "dup" in log.error.call_args.args[0]

--- a/views.py
+++ b/views.py
@@ -3582,19 +3582,27 @@ class BetCapToggleButton(CallbackButton):
                 combined_view.add_item(stake_select)
                 
                 # Add bet cap status button (informational only)
+                # No custom_id here either: disabled has nothing to do with it —
+                # py-cord's is_dispatchable() is just `custom_id is not None`, so a
+                # disabled button still takes a dispatch slot and still collides with
+                # the same panel opened by another player in this draft.
                 status_button = discord.ui.Button(
                     label=f"Bet Cap: {status}",
                     style=style,
-                    custom_id=f"bet_cap_status_{self.draft_session_id}",
                     disabled=True
                 )
                 combined_view.add_item(status_button)
                 
                 # Create ON button with its callback
+                # No custom_id: this panel is sent ephemerally, and py-cord keys
+                # dispatch on (type, message_id=None, custom_id) — so an id fixed per
+                # SESSION is shared by every player in that draft who opens it, and
+                # each new panel silently evicts the last. The evicted player's click
+                # then lands on someone else's view, whose callback closes over a
+                # different opener, and tells them "This button is not for you."
                 yes_button = discord.ui.Button(
                     label="Turn ON 🧢",
                     style=discord.ButtonStyle.green,
-                    custom_id=f"cap_yes_{self.draft_session_id}"
                 )
                 
                 async def yes_callback(yes_interaction):
@@ -3609,10 +3617,10 @@ class BetCapToggleButton(CallbackButton):
                 combined_view.add_item(yes_button)
                 
                 # Create OFF button with its callback
+                # Same reasoning as the ON button above.
                 no_button = discord.ui.Button(
                     label="Turn OFF 🏎️", 
                     style=discord.ButtonStyle.red,
-                    custom_id=f"cap_no_{self.draft_session_id}"
                 )
                 
                 async def no_callback(no_interaction):


### PR DESCRIPTION
#420 and #421 fixed instances of a bug. This stops the class recurring a fourth time.

## Why a mechanism rather than another fix

py-cord routes every component click by one key in one process-wide dict (`ui/view.py:599`), and an ephemeral view registers with `message_id=None` — so `custom_id` is the only thing separating two live instances, and the assignment is unconditional. The newer registration **silently evicts** the older.

This has now been fixed by hand three times: the trophy quiz views (`d2feec1`), the settle selects (#420), and the staked bet-cap panel below. Each fix removed hardcoded ids from one batch of call sites and missed the next batch, because the rule lived in a commit message rather than anywhere a machine could check it.

## What it does

One wrapper on `ViewStore.add_view` — the single point every registration passes through — installed as the first statement of `on_ready`. Before delegating, it checks whether any dispatchable child would take a slot a **live** view already holds.

**It checks for the collision, not for hardcoded ids.** That distinction is load-bearing:

- A fixed `custom_id` is only wrong when two live views hold it. Single-instance fixed ids are correct and *required* for persistent views, so there are no false positives on legitimate use.
- It catches causes a lint rule cannot see, including components built outside the view class that owns them. Of 37 in-class `custom_id` sites in this repo, **14 are in `Button`/`Modal` subclasses whose owning view isn't statically knowable** — and the bet-cap bug below was in exactly that blind spot. A static rule would not have found it.

Raises under `TEST_MODE`; logs an error otherwise. A diagnostic must never be the thing that takes down a live draft.

## Three details that are load-bearing, not decorative

- **`is_finished()` filter.** py-cord's `remove_view` pops a 2-tuple against a 3-tuple keyspace, so stopped views are never actually removed; only `__verify_integrity()` prunes them, and that runs *inside* the real `add_view` — after this check. Without replicating the filter, the guard would fire on every timed-out menu.
- **Same-class persistent exemption.** `bot.add_view()` lives in `on_ready`, which fires again on *every gateway reconnect*, with `timeout=None` so the previous instance never reports itself finished. Without this it would cry wolf on every reconnect.
- **Detect inside the `try`, report outside it.** `DispatchCollision` is an `Exception`, so raising it inside the catch-all would have it swallowed by the net meant to contain the detector's own bugs.

## The instance it found

The staked bet-cap panel is sent ephemerally with three components carrying ids fixed per **draft session** — `cap_yes_{id}`, `cap_no_{id}`, `bet_cap_status_{id}`. Per session, not per user, so every player in that draft who opened the panel shared one slot. Because the callbacks close over the opener's id, an evicted player clicking their **own** panel was told *"This button is not for you."*

The status button is `disabled=True` and I initially skipped it for that reason — wrongly. `is_dispatchable()` is just `custom_id is not None`; disabled buttons still take a slot.

## Tests

Nine, over py-cord's real `ViewStore`: what it catches, what it deliberately doesn't (finished views, benign re-registration, real message ids), and **both modes** — raise in test, log in production. Plus one asserting the guard is still attached to `add_view`, so a py-cord upgrade that moves it breaks the test rather than silently disabling the guard.

The fixture restores `ViewStore.add_view` on teardown. Without that the patch leaks for the whole pytest session and arms the raise for every later file — verified in both directions.

Full suite green (1227 passed), `pyrefly check` 0 errors.

## Worth knowing

`TEST_MODE=true` in production would make this raise into a live interaction path. That's already a documented hard rule with a pre-commit checklist item in `CLAUDE.md`, but this adds a new consequence to breaking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw