### PR TITLE
Stop lent cards being netted against a tix debt

### DIFF
--- a/services/mtgo_resolution_service.py
+++ b/services/mtgo_resolution_service.py
@@ -462,12 +462,18 @@ async def settle_debt_from_wallet(guild_id: str, payer_id: str, creditor_id: str
                         "error": f"insufficient wallet funds (available {available})",
                         "code": wallet_service.INSUFFICIENT_FUNDS, "available": available}
 
-            # payer must actually owe the creditor at least this much
+            # payer must actually owe the creditor at least this much, IN TIX. The
+            # card-entity filter is not optional: on a card row ``amount`` is a count of
+            # COPIES, so without it a lent card nets against money owed — a payer owing 5
+            # tix who has lent 3 cards to the same person reads as owing 2, and their
+            # settlement is refused as exceeding the debt, leaving real tix uncollected.
+            # Every other balance read in debt_service applies the same filter.
             debt_balance = int((await session.execute(
                 select(func.coalesce(func.sum(DebtLedger.amount), 0)).where(
                     DebtLedger.guild_id == guild_id,
                     DebtLedger.player_id == payer_id,
                     DebtLedger.counterparty_id == creditor_id,
+                    debt_service.TIX_ONLY,
                 ))).scalar() or 0)
             if debt_balance >= 0:
                 return {"ok": False, "error": "no outstanding debt to this creditor"}

--- a/tests/test_wallet_debt_settlement.py
+++ b/tests/test_wallet_debt_settlement.py
@@ -355,6 +355,37 @@ async def test_paying_someone_you_do_not_owe_is_still_a_plain_transfer(test_db):
     assert await ws.get_balance(GUILD, CRED) == 3         # 5 in, 2 out to their creditor
     assert await ws.get_balance(GUILD, CRED2) == 2
 
+async def _lend_cards(lender, borrower, quantity, source_id):
+    """Book a card loan: the borrower owes ``quantity`` COPIES back. On a card row
+    ``amount`` is a count of copies, not tix -- which is why every balance read has to
+    filter card_name IS NULL before treating the number as money."""
+    async with db_session() as session:
+        session.add(DebtLedger(guild_id=GUILD, player_id=borrower, counterparty_id=lender,
+                               amount=-quantity, source_type="card_loan",
+                               source_id=source_id, card_name="Black Lotus",
+                               created_by=lender))
+        session.add(DebtLedger(guild_id=GUILD, player_id=lender, counterparty_id=borrower,
+                               amount=quantity, source_type="card_loan",
+                               source_id=source_id, card_name="Black Lotus",
+                               created_by=lender))
+
+
+@pytest.mark.asyncio
+async def test_lent_cards_do_not_block_settling_a_tix_debt(test_db):  # noqa: F811
+    """settle_debt_from_wallet's own debt check is the one balance read in the codebase
+    that omits the tix filter, so it nets copies against money. A payer who owes 5 tix
+    AND has lent 3 cards to the same person looks like they owe 2 -- and their settlement
+    is REJECTED as exceeding the debt, leaving real money uncollected."""
+    await ws.credit_done(GUILD, PAYER, 10, job_id="j1")
+    await _owe(PAYER, CRED, 5, "tix-debt")
+    await _lend_cards(PAYER, CRED, 3, "card-loan")
+
+    res = await resolution.settle_debt_from_wallet(GUILD, PAYER, CRED, 5)
+
+    assert res["ok"], f"5 tix are genuinely owed, but got: {res.get('error')}"
+    assert await ws.get_balance(GUILD, PAYER) == 5
+    assert await ws.get_balance(GUILD, CRED) == 5
+
 
 # ---- on_inflow: the one call every inflow path makes ----------------------------
 


### PR DESCRIPTION
## The bug

`debt_ledger` holds two entities in one signed column, told apart only by `card_name`:

| `card_name` | what `amount` means |
|---|---|
| `NULL` | **tix** |
| set | **copies of that card** |

Every balance read filters `card_name IS NULL` (`TIX_ONLY`) — **18 of them in `debt_service`** — except one, in `settle_debt_from_wallet`, which summed the column raw.

So cards netted against money. A payer owing **5 tix** who had **lent 3 cards** to the same person read as owing **2**, and their settlement was refused:

```
amount (5) exceeds debt (2)
```

Tix that were genuinely owed went uncollected — silently, with no error anywhere except a return value the caller treats as "nothing to settle".

## Where it came from

Nobody introduced this by getting it wrong.

`settle_debt_from_wallet` was written **2026-08-03**, when `debt_ledger` held only tix and summing the column was exactly right. Card lending landed two days later (`d08130f`, *"debt_ledger grows nullable card_name (multi-entity ledger)"*), redefining what `amount` can mean. It applied the new guard thoroughly inside `debt_service` but never crossed into `mtgo_resolution_service`, which also reads the table.

A correct query, invalidated from a distance. It has survived since **2026-08-05** because it needs *both* a tix debt and a card loan between the same pair to fire.

## The fix

One predicate, bringing this read in line with every other one:

```python
DebtLedger.counterparty_id == creditor_id,
debt_service.TIX_ONLY,
```

## Verification

- Test written RED against the real symptom (`amount (5) exceeds debt (2)`), green after
- Full suite: **1250 passed**, 9 skipped, pytest exit code 0
- `pipenv run pyrefly check`: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLERVw2GEcW92iWRuwWk3k