### PR TITLE
Auto-debit a staked-draft loser's wallet when the debt lands

### DIFF
--- a/helpers/display_names.py
+++ b/helpers/display_names.py
@@ -7,7 +7,7 @@ for display name logic, including crown icons for leaderboard leaders.
 """
 
 import discord
-from typing import Optional
+from typing import Iterable, Optional
 from leaderboard_config import CROWN_ICONS
 
 
@@ -156,6 +156,22 @@ def get_display_name_by_id(user_id: str, guild: discord.Guild, fallback: str = "
         return get_display_name(member, guild)
     except (ValueError, TypeError):
         return discord.utils.escape_markdown(fallback)
+
+
+SEATING_ORDER_SEPARATOR = " -> "
+
+
+def format_seating_order(display_names: Iterable[str]) -> str:
+    """Render a seating order for an embed field.
+
+    Seating orders are built from raw `sign_ups` values, but the team-name lists
+    shown in the same embed go through get_display_name_by_id, which escapes
+    markdown. Without this, a player named **Bold**User renders bold in one
+    field and literal in the other.
+    """
+    return SEATING_ORDER_SEPARATOR.join(
+        discord.utils.escape_markdown(str(name)) for name in display_names
+    )
 
 
 def format_display_name(display_name: str, user_id: Optional[str] = None, guild: Optional[discord.Guild] = None) -> str:

--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -17,6 +17,14 @@ from models.stake_pairing import StakePairing
 # queries go through _open_card_groups instead.
 TIX_ONLY = DebtLedger.card_name.is_(None)
 
+# Serializes the check-then-insert in create_debt_entries_from_stakes. That check is a
+# SELECT with no DB uniqueness guard behind it, and it runs from an embed renderer with
+# six call sites, so two concurrent renders could each find no rows and both insert.
+# An in-process lock is sufficient because the bot is the database's only writer (the
+# same reasoning wallet_service.MONEY_LOCK rests on). Held only around one short
+# transaction, and taken nowhere else — no lock ordering to get wrong.
+_STAKE_DEBT_LOCK = asyncio.Lock()
+
 
 async def create_ledger_entries(
     guild_id: str,
@@ -483,6 +491,12 @@ async def create_debt_entries_from_stakes(
     This function is idempotent - if debt entries already exist for this session,
     it will skip creation and return an empty list.
 
+    Settling those debts is the CALLER's job, not this one's: writing the ledger rows is
+    a pure debt-layer operation, while drawing them against a wallet moves money and
+    belongs a layer up. The one caller (utils.generate_draft_summary_embed) hands the
+    returned debtors straight to mtgo_resolution_service.settle_new_debts — the empty
+    list on replay is what stops a re-render charging anyone twice.
+
     Args:
         guild_id: The guild this draft belongs to
         session_id: The draft session ID
@@ -494,8 +508,11 @@ async def create_debt_entries_from_stakes(
     winning_team_set = set(winning_team_ids)
     debts_created = []
 
-    # Single session for everything: idempotency check, read stakes, create all entries
-    async with db_session() as session:
+    # Single session for everything: idempotency check, read stakes, create all entries.
+    # Serialized (see _STAKE_DEBT_LOCK) so the check and the insert can't be interleaved
+    # by a concurrent render — duplicated stake debts stop being a cosmetic problem once
+    # they are auto-debited from a wallet.
+    async with _STAKE_DEBT_LOCK, db_session() as session:
         # Idempotency check: see if debt entries already exist for this session
         existing_query = select(DebtLedger).where(
             DebtLedger.source_type == 'draft',
@@ -576,6 +593,32 @@ async def create_debt_entries_from_stakes(
 
     logger.info(f"Created {len(debts_created)} debt entries for session {session_id}")
     return debts_created
+
+
+async def get_draft_debtors(guild_id: str, session_id: str) -> list[str]:
+    """Everyone left owing tix from this draft's stake outcomes.
+
+    Settlement callers use THIS rather than create_debt_entries_from_stakes' return
+    value, which names the debtors only on the pass that created them: an idempotent
+    replay returns [], so a debtor whose settlement failed — or who funded their wallet
+    a minute later — would never be revisited. Reading them back off the ledger makes
+    every subsequent pass a free retry, and settling an already-settled debt is a no-op
+    because the balance it draws against is zero.
+
+    Returns everyone the draft made a debtor, settled or not; deciding who still owes
+    is settlement's job, and it re-checks that inside its own transaction anyway.
+    """
+    async with db_session() as session:
+        rows = await session.execute(
+            select(DebtLedger.player_id).where(
+                DebtLedger.guild_id == guild_id,
+                DebtLedger.source_type == 'draft',
+                DebtLedger.source_id == session_id,
+                DebtLedger.amount < 0,      # the debtor side of each mirrored pair
+                TIX_ONLY,
+            ).distinct()
+        )
+        return list(rows.scalars().all())
 
 
 async def adjust_debt(

--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -22,6 +22,7 @@ background task within Discord's interaction window.
 """
 import asyncio
 import uuid
+from collections.abc import Iterable
 from datetime import datetime
 
 from loguru import logger
@@ -436,9 +437,11 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
         return await with_db_retry(_do)
 
 
-async def settle_inflow(guild_id: str, player_id: str) -> list[dict]:
-    """Run ``auto_draw`` for a holder who has just RECEIVED tix. Call this from every
-    inflow path, not just deposits.
+async def settle_inflow(guild_id: str, player_id: str,
+                        occasion: str = "an inflow") -> list[dict]:
+    """Run ``auto_draw`` for a holder, guarded. Call this from every inflow path, not just
+    deposits — and from ``settle_new_debts`` for the mirror case, a debt arriving at
+    someone who already holds tix (``occasion`` only names the trigger in the error log).
 
     Deposits alone are not enough: a payout, a refund, a player-to-player payment or a
     returned withdraw all credit a wallet without going near the deposit path, so a debtor
@@ -461,9 +464,40 @@ async def settle_inflow(guild_id: str, player_id: str) -> list[dict]:
         return []
     try:
         return await auto_draw(guild_id, player_id)
-    except Exception as e:  # noqa: BLE001 - settlement must never fail the inflow itself
-        logger.error(f"settle_inflow: auto_draw failed for {player_id} after an inflow: {e}")
+    except Exception as e:  # noqa: BLE001 - settlement must never fail its trigger
+        logger.error(f"settle_inflow: auto_draw failed for {player_id} after {occasion}: {e}")
         return []
+
+
+async def settle_new_debts(guild_id: str, debtor_ids: Iterable[str]) -> list[dict]:
+    """Draw brand-new debts against what their debtors ALREADY hold.
+
+    The mirror of ``settle_inflow``: that fires when money reaches someone who owes, this
+    when a debt reaches someone who has money. Without it, losing a staked draft while
+    holding tix left paying up to the debtor's discretion — and the whole point of a
+    wallet-backed ledger is that it isn't discretionary.
+
+    De-duplicated because ``auto_draw`` settles a debtor's WHOLE book in one pass, so a
+    loser who owes three people needs one pass, not three.
+    """
+    ids = list(dict.fromkeys(debtor_ids))
+    if not ids:
+        return []
+    # One batched balance read, then only the funded debtors do any work. Most draft
+    # losers have an empty wallet and nothing to draw against, and auto_draw would spend
+    # two sessions apiece just to discover that.
+    balances = await wallet_service.balances_for(guild_id, ids)
+    funded = [pid for pid in ids if balances.get(pid, 0) > 0]
+    if not funded:
+        return []
+    # Concurrent on purpose: MONEY_LOCK covers only each settlement's own transaction, so
+    # the balance reads and the two settlement DMs per creditor run lock-free and would
+    # otherwise just add their round-trips together. Safe because each debtor's failures
+    # are swallowed independently and settle_debt_from_wallet re-checks the live debt and
+    # balance INSIDE the lock, so overlapping work converges instead of over-paying.
+    drawn = await asyncio.gather(*(
+        settle_inflow(guild_id, pid, "a new debt") for pid in funded))
+    return [settlement for per_debtor in drawn for settlement in per_debtor]
 
 
 async def auto_draw(guild_id: str, player_id: str) -> list[dict]:

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -13,7 +13,7 @@ import random
 from sqlalchemy import update, select
 
 from session import AsyncSessionLocal, DraftSession, StakeInfo
-from helpers.display_names import format_seating_order
+from helpers.display_names import format_display_name, format_seating_order
 from helpers.draft_footer import apply_draft_footer_from_session
 from models.draft_session import DraftSession as DraftSessionModel
 from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
@@ -255,6 +255,8 @@ async def _create_teams_embed(session, team_a_names, team_b_names, seating_order
     user_links = []
     for user_id, display_name in session.sign_ups.items():
         personalized_link = session.get_draft_link_for_user(display_name)
+        # Label stays RAW: Discord does not process backslash escapes inside a
+        # markdown link label, so escaping here renders literal backslashes.
         user_links.append(f"[{display_name}]({personalized_link})")
 
     add_links_to_embed_safely(embed, user_links, "Your Personalized Draft Links")
@@ -264,8 +266,10 @@ async def _create_teams_embed(session, team_a_names, team_b_names, seating_order
         team_a_label = "🔴 Team Red" if session_type in ["random", "staked"] else session.team_a_name
         team_b_label = "🔵 Team Blue" if session_type in ["random", "staked"] else session.team_b_name
 
-        embed.add_field(name=team_a_label, value="\n".join(team_a_names), inline=True)
-        embed.add_field(name=team_b_label, value="\n".join(team_b_names), inline=True)
+        embed.add_field(name=team_a_label,
+                        value="\n".join(format_display_name(n) for n in team_a_names), inline=True)
+        embed.add_field(name=team_b_label,
+                        value="\n".join(format_display_name(n) for n in team_b_names), inline=True)
 
     embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
 
@@ -294,6 +298,7 @@ async def _create_channel_announcement_embed(session, seating_order, stake_info_
 
     for user_id, display_name in session.sign_ups.items():
         personalized_link = session.get_draft_link_for_user(display_name)
+        # Raw label -- see the note in _create_teams_embed.
         link_entry = f"[{display_name}]({personalized_link})"
 
         if session.session_type == 'swiss':

--- a/services/team_creator.py
+++ b/services/team_creator.py
@@ -13,6 +13,7 @@ import random
 from sqlalchemy import update, select
 
 from session import AsyncSessionLocal, DraftSession, StakeInfo
+from helpers.display_names import format_seating_order
 from helpers.draft_footer import apply_draft_footer_from_session
 from models.draft_session import DraftSession as DraftSessionModel
 from utils import split_into_teams, generate_seating_order, reorder_sign_ups, get_formatted_stake_pairs, check_weekly_limits, add_links_to_embed_safely
@@ -266,7 +267,7 @@ async def _create_teams_embed(session, team_a_names, team_b_names, seating_order
         embed.add_field(name=team_a_label, value="\n".join(team_a_names), inline=True)
         embed.add_field(name=team_b_label, value="\n".join(team_b_names), inline=True)
 
-    embed.add_field(name="Seating Order", value=" -> ".join(seating_order), inline=False)
+    embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
 
     # Add stakes for staked drafts
     if session_type == "staked":
@@ -315,7 +316,7 @@ async def _create_channel_announcement_embed(session, seating_order, stake_info_
         add_links_to_embed_safely(channel_embed, team_b_links, f"{team_name} Draft Links",
                                   "blue" if session.session_type in ["random", "staked"] else "")
 
-    channel_embed.add_field(name="Seating Order", value=" -> ".join(seating_order), inline=False)
+    channel_embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
 
     # Add stakes for staked drafts
     if session_type == "staked":

--- a/tests/test_seating_order_display.py
+++ b/tests/test_seating_order_display.py
@@ -1,0 +1,26 @@
+"""Seating orders are built from raw sign_ups display names, while the team-name
+lists in the SAME embed go through get_display_name_by_id, which escapes
+markdown. A player named **Bold**User therefore renders bold in one field and
+literal in the other."""
+from helpers.display_names import format_seating_order
+
+
+def test_seating_order_escapes_markdown_like_the_team_lists_beside_it():
+    out = format_seating_order(["**Bold**User", "Normal User"])
+    assert "**Bold**User" not in out, f"unescaped markdown would render bold: {out!r}"
+    assert "Normal User" in out
+
+
+def test_seating_order_keeps_the_arrow_separator():
+    assert format_seating_order(["Alice", "Bob", "Carol"]) == "Alice -> Bob -> Carol"
+
+
+def test_seating_order_handles_an_empty_roster():
+    assert format_seating_order([]) == ""
+
+
+def test_seating_order_escapes_underscores_and_tildes():
+    """The repo's own test users are named _Italic_Name and ~Strike~User."""
+    out = format_seating_order(["_Italic_Name", "~Strike~User"])
+    assert "_Italic_Name" not in out
+    assert "~Strike~User" not in out

--- a/tests/test_team_embed_escaping.py
+++ b/tests/test_team_embed_escaping.py
@@ -1,0 +1,84 @@
+"""Display names in the teams embeds, and where escaping them is correct.
+
+Escaping is context-dependent, which is not obvious from the code:
+
+  - PLAIN embed fields (team rosters, seating order): Discord consumes the
+    backslashes, so an escaped name renders literally. Escape here.
+  - MARKDOWN LINK LABELS: Discord does NOT process backslash escapes inside
+    `[label](url)` -- the backslashes render as visible characters. Verified
+    live in Discord, where escaped labels came out as "[TEST] \\*\\*Bold\\*\\*User".
+    Leave raw here; the name renders with formatting applied, which is cosmetic
+    because the URL carries the authoritative name and the Seating Order field
+    is the one players read to match their Draftmancer seat.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from services import team_creator
+
+MARKDOWN_NAMES = {
+    "a1": "**Bold**User",
+    "a2": "*Single*Star",
+    "b1": "~Strike~User",
+    "b2": "plain",
+}
+
+
+def fake_session():
+    return SimpleNamespace(
+        session_type="random",
+        sign_ups=dict(MARKDOWN_NAMES),
+        team_a=["a1", "a2"],
+        team_b=["b1", "b2"],
+        team_a_name=None,
+        team_b_name=None,
+        cube="LSVCube",
+        friendly_id="test-1",
+        get_draft_link_for_user=lambda name: f"https://draftmancer.com/?session=X&userName={name}",
+    )
+
+
+def field_values(embed):
+    return "\n".join(f.value for f in embed.fields)
+
+
+@pytest.mark.asyncio
+async def test_draft_link_labels_are_left_raw():
+    """Escaping a link label puts visible backslashes in front of players."""
+    embed = await team_creator._create_channel_announcement_embed(
+        fake_session(), ["**Bold**User"], {}, "random"
+    )
+    links = "\n".join(f.value for f in embed.fields if "Draft Links" in f.name)
+    assert "[**Bold**User]" in links, f"link label should stay raw: {links}"
+    assert "\\*\\*Bold\\*\\*User" not in links, "escaped label renders literal backslashes in Discord"
+
+
+@pytest.mark.asyncio
+async def test_link_urls_keep_the_raw_name():
+    """The URL becomes ?userName= and is what seats the player -- escaping it
+    would send backslashes to Draftmancer and break the join."""
+    embed = await team_creator._create_channel_announcement_embed(
+        fake_session(), ["**Bold**User"], {}, "random"
+    )
+    assert "userName=**Bold**User" in field_values(embed)
+
+
+@pytest.mark.asyncio
+async def test_announcement_seating_order_is_escaped():
+    embed = await team_creator._create_channel_announcement_embed(
+        fake_session(), ["**Bold**User", "*Single*Star"], {}, "random"
+    )
+    seating = next(f.value for f in embed.fields if f.name == "Seating Order")
+    assert "\\*\\*Bold\\*\\*User" in seating, f"plain field should be escaped: {seating}"
+
+
+@pytest.mark.asyncio
+async def test_team_roster_lists_are_escaped():
+    """Plain fields, so the escapes are consumed and the name renders literally."""
+    embed = await team_creator._create_teams_embed(
+        fake_session(), ["**Bold**User", "*Single*Star"], ["~Strike~User", "plain"],
+        ["**Bold**User"], {}, "random",
+    )
+    roster = next(f.value for f in embed.fields if "Team Red" in f.name)
+    assert "\\*\\*Bold\\*\\*User" in roster, f"roster should be escaped: {roster}"

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -3,7 +3,10 @@
 These paths had no coverage, which is how a stale `status=` kwarg survived the move to
 the status-free ledger and broke every settlement at runtime.
 """
+import asyncio
+
 import pytest
+from sqlalchemy import select
 
 from conftest import test_db  # noqa: F401  (fixture)
 from database.db_session import db_session
@@ -171,6 +174,131 @@ async def test_a_deposit_pays_the_players_own_entry_before_their_creditors(test_
     assert await ws.get_balance(GUILD, CRED) == 3      # creditor got only what was left
     assert await ws.get_balance(GUILD, PAYER) == 0
     assert sum(d["amount"] for d in drawn) == 3
+
+
+# ---- a new debt draws against the wallet the moment it appears -------------------
+
+@pytest.mark.asyncio
+async def test_a_new_debt_is_debited_from_the_wallet_immediately(test_db):  # noqa: F811
+    """Losing a staked draft while holding tix must not leave paying up to the debtor's
+    discretion. Settlement used to fire only when money arrived; a debt arriving at
+    someone who ALREADY has funds is the mirror case, and it went uncollected."""
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+    await _owe(PAYER, CRED, 4, "d1")          # the stake outcome lands
+
+    drawn = await resolution.settle_new_debts(GUILD, [PAYER])
+
+    assert sum(d["amount"] for d in drawn) == 4
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == 0
+    assert await ws.get_balance(GUILD, PAYER) == 6
+    assert await ws.get_balance(GUILD, CRED) == 4
+
+
+@pytest.mark.asyncio
+async def test_a_new_debt_takes_what_it_can_when_the_wallet_is_short(test_db):  # noqa: F811
+    """Partial funds still collect. Leaving a short wallet untouched would hand back the
+    very discretion this removes -- the remainder simply stays owed."""
+    await ws.credit_done(GUILD, PAYER, 3, job_id="j1")
+    await _owe(PAYER, CRED, 10, "d1")
+
+    drawn = await resolution.settle_new_debts(GUILD, [PAYER])
+
+    assert sum(d["amount"] for d in drawn) == 3
+    assert await ws.get_balance(GUILD, PAYER) == 0
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == -7, "the unpaid remainder must stay on the books"
+
+
+@pytest.mark.asyncio
+async def test_a_new_debt_against_an_empty_wallet_is_a_clean_no_op(test_db):  # noqa: F811
+    await _owe(PAYER, CRED, 10, "d1")
+
+    assert await resolution.settle_new_debts(GUILD, [PAYER]) == []
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == -10
+
+
+@pytest.mark.asyncio
+async def test_stake_outcomes_are_debited_as_soon_as_they_are_created(test_db):  # noqa: F811
+    """The slice as the draft-completion path runs it: create the stake debts, then hand
+    the debtors straight to settlement. Losing with a funded wallet settles on the spot."""
+    from models.stake_pairing import StakePairing
+    from services.debt_service import create_debt_entries_from_stakes
+
+    async with db_session() as session:
+        session.add(StakePairing(session_id="s-1", player_a_id=PAYER,
+                                 player_b_id=CRED, amount=4))
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+
+    debts = await create_debt_entries_from_stakes(
+        guild_id=GUILD, session_id="s-1", winning_team_ids=[CRED])
+    drawn = await resolution.settle_new_debts(GUILD, [debtor for debtor, _, _ in debts])
+
+    assert debts == [(PAYER, CRED, 4)]
+    assert sum(d["amount"] for d in drawn) == 4
+    assert await ws.get_balance(GUILD, PAYER) == 6
+    assert await ws.get_balance(GUILD, CRED) == 4
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_racing_renders_create_one_set_of_stake_debts(test_db):  # noqa: F811
+    """The idempotency check is SELECT-then-insert with no DB uniqueness guard, and the
+    embed that runs it is re-rendered from six call sites. Two racing renders could each
+    see no rows and both insert -- and once a debt is auto-debited, a duplicate is money
+    genuinely taken twice rather than a stray row someone can delete."""
+    from models.stake_pairing import StakePairing
+    from services.debt_service import create_debt_entries_from_stakes
+
+    async with db_session() as session:
+        session.add(StakePairing(session_id="race-1", player_a_id=PAYER,
+                                 player_b_id=CRED, amount=4))
+
+    both = await asyncio.gather(
+        create_debt_entries_from_stakes(guild_id=GUILD, session_id="race-1",
+                                        winning_team_ids=[CRED]),
+        create_debt_entries_from_stakes(guild_id=GUILD, session_id="race-1",
+                                        winning_team_ids=[CRED]),
+    )
+
+    assert sorted(len(r) for r in both) == [0, 1], "exactly one call may create the debts"
+    async with db_session() as session:
+        rows = (await session.execute(
+            select(DebtLedger).where(DebtLedger.source_id == "race-1"))).scalars().all()
+    assert len(rows) == 2, "one debtor row and one creditor row, not four"
+
+
+@pytest.mark.asyncio
+async def test_an_uncollected_stake_debt_is_collected_on_a_later_pass(test_db):  # noqa: F811
+    """Deriving the debtors from create_debt_entries_from_stakes' return value makes
+    settlement one-shot: a replay returns [] so nobody is revisited, and a debtor whose
+    settlement failed -- or who funds their wallet a minute later -- is never collected.
+    Reading the debtors back off the ledger turns every later pass into a retry."""
+    from models.stake_pairing import StakePairing
+    from services.debt_service import create_debt_entries_from_stakes
+
+    async with db_session() as session:
+        session.add(StakePairing(session_id="s-2", player_a_id=PAYER,
+                                 player_b_id=CRED, amount=4))
+
+    debts = await create_debt_entries_from_stakes(
+        guild_id=GUILD, session_id="s-2", winning_team_ids=[CRED])
+    assert await resolution.settle_new_debts(
+        GUILD, [d for d, _, _ in debts]) == [], "empty wallet: nothing to collect yet"
+
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")   # funded after the fact
+
+    replay = await create_debt_entries_from_stakes(
+        guild_id=GUILD, session_id="s-2", winning_team_ids=[CRED])
+    assert replay == [], "the creator is idempotent, so it can't name the debtors again"
+
+    debtors = await debt_service.get_draft_debtors(GUILD, "s-2")
+    drawn = await resolution.settle_new_debts(GUILD, debtors)
+
+    assert sum(d["amount"] for d in drawn) == 4
+    assert await ws.get_balance(GUILD, PAYER) == 6
 
 
 # ---- on_inflow: the one call every inflow path makes ----------------------------

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,12 @@ from helpers.draft_footer import apply_draft_footer_from_session
 from services.draft_analysis import DraftAnalysis
 from cogs.leaderboard import create_leaderboard_embed, TimeframeView
 from draft_organization.tournament import Tournament
-from services.debt_service import create_debt_entries_from_stakes, get_balance_with
+from services.debt_service import (
+    create_debt_entries_from_stakes,
+    get_balance_with,
+    get_draft_debtors,
+)
+from services.mtgo_resolution_service import settle_new_debts
 from debt_views import SettleDebtsView
 from debt_views.settle_views import PublicSettleDebtsView
 from models.debt_summary_message import DebtSummaryMessage
@@ -620,15 +625,28 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                             # this is where a loser first learns they owe someone.
                             add_wallet_howto(bet_embed, draft_session.guild_id)
 
-                            # Create debt ledger entries for stake outcomes
+                            # Create the debt ledger entries these outcomes imply, then
+                            # draw them against the losers' wallets: a debt landing on
+                            # someone who already holds tix is settled, not offered to them
+                            # to honour.
+                            # The debtors come from the ledger, not from what this call
+                            # just created: creation is idempotent, so on every later
+                            # render it returns [] while the debts are still there. Reading
+                            # them back makes each render retry anyone still owing, which
+                            # is what stops a settlement that failed once from being
+                            # abandoned for good.
                             try:
                                 await create_debt_entries_from_stakes(
                                     guild_id=draft_session.guild_id,
                                     session_id=draft_session_id,
                                     winning_team_ids=winning_team
                                 )
+                                await settle_new_debts(
+                                    draft_session.guild_id,
+                                    await get_draft_debtors(draft_session.guild_id,
+                                                            draft_session_id))
                             except Exception as e:
-                                logger.error(f"Failed to create debt entries for session {draft_session_id}: {e}")
+                                logger.error(f"Failed to settle stake debts for session {draft_session_id}: {e}")
 
             else:
                 # Code for Swiss drafts

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ from services.crown_roles import update_crown_roles_for_guild
 # Module-level dict to track match streak extensions for ring bearer checks
 # {session_id: {player_id: {win_streak_increased: bool, perfect_streak_increased: bool}}}
 MATCH_STREAK_EXTENSIONS = {}
-from helpers.display_names import get_display_name, get_display_name_by_id
+from helpers.display_names import format_seating_order, get_display_name, get_display_name_by_id
 from helpers.skill import (
     PRIOR_MU,
     PRIOR_SIGMA,
@@ -575,7 +575,7 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                         ("\n🔵 **Team Blue Wins:** " + str(team_b_wins) if draft_session.session_type == "random" or draft_session.session_type == "test" or draft_session.session_type == "staked" else f"\n**{draft_session.team_b_name} Wins:** {team_b_wins}"), 
                     inline=False)
                 if draft_session.session_type != "premade":
-                    embed.add_field(name="Seating Order", value=" -> ".join(seating_order), inline=False)
+                    embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
 
                 # Add stakes information if this is a staked draft
                 if draft_session.session_type == "staked":
@@ -638,7 +638,7 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                 discord_color = discord.Color.dark_magenta()
                 embed = discord.Embed(title=title, description=description, color=discord_color)
                 seating_order = [draft_session.sign_ups[user_id] for user_id in sign_ups_list]
-                embed.add_field(name="Seating Order", value=" -> ".join(seating_order), inline=False)
+                embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
                 bet_embed = None  # Swiss drafts don't have bet outcomes
 
             # Shared draft metadata footer, on the main embed only — bet_embed
@@ -859,7 +859,7 @@ async def check_and_post_victory_or_draw(bot, draft_session_id):
                                             discord_color = discord.Color.gold()
                                             embed = discord.Embed(title=title, description=description, color=discord_color)
                                             seating_order = [draft_session.sign_ups[user_id] for user_id in sign_ups_list]
-                                            embed.add_field(name="Seating Order", value=" -> ".join(seating_order), inline=False)
+                                            embed.add_field(name="Seating Order", value=format_seating_order(seating_order), inline=False)
                                             embed.add_field(name="Standings", value=standings, inline=False)
                                             apply_draft_footer_from_session(embed, draft_session)
 


### PR DESCRIPTION
## What

Settlement only ever fired on **inflow** — money arriving at someone who owes, via `settle_inflow` → `auto_draw`. The mirror case had no trigger: a **debt** arriving at someone who already holds tix.

So losing a staked draft with a funded wallet left paying up to the debtor's discretion. Perversely, doing nothing worked better than acting: merely *receiving* tix would have auto-settled the same debt.

`settle_new_debts` is that missing trigger.

## How

It reuses `settle_inflow` rather than adding a parallel path, so the two rules every automatic settlement needs — skip synthetic holders, never fail the caller — stay stated once. Partial funds collect what's there and leave the remainder owed. Card loans are unreachable, because every balance read filters `TIX_ONLY`.

Two details worth knowing when reading it:

**The debtors come from the ledger, not from what was just created.** `create_debt_entries_from_stakes` is idempotent, so on every later render it returns `[]` while the debts are still outstanding. Consuming that return value would make settlement one-shot — abandoning any debtor whose settlement failed, or who funded their wallet a minute later. Reading the ledger (`get_draft_debtors`) makes each render a free retry, since settling an already-settled debt draws against a zero balance.

**Stake debt creation now runs under `_STAKE_DEBT_LOCK`.** Its idempotency check is a SELECT-then-insert with no uniqueness constraint behind it, invoked from an embed renderer with six call sites, so two concurrent renders could both find nothing and both insert. This reproduced in a test. Duplicated debts stop being cosmetic once they're auto-debited.

## Scope

Draft stakes only — admin adjustments and debt transfers deliberately don't trigger it.

## Verification

- Full suite: **1241 passed**, 9 skipped
- `pipenv run pyrefly check`: **0 errors**
- Reviewed by four cleanup passes (reuse / simplification / efficiency / altitude) and by Codex; both Codex findings fixed and covered by tests

**End-to-end against a live test guild**, confirming three behaviours:

| scenario | result |
|---|---|
| loser funded at victory | debited immediately, both parties DM'd |
| loser with 60 owing 100 | partial settlement, 40 left on the books |
| loser funded **after** the draft ended | collected on the next render (the case that was previously abandoned for good) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLERVw2GEcW92iWRuwWk3k