### PR TITLE
Say how to fix an empty wallet, and how MTGO trades actually work

### DIFF
--- a/cogs/wallet_cog.py
+++ b/cogs/wallet_cog.py
@@ -30,7 +30,7 @@ from services.mtgo_tradebot_client import EVENT_TICKET
 from services.tournament_formatter import refresh_boards
 from helpers.money_gate import (
     DEFAULT_WAIT_MINUTES, custodian_name, explain_trade_failure, gate_read, gate_serve,
-    linked_username, spawn_followup,
+    linked_username, mtgo_job_footer, mtgo_trade_prompt, spawn_followup,
 )
 from helpers.permissions import has_bot_manager_role
 
@@ -99,9 +99,9 @@ class WalletCommands(commands.Cog):
         job_id = started["job_id"]
         custodian = await custodian_name()
         await ctx.followup.send(
-            f"**Deposit started.** In MTGO, trade **{amount} {EVENT_TICKET}(s)** to "
-            f"`{custodian}` and accept when the trade window pops. I'll confirm here once it "
-            f"lands.\n_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
+            f"**Deposit started** — **{amount} {EVENT_TICKET}(s)**. "
+            f"{mtgo_trade_prompt(custodian)}"
+            f"{mtgo_job_footer(job_id)}", ephemeral=True)
 
         # capture only what the poller needs (not ctx) — this task can live for ~14 min
         followup = ctx.followup
@@ -161,9 +161,9 @@ class WalletCommands(commands.Cog):
         job_id = started["job_id"]
         custodian = await custodian_name()
         await ctx.followup.send(
-            f"**Withdraw started** — {amount} tix committed. In MTGO, accept the trade from "
-            f"`{custodian}` when it pops. I'll confirm here once it completes.\n"
-            f"_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._", ephemeral=True)
+            f"**Withdraw started** — **{amount} tix** committed. "
+            f"{mtgo_trade_prompt(custodian)}"
+            f"{mtgo_job_footer(job_id)}", ephemeral=True)
 
         followup = ctx.followup
 
@@ -209,6 +209,19 @@ class WalletCommands(commands.Cog):
             guild_id, str(ctx.author.id), str(player.id), amount,
             notes=f"pay to {player.display_name}")
         if not res.get("ok"):
+            if res.get("code") == wallet_service.INSUFFICIENT_FUNDS:
+                have = res.get("available", 0)
+                # Says where an arriving deposit goes rather than telling the player to
+                # do arithmetic about it: settle_deposit_inflow spends it on a pending
+                # tournament entry first and debts second, so someone with either would
+                # otherwise be surprised to find their deposit gone.
+                return await ctx.followup.send(
+                    f"You have **{have} tix** — sending **{amount}** needs "
+                    f"**{amount - have}** more.\n"
+                    f"Use `/wallet deposit` to trade tix in from MTGO. Deposits "
+                    f"automatically cover any pending tournament entry first, then any "
+                    f"outstanding debts — `/debts summary` shows what you owe.",
+                    ephemeral=True)
             return await ctx.followup.send(f"Couldn't send tix: {res.get('error')}", ephemeral=True)
 
         payer_bal = await wallet_service.get_balance(guild_id, str(ctx.author.id))

--- a/helpers/money_gate.py
+++ b/helpers/money_gate.py
@@ -75,6 +75,28 @@ def add_wallet_howto(embed, guild_id) -> bool:
     return True
 
 
+def mtgo_trade_prompt(custodian: str) -> str:
+    """How a player completes an MTGO trade with the custodian.
+
+    Deposits and withdrawals drive the same serve and so take the same steps, but the
+    two commands used to describe them differently — deposit told the player to open
+    the trade themselves, which is not how the serve works at all. One string so the
+    instructions cannot disagree about a protocol that is identical.
+    """
+    return (f"`{custodian}` will message you in MTGO — reply **YES** and it will open "
+            f"the trade. Accept it and I'll confirm here once it lands.")
+
+
+def mtgo_job_footer(job_id: str) -> str:
+    """The job reference and how long the player has to accept.
+
+    Folded in beside the prompt for the same reason the prompt itself exists: the two
+    commands rendered this line identically and separately, which is exactly how the
+    instructions above it drifted apart in the first place.
+    """
+    return f"\n_Job `{job_id}` — you have ~{DEFAULT_WAIT_MINUTES} min._"
+
+
 def gate_read(ctx) -> str | None:
     """Wallet must be used in a money server. Returns an error string, or None."""
     if not ctx.guild:

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -361,6 +361,11 @@ async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, n
     """Move tix between two wallets with no MTGO trade (a plain claim transfer)."""
     try:
         debit, credit = await wallet_service.pay(guild_id, from_player, to_player, amount, notes=notes)
+    except wallet_service.InsufficientFunds as e:
+        # Tagged rather than left as prose: the cog answers this one refusal with "go
+        # and deposit", which would be nonsense advice for any of the others.
+        return {"ok": False, "error": str(e),
+                "code": wallet_service.INSUFFICIENT_FUNDS, "available": e.available}
     except ValueError as e:
         return {"ok": False, "error": str(e)}
     # Receiving money is the case you are least likely to be watching for.
@@ -401,7 +406,11 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
             # formula every wallet op uses
             available = await wallet_service.balance_in(session, guild_id, payer_id)
             if amount > available:
-                return {"ok": False, "error": f"insufficient wallet funds (available {available})"}
+                # Same refusal as pay()'s, tagged the same way so any caller that
+                # wants to answer it with deposit advice can, without matching prose.
+                return {"ok": False,
+                        "error": f"insufficient wallet funds (available {available})",
+                        "code": wallet_service.INSUFFICIENT_FUNDS, "available": available}
 
             # payer must actually owe the creditor at least this much
             debt_balance = int((await session.execute(

--- a/services/wallet_service.py
+++ b/services/wallet_service.py
@@ -81,6 +81,28 @@ async def _sum_amount(session, *conditions) -> int:
     return int(result.scalar() or 0)
 
 
+# The one failure a caller answers differently: "you have no money" is fixed by
+# depositing, "that amount is nonsense" is not. Named once here so the layer that
+# tags it and the layer that switches on it cannot drift apart on a typo.
+INSUFFICIENT_FUNDS = "insufficient_funds"
+
+
+class InsufficientFunds(ValueError):
+    """Not enough available tix. A ValueError subclass so every existing
+    ``except ValueError`` keeps catching it, but a distinct type so a caller can tell
+    this apart from the other reasons a transfer is refused.
+
+    Carries ``available`` only — the shortfall is the caller's own amount minus that,
+    which every caller already has. The message names the holder for the log; it is
+    deliberately not what a player is shown, since it reads back their Discord id.
+    """
+
+    def __init__(self, player_id: str, needed: int, available: int):
+        super().__init__(
+            f"Insufficient funds: {player_id} needs {needed}, has {available}")
+        self.available = available
+
+
 async def balance_in(session, guild_id: str, player_id: str) -> int:
     """A holder's balance inside an existing session/transaction — the single definition,
     reused by every caller that needs to check funds within its own transaction."""
@@ -257,8 +279,7 @@ async def pay(
                 return existing[0], existing[1]
             balance = await balance_in(session, guild_id, from_player)
             if amount > balance:
-                raise ValueError(
-                    f"Insufficient funds: {from_player} needs {amount}, has {balance}")
+                raise InsufficientFunds(from_player, amount, balance)
             rows = await transfer_in(session, guild_id, from_player, to_player,
                                      amount, source, notes)
             logger.info(f"pay: {from_player} -> {to_player} {amount} tix (source {source})")

--- a/tests/test_wallet_trade_copy.py
+++ b/tests/test_wallet_trade_copy.py
@@ -1,0 +1,180 @@
+"""What the wallet tells a player to do next.
+
+Two things had gone wrong in the copy. `/wallet pay` on an empty wallet reported
+"Insufficient funds: 123456789012345678 needs 5, has 0" — the player's own Discord id
+read back at them, and no hint that depositing is the fix. And `/wallet deposit` told
+them to open an MTGO trade themselves, which is not how the serve works: the custodian
+messages the player, they reply YES, and it opens the trade. Withdraw described the
+same protocol differently again.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from helpers.money_gate import mtgo_trade_prompt
+
+
+async def _run_trade(command, start_name):
+    """Drive deposit/withdraw to the point where they tell the player what to do."""
+    from cogs.wallet_cog import WalletCommands
+
+    cog = WalletCommands.__new__(WalletCommands)
+    cog.bot = MagicMock()   # the followup task captures it; nothing here runs that task
+    ctx = _ctx()
+
+    with patch("cogs.wallet_cog.gate_serve", return_value=None), \
+         patch("cogs.wallet_cog.linked_username", new=AsyncMock(return_value="me")), \
+         patch("cogs.wallet_cog.custodian_name", new=AsyncMock(return_value="TheCustodian")), \
+         patch(f"cogs.wallet_cog.resolution.{start_name}",
+               new=AsyncMock(return_value={"ok": True, "job_id": "J1"})), \
+         patch("cogs.wallet_cog.spawn_followup",
+               side_effect=lambda label, coro: coro.close()):
+        await command.callback(cog, ctx, 5)
+
+    return ctx.followup.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_both_trade_commands_give_the_same_instructions():
+    """Runs both commands and compares what they actually send.
+
+    Deposit and withdraw drive the same serve and take the same steps, but they drifted
+    once already — deposit told the player to open the trade themselves, which the serve
+    never asks for. Asserting on the sent message rather than on the source means a
+    command that imports the shared prompt and then fails to send it still fails.
+    """
+    from cogs.wallet_cog import WalletCommands
+
+    deposit_msg = await _run_trade(WalletCommands.wallet_deposit, "start_deposit")
+    withdraw_msg = await _run_trade(WalletCommands.wallet_withdraw, "start_withdraw")
+
+    shared = mtgo_trade_prompt("TheCustodian")
+    assert shared in deposit_msg, "deposit should render the shared instructions"
+    assert shared in withdraw_msg, "withdraw should render the shared instructions"
+
+
+def test_the_prompt_says_to_reply_yes_and_wait():
+    prompt = mtgo_trade_prompt("TheCustodian")
+
+    assert "YES" in prompt, "replying YES is the step players miss"
+    assert "TheCustodian" in prompt
+    # the serve opens the trade; telling players to open it themselves is what the
+    # old deposit copy got wrong
+    assert "will open" in prompt
+
+
+# ---- /wallet pay on an empty wallet ----------------------------------------------
+
+
+def _ctx(author_id=111, guild_id=999):
+    ctx = MagicMock()
+    ctx.author.id = author_id
+    ctx.guild.id = guild_id
+    ctx.defer = AsyncMock()
+    ctx.followup.send = AsyncMock()
+    return ctx
+
+
+async def _run_pay(pay_result, amount=5):
+    """Drive wallet_pay far enough to reach the failure branch."""
+    from cogs.wallet_cog import WalletCommands
+
+    cog = WalletCommands.__new__(WalletCommands)
+    ctx = _ctx()
+    target = MagicMock()
+    target.id = 222
+    target.display_name = "Someone"
+
+    with patch("cogs.wallet_cog.gate_read", return_value=None), \
+         patch("cogs.wallet_cog.MtgoAccount.usernames_for_discord_ids",
+               new=AsyncMock(return_value={"111": "me", "222": "them"})), \
+         patch("cogs.wallet_cog.resolution.pay", new=AsyncMock(return_value=pay_result)):
+        await WalletCommands.wallet_pay.callback(cog, ctx, target, amount)
+
+    return ctx.followup.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_paying_with_an_empty_wallet_points_at_deposit():
+    msg = await _run_pay(
+        {"ok": False, "error": "Insufficient funds: 111 needs 5, has 0",
+         "code": "insufficient_funds", "available": 0})
+
+    assert "/wallet deposit" in msg
+    assert "0 tix" in msg
+    # the raw service string names the player by Discord id; players should never see it
+    assert "111" not in msg
+
+
+@pytest.mark.asyncio
+async def test_the_deposit_advice_names_everything_that_gets_paid_first():
+    """Tells the player where an arriving deposit goes, rather than setting them
+    arithmetic.
+
+    settle_deposit_inflow spends a deposit on a pending tournament entry first and
+    debts second. Someone with either who is told only "deposit more" would trade tix
+    in, watch them vanish into a creditor, and have no idea why — so both claims are
+    named, in the order they are actually paid.
+    """
+    msg = await _run_pay(
+        {"ok": False, "error": "...", "code": "insufficient_funds", "available": 2})
+
+    assert "tournament entry" in msg.lower()
+    assert "debts" in msg.lower()
+    assert "/debts summary" in msg
+
+
+@pytest.mark.asyncio
+async def test_other_failures_do_not_suggest_depositing():
+    """Depositing does not fix "amount must be positive". Only the funds case earns
+    the advice, which is why the service tags it rather than the cog matching prose."""
+    msg = await _run_pay({"ok": False, "error": "cannot pay yourself"})
+
+    assert "deposit" not in msg.lower()
+    assert "cannot pay yourself" in msg
+
+
+def test_the_funds_failure_is_its_own_type():
+    """A ValueError subclass, so every existing `except ValueError` still catches it,
+    but distinguishable for callers that answer it differently.
+
+    Only `available` is pinned: it is the one thing a caller cannot work out for
+    itself, and asserting on attributes nobody reads would present them as contract."""
+    from services.wallet_service import InsufficientFunds
+
+    err = InsufficientFunds("111", 5, 2)
+    assert isinstance(err, ValueError)
+    assert err.available == 2
+
+
+@pytest.mark.asyncio
+async def test_the_funds_failure_reaches_the_cog_tagged():
+    """The tests above hand the cog a ready-made result, so they pin the cog's half of
+    the contract and nothing else. This pins the other half: that resolution.pay really
+    does turn the exception into the code the cog switches on. Without it, dropping the
+    tag would silently fall back to the raw "needs 5, has 0" string with every other
+    test still green.
+    """
+    from services import mtgo_resolution_service as resolution
+    from services import wallet_service
+    from services.wallet_service import InsufficientFunds
+
+    with patch("services.wallet_service.pay",
+               new=AsyncMock(side_effect=InsufficientFunds("111", 5, 2))):
+        res = await resolution.pay("999", "111", "222", 5)
+
+    assert res["ok"] is False
+    assert res["code"] == wallet_service.INSUFFICIENT_FUNDS
+    assert res["available"] == 2
+
+
+@pytest.mark.asyncio
+async def test_other_value_errors_stay_untagged():
+    from services import mtgo_resolution_service as resolution
+
+    with patch("services.wallet_service.pay",
+               new=AsyncMock(side_effect=ValueError("Cannot transfer to the same holder"))):
+        res = await resolution.pay("999", "111", "111", 5)
+
+    assert res["ok"] is False
+    assert "code" not in res


### PR DESCRIPTION
Two bits of wallet copy told players the wrong thing. Independent of #420/#421/#422 — this touches only the money stack.

## 1. `/wallet pay` on an empty wallet

It reported the raw service string:

> Couldn't send tix: Insufficient funds: 1359405606263586836 needs 5, has 0

The player's own Discord id, read back at them, and no hint that depositing is the fix. Now:

> You have **8 tix** — sending **999** needs **991** more.
> Use `/wallet deposit` to trade tix in from MTGO. Deposits automatically cover any pending tournament entry first, then any outstanding debts — `/debts summary` shows what you owe.

The second sentence is deliberate. `settle_deposit_inflow` spends an arriving deposit on a pending tournament entry **first** and debts **second**, so "just deposit the shortfall" would be wrong advice for anyone carrying either — they'd trade tix in, watch them swept, and still be unable to send. The copy states where the money goes rather than setting the player arithmetic. *(An earlier draft had this ordering backwards; caught in review against `settle_deposit_inflow`.)*

**Only that refusal earns the advice** — depositing doesn't fix "amount must be positive". So `wallet_service.pay` raises `InsufficientFunds`, a `ValueError` subclass (every existing `except ValueError` still catches it), and `mtgo_resolution_service.pay` tags it with a code the cog switches on, rather than the cog pattern-matching prose. `settle_debt_from_wallet` returns the same tag, since it's the same refusal two functions away.

## 2. `/wallet deposit` described a protocol that doesn't exist

It told players to open the MTGO trade themselves:

> In MTGO, trade **3 Event Ticket(s)** to `custodian` and accept when the trade window pops.

That is not how the serve works — the custodian messages the player, they reply **YES**, and it opens the trade. `/wallet withdraw` described the same protocol in different words again. Both now render one shared `mtgo_trade_prompt()`, with `mtgo_job_footer()` for the job line that was also duplicated:

> **Deposit started** — **3 Event Ticket(s)**. `custodian` will message you in MTGO — reply **YES** and it will open the trade. Accept it and I'll confirm here once it lands.

## Verified end to end

Driven in the test guild against a **local stub serve**, with `MTGO_TRADEBOT_URL` overridden on the command line so the process had no route to the real serve — verified three ways (`load_dotenv` doesn't override an existing var, `/proc/<pid>/environ` on the live bot, and the stub's own request log). **No MTGO trade was attempted.**

All three paths confirmed in Discord: the pay message with a real balance and no id leak, and deposit and withdraw rendering the *identical* shared instructions. The stub reported every job as failed, which is the outcome that unwinds cleanly — ledger verified back at its starting balances afterwards.

## Tests

`tests/test_wallet_trade_copy.py`: both commands run and their sent messages compared (not their source text — an earlier version inspected source and would have passed if the string were built and never sent), the deposit advice naming both claims in order, other failures *not* suggesting a deposit, and the service→cog tagging pinned separately so dropping it can't pass silently.

Full suite green (1235 passed), `pyrefly check` 0 errors. Rebased onto `main` after #422 and re-run with the new dispatch guard active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K83APav4y1vPdxUaE6P2fw