### PR TITLE
Paying someone you owe settles that debt

### DIFF
--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -358,22 +358,71 @@ async def pending_jobs_watchdog(bot=None):
 # ---------------------------------------------------------------------------
 # internal pay (no trade)
 # ---------------------------------------------------------------------------
+async def _settle_owed_portion(guild_id: str, payer_id: str, creditor_id: str,
+                               amount: int) -> dict | None:
+    """Settle up to ``amount`` of what ``payer_id`` owes ``creditor_id``, or None if they
+    owe nothing (or the settlement could not be applied).
+
+    Capped at the outstanding debt because settle_debt_from_wallet refuses an amount that
+    exceeds it. A failure here is deliberately soft: the caller falls through to a plain
+    transfer, which runs its own funds check and surfaces the real error rather than
+    turning a payment into a settlement-shaped one.
+    """
+    balance = await debt_service.get_balance_with(
+        guild_id=guild_id, player_id=payer_id, counterparty_id=creditor_id)
+    if balance >= 0:
+        return None                       # owes them nothing: an ordinary payment
+    res = await settle_debt_from_wallet(
+        guild_id, payer_id, creditor_id, min(amount, -balance))
+    if not res.get("ok"):
+        logger.warning(
+            f"pay: debt settle {payer_id}->{creditor_id} skipped: {res.get('error')}")
+        return None
+    return res
+
+
 async def pay(guild_id: str, from_player: str, to_player: str, amount: int, *, notes: str = None) -> dict:
-    """Move tix between two wallets with no MTGO trade (a plain claim transfer)."""
+    """Move tix between two wallets with no MTGO trade (a plain claim transfer).
+
+    Paying someone you OWE settles that debt (up to the amount owed) rather than landing
+    as a plain transfer that leaves it standing. `/wallet pay` is how a debtor actually
+    pays their creditor, so the ledger has to follow the money — otherwise the tix move,
+    the debt does not, and the pair have to settle it a second time by hand. Anything
+    above the debt moves on as an ordinary payment.
+
+    Note the asymmetry this closes: ``on_inflow`` settles what the RECIPIENT owes, so
+    before this a debtor paying their creditor directly was the one route that skipped
+    settlement entirely — while merely receiving tix would have auto-settled the same debt.
+    """
+    cleared = await _settle_owed_portion(guild_id, from_player, to_player, amount)
+    settled_amount = cleared["amount"] if cleared else 0
+    rest = amount - settled_amount
+
+    if settled_amount:
+        # Tell the creditor, but do NOT run their on_inflow: a settlement must not cascade
+        # down the creditor chain (the rule auto_draw states and keeps).
+        from notification_service import notify_wallet, notify_payment_received
+        await notify_wallet(notify_payment_received, guild_id, to_player, from_player,
+                            settled_amount, note=f"settled {settled_amount} tix of debt")
+
+    if rest <= 0:
+        return {"ok": True, "amount": amount, "debt_settled": cleared, "settled": []}
+
     try:
-        debit, credit = await wallet_service.pay(guild_id, from_player, to_player, amount, notes=notes)
+        debit, credit = await wallet_service.pay(guild_id, from_player, to_player, rest, notes=notes)
     except wallet_service.InsufficientFunds as e:
         # Tagged rather than left as prose: the cog answers this one refusal with "go
         # and deposit", which would be nonsense advice for any of the others.
-        return {"ok": False, "error": str(e),
+        return {"ok": False, "error": str(e), "debt_settled": cleared,
                 "code": wallet_service.INSUFFICIENT_FUNDS, "available": e.available}
     except ValueError as e:
-        return {"ok": False, "error": str(e)}
+        return {"ok": False, "error": str(e), "debt_settled": cleared}
     # Receiving money is the case you are least likely to be watching for.
     from notification_service import notify_payment_received
     drawn = await on_inflow(guild_id, to_player, notify_payment_received,
-                            from_player, amount, note=notes)
-    return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id], "settled": drawn}
+                            from_player, rest, note=notes)
+    return {"ok": True, "amount": amount, "tx_ids": [debit.id, credit.id],
+            "debt_settled": cleared, "settled": drawn}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -301,6 +301,61 @@ async def test_an_uncollected_stake_debt_is_collected_on_a_later_pass(test_db): 
     assert await ws.get_balance(GUILD, PAYER) == 6
 
 
+# ---- paying someone you owe settles that debt ------------------------------------
+
+@pytest.mark.asyncio
+async def test_paying_a_creditor_settles_that_debt(test_db):  # noqa: F811
+    """Reported live: keezles owed Birb 10, sent 10 with /wallet pay, and the debt stayed
+    on the books until Birb cleared it by hand. Settlement fired only for the RECIPIENT's
+    debts (on_inflow), so a debtor paying their creditor directly was the one route that
+    skipped it -- while merely RECEIVING tix would have settled the very same debt."""
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+    await _owe(PAYER, CRED, 4, "d1")
+
+    res = await resolution.pay(GUILD, PAYER, CRED, 4)
+
+    assert res["ok"]
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == 0, "the debt should be cleared, not just the tix moved"
+    assert await ws.get_balance(GUILD, PAYER) == 6
+    assert await ws.get_balance(GUILD, CRED) == 4
+    assert await ws.total_wallets() == 10, "the tix must move exactly once, not twice"
+
+
+@pytest.mark.asyncio
+async def test_paying_more_than_the_debt_settles_it_and_sends_the_rest(test_db):  # noqa: F811
+    """Overpaying stays one command: the debt closes and the surplus lands as an ordinary
+    payment, so the creditor ends up with the whole amount either way."""
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+    await _owe(PAYER, CRED, 3, "d1")
+
+    res = await resolution.pay(GUILD, PAYER, CRED, 8)
+
+    assert res["ok"]
+    assert res["debt_settled"]["amount"] == 3
+    balances = await debt_service.get_all_balances_for(GUILD, PAYER)
+    assert balances.get(CRED, 0) == 0
+    assert await ws.get_balance(GUILD, CRED) == 8      # 3 settling the debt + 5 plain
+    assert await ws.get_balance(GUILD, PAYER) == 2
+    assert await ws.total_wallets() == 10
+
+
+@pytest.mark.asyncio
+async def test_paying_someone_you_do_not_owe_is_still_a_plain_transfer(test_db):  # noqa: F811
+    """Regression guard: debt-awareness must not disturb the ordinary case, including the
+    recipient's own auto-draw on the way in."""
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+    await _owe(CRED, CRED2, 2, "d1")          # the RECIPIENT owes someone else
+
+    res = await resolution.pay(GUILD, PAYER, CRED, 5)
+
+    assert res["ok"] and res["debt_settled"] is None
+    assert [d["amount"] for d in res["settled"]] == [2]   # recipient's debt drawn as before
+    assert await ws.get_balance(GUILD, PAYER) == 5
+    assert await ws.get_balance(GUILD, CRED) == 3         # 5 in, 2 out to their creditor
+    assert await ws.get_balance(GUILD, CRED2) == 2
+
+
 # ---- on_inflow: the one call every inflow path makes ----------------------------
 
 @pytest.mark.asyncio

--- a/tests/test_wallet_trade_copy.py
+++ b/tests/test_wallet_trade_copy.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from conftest import test_db  # noqa: F401  (fixture)
 from helpers.money_gate import mtgo_trade_prompt
 
 
@@ -148,7 +149,7 @@ def test_the_funds_failure_is_its_own_type():
 
 
 @pytest.mark.asyncio
-async def test_the_funds_failure_reaches_the_cog_tagged():
+async def test_the_funds_failure_reaches_the_cog_tagged(test_db):  # noqa: F811
     """The tests above hand the cog a ready-made result, so they pin the cog's half of
     the contract and nothing else. This pins the other half: that resolution.pay really
     does turn the exception into the code the cog switches on. Without it, dropping the
@@ -169,7 +170,7 @@ async def test_the_funds_failure_reaches_the_cog_tagged():
 
 
 @pytest.mark.asyncio
-async def test_other_value_errors_stay_untagged():
+async def test_other_value_errors_stay_untagged(test_db):  # noqa: F811
     from services import mtgo_resolution_service as resolution
 
     with patch("services.wallet_service.pay",


### PR DESCRIPTION
> Stacked on #424 — review that one first.

## The report

> "I'd have wallet autoresolve the debt. received 10 from keezles in the bot but had to manually resolve debt as well" — Birb // Entropy263

Confirmed in the ledger: the draft booked keezles owing Birb 10 at 23:53, keezles sent 10 with `/wallet pay` at 23:54, and Birb cleared the debt by hand at 23:59. The tix moved; the debt didn't.

## The cause

`resolution.pay` fired the settlement hook only for the **recipient**:

```python
drawn = await on_inflow(guild_id, to_player, notify_payment_received, ...)
```

`on_inflow` → `auto_draw(recipient)` settles what the *recipient* owes other people. It ran for Birb, found he owed nobody, and correctly did nothing. The keezles→Birb debt was never in scope, because `auto_draw` never ran for keezles — settlement was modelled purely as an on-the-way-**in** event, so the payer side had no trigger at all.

The perverse consequence: keezles held 150 tix and owed 10, so had he merely *received* tix instead, settlement would have paid Birb automatically. Deliberately paying the person you owe was the one route that skipped the mechanism.

## The fix

A payment to someone you owe routes that portion through `settle_debt_from_wallet`, so a **single movement of tix both pays and clears the ledger**. Anything above the debt continues as an ordinary payment.

Two deliberate choices:

- **Capped at the outstanding debt**, because `settle_debt_from_wallet` refuses more than is owed. Overpayment splits: the debt closes, the surplus goes plain.
- **No cascade.** The creditor is notified, but their `on_inflow` doesn't run for the settled portion — settlement chaining down the creditor chain is a rule `auto_draw` already states and keeps, and `/wallet pay` shouldn't be the one path that breaks it.

Rejected alternative: calling `auto_draw` for the payer. It settles their debts *oldest-first across all creditors*, so keezles' remaining balance could have gone to someone else entirely — and it would move tix a second time on top of the payment already sent.

## No data repair needed

Checked: the manual settle was ledger-only and moved no second payment. Net position was already correct — 10 tix moved once, debt now zero. They just had to do it in two steps.

## Verification

- Full suite: **1244 passed**, 9 skipped
- `pipenv run pyrefly check`: **0 errors**
- Three tests, the first written RED (`assert -4 == 0` — the debt surviving the payment): the reported case, overpayment splitting, and a regression guard that ordinary payments still trigger the recipient's own auto-draw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLERVw2GEcW92iWRuwWk3k