### PR TITLE
DraftBot: give each team a scouting thread per opponent

### DIFF
--- a/helpers/opponent_threads.py
+++ b/helpers/opponent_threads.py
@@ -1,0 +1,152 @@
+"""Per-opponent scouting threads in a team's private draft channel.
+
+When Red-Team-Chat / Blue-Team-Chat are created, each team gets one thread per
+player on the *other* team, so they have a dedicated place to pool reads and
+matchup notes on that specific opponent.
+
+Best-effort throughout: create_team_channel persists channel_ids and moves the
+session to the 'pairings' stage, so nothing here may raise into that path.
+"""
+from __future__ import annotations
+
+import discord
+from loguru import logger
+
+from helpers.substitutes import TEAM_A_CHANNEL_PREFIX, TEAM_B_CHANNEL_PREFIX
+from helpers.utils import THREAD_ARCHIVE_MINUTES
+
+DISCORD_THREAD_NAME_LIMIT = 100
+ARCHIVED_THREAD_LOOKUP_LIMIT = 100
+
+# Team channel -> how to describe the team its occupants are playing against.
+# Keyed on the shared prefix constants: the channel names have been renamed once
+# already, and a stale literal here would silently produce no threads at all.
+_OPPONENT_LABEL = {
+    TEAM_A_CHANNEL_PREFIX: "Blue Team",
+    TEAM_B_CHANNEL_PREFIX: "Red Team",
+}
+
+
+def opponent_ids(
+    team_name: str,
+    team_a: list[str] | None,
+    team_b: list[str] | None,
+) -> list[str]:
+    """Discord ids of the players a `team_name` channel's occupants face.
+
+    Returns [] for the shared "Draft" channel (which holds both teams, so nobody
+    in it is an opponent) and for any other channel name, which is what keeps
+    swiss -- whose only channel is "Draft" -- out of this feature entirely.
+    """
+    if team_name == TEAM_A_CHANNEL_PREFIX:
+        return list(team_b or [])
+    if team_name == TEAM_B_CHANNEL_PREFIX:
+        return list(team_a or [])
+    return []
+
+
+def _thread_name(discord_id: str, sign_ups: dict[str, str] | None) -> str:
+    """Thread label for one opponent, derived from their sign-up display name.
+
+    Must be a pure function of (discord_id, sign_ups): spawn_opponent_threads
+    skips names it already finds in the channel, so a name that varies with
+    roster order or with existing threads would make a re-run duplicate them.
+
+    Display names are not unique (sign_ups stores member.display_name), so an id
+    fragment is appended when another sign-up shares the name -- otherwise the
+    second player silently gets no thread. Counted over the whole sign_ups dict,
+    never over iteration state, to keep the function pure.
+    """
+    sign_ups = sign_ups or {}
+    name = str(sign_ups.get(discord_id) or "").strip()
+    if not name:
+        return str(discord_id)[:DISCORD_THREAD_NAME_LIMIT]
+
+    shared = sum(1 for other in sign_ups.values() if str(other or "").strip() == name)
+    if shared < 2:
+        return name[:DISCORD_THREAD_NAME_LIMIT]
+
+    # Clip the name *before* appending, so a very long name can't push the
+    # discriminator past the limit and take uniqueness with it.
+    suffix = f" ({str(discord_id)[-4:]})"
+    return name[:DISCORD_THREAD_NAME_LIMIT - len(suffix)] + suffix
+
+
+async def _existing_thread_names(channel: discord.TextChannel) -> set[str]:
+    """Names of the threads already in `channel`, active and archived.
+
+    `channel.threads` is pycord's cache of ACTIVE threads only, and scouting
+    threads auto-archive after THREAD_ARCHIVE_MINUTES -- so a re-run days later
+    would not see its own earlier work and would duplicate every thread. The
+    archived lookup is a real API call; if it fails we keep the active names
+    rather than lose the whole run.
+    """
+    names = {t.name for t in channel.threads}
+    try:
+        async for thread in channel.archived_threads(limit=ARCHIVED_THREAD_LOOKUP_LIMIT):
+            names.add(thread.name)
+    except Exception as e:
+        logger.warning(f"[opponent-threads] archived thread lookup failed: {e}")
+    return names
+
+
+def _starter(name: str, opponent_team_label: str) -> str:
+    return (
+        f"🔍 Scouting thread for **{name}** ({opponent_team_label}). "
+        "Share reads, matchup notes, and what you saw them pick."
+    )
+
+
+async def spawn_opponent_threads(
+    channel: discord.TextChannel,
+    team_name: str,
+    team_a: list[str] | None,
+    team_b: list[str] | None,
+    sign_ups: dict[str, str] | None,
+) -> int:
+    """Create one scouting thread per opponent in `channel`. Returns how many
+    were created.
+
+    Never raises -- this runs inside channel creation, which is the draft's
+    critical path, so the guard lives here rather than at each call site.
+
+    Skips opponents that already have a same-named thread, so re-running against
+    an existing channel (recover_draft_channels) doesn't double up.
+    """
+    try:
+        ids = opponent_ids(team_name, team_a, team_b)
+        if not ids:
+            return 0
+        label = _OPPONENT_LABEL[team_name]
+        existing = await _existing_thread_names(channel)
+    except Exception as e:
+        logger.warning(f"[opponent-threads] could not resolve opponents for '{team_name}': {e}")
+        return 0
+
+    created = 0
+    for discord_id in ids:
+        name = str(discord_id)
+        try:
+            name = _thread_name(discord_id, sign_ups)
+            if name in existing:
+                continue
+            thread = await channel.create_thread(
+                name=name,
+                type=discord.ChannelType.public_thread,
+                auto_archive_duration=THREAD_ARCHIVE_MINUTES,
+            )
+        except Exception as e:
+            logger.warning(f"[opponent-threads] could not create thread '{name}': {e}")
+            continue
+
+        # The thread exists from here on. Record it before posting the starter:
+        # that is a separate call which can fail on its own, and treating that
+        # as a failed creation would lose track of a thread that is really
+        # there -- and re-create it on the next run.
+        existing.add(name)
+        created += 1
+        try:
+            await thread.send(_starter(name, label))
+        except Exception as e:
+            logger.warning(f"[opponent-threads] created '{name}' but its starter failed: {e}")
+    return created

--- a/helpers/quiz_threads.py
+++ b/helpers/quiz_threads.py
@@ -7,7 +7,7 @@ from typing import Optional
 import discord
 from loguru import logger
 
-THREAD_ARCHIVE_MINUTES = 4320  # 3 days
+from helpers.utils import THREAD_ARCHIVE_MINUTES
 
 DISCUSSION_THREAD_STARTER = (
     "💬 Discuss the quiz here — spoilers ahead! Use **Share Results** on your "

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -30,6 +30,12 @@ def as_messageable(channel: object) -> "discord.abc.Messageable":
     return channel
 
 
+# How long a bot-created thread stays active before Discord auto-archives it.
+# Shared by every thread-spawning feature (quiz discussion, opponent scouting)
+# so they age out together rather than drifting apart per feature.
+THREAD_ARCHIVE_MINUTES = 4320  # 3 days
+
+
 # Define a mapping of cube names to thumbnail URLs
 # This is used for consistent cube thumbnails across the app
 CUBE_THUMBNAILS = {

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -10,6 +10,7 @@ preset = "strict"
 
 project-includes = [
     "cogs/server_draft_stats.py",
+    "helpers/opponent_threads.py",
     "helpers/utils.py",
     "helpers/view_dispatch_guard.py",
     "ready_check.py",

--- a/tests/test_opponent_threads.py
+++ b/tests/test_opponent_threads.py
@@ -1,0 +1,228 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from helpers.opponent_threads import opponent_ids, spawn_opponent_threads
+
+
+def make_channel(existing_thread_names=(), archived_thread_names=(), starter_fails=False):
+    """Fake TextChannel. create_thread returns a fresh fake thread each call and
+    records it on `created_threads`, so tests can inspect what was sent into it.
+
+    `threads` mirrors pycord's cached ACTIVE threads; archived ones are only
+    reachable through the separate archived_threads() API call.
+    """
+    created_threads = []
+
+    def new_thread(**kwargs):
+        send = AsyncMock(side_effect=RuntimeError("cannot post")) if starter_fails else AsyncMock()
+        thread = SimpleNamespace(name=kwargs.get("name"), send=send)
+        created_threads.append(thread)
+        return thread
+
+    async def archived_threads(**kwargs):
+        for name in archived_thread_names:
+            yield SimpleNamespace(name=name)
+
+    return SimpleNamespace(
+        threads=[SimpleNamespace(name=n) for n in existing_thread_names],
+        archived_threads=archived_threads,
+        create_thread=AsyncMock(side_effect=new_thread),
+        created_threads=created_threads,
+    )
+
+
+def thread_names(channel):
+    """Names the helper asked Discord to create, in order."""
+    return [c.kwargs["name"] for c in channel.create_thread.await_args_list]
+
+
+def test_red_team_channel_gets_team_b_as_opponents():
+    assert opponent_ids("Red-Team", ["a1", "a2"], ["b1", "b2"]) == ["b1", "b2"]
+
+
+def test_blue_team_channel_gets_team_a_as_opponents():
+    assert opponent_ids("Blue-Team", ["a1", "a2"], ["b1", "b2"]) == ["a1", "a2"]
+
+
+def test_shared_draft_channel_has_no_opponents():
+    """The 'Draft' channel holds both teams, so nobody in it is an opponent."""
+    assert opponent_ids("Draft", ["a1"], ["b1"]) == []
+
+
+def test_unknown_team_name_has_no_opponents():
+    assert opponent_ids("Green-Team", ["a1"], ["b1"]) == []
+
+
+def test_missing_team_rosters_yield_no_opponents():
+    """team_a/team_b default to None in create_team_channel's signature."""
+    assert opponent_ids("Red-Team", None, None) == []
+
+
+SIGN_UPS = {"a1": "Alice", "b1": "Dave", "b2": "Erin"}
+
+
+@pytest.mark.asyncio
+async def test_creates_one_named_thread_per_opponent():
+    channel = make_channel()
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], SIGN_UPS
+    )
+    assert created == 2
+    names = thread_names(channel)
+    assert names == ["Dave", "Erin"]
+
+
+@pytest.mark.asyncio
+async def test_thread_starter_names_the_opponent_and_their_team():
+    channel = make_channel()
+    await spawn_opponent_threads(channel, "Red-Team", ["a1"], ["b1"], SIGN_UPS)
+    (thread,) = channel.created_threads
+    starter = thread.send.await_args.args[0]
+    assert "Dave" in starter
+    assert "Blue Team" in starter
+
+
+@pytest.mark.asyncio
+async def test_skips_opponents_that_already_have_a_thread():
+    """Reruns (recover_draft_channels) must not double up."""
+    channel = make_channel(existing_thread_names=["Dave"])
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], SIGN_UPS
+    )
+    assert created == 1
+    names = thread_names(channel)
+    assert names == ["Erin"]
+
+
+@pytest.mark.asyncio
+async def test_one_failed_thread_does_not_block_the_others():
+    channel = make_channel()
+    channel.create_thread = AsyncMock(
+        side_effect=[RuntimeError("no perms"), SimpleNamespace(send=AsyncMock())]
+    )
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], SIGN_UPS
+    )
+    assert created == 1
+
+
+@pytest.mark.asyncio
+async def test_shared_draft_channel_creates_nothing():
+    channel = make_channel()
+    created = await spawn_opponent_threads(
+        channel, "Draft", ["a1"], ["b1"], SIGN_UPS
+    )
+    assert created == 0
+    channel.create_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_two_opponents_with_the_same_display_name_each_get_a_thread():
+    """Discord display names are not unique. If both opponents resolve to the
+    same thread name, the already-exists check silently swallows the second one
+    and that player ends up with no scouting thread at all."""
+    sign_ups = {"b1": "Dave", "b2": "Dave"}
+    channel = make_channel()
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], sign_ups
+    )
+    assert created == 2
+    names = thread_names(channel)
+    assert len(set(names)) == 2, f"opponents collapsed onto one thread name: {names}"
+
+
+@pytest.mark.asyncio
+async def test_long_display_name_fits_discord_thread_name_limit():
+    """Discord rejects thread names over 100 characters with a 400."""
+    sign_ups = {"b1": "M" + "a" * 200 + "n"}
+    channel = make_channel()
+    await spawn_opponent_threads(channel, "Red-Team", ["a1"], ["b1"], sign_ups)
+    (name,) = thread_names(channel)
+    assert 0 < len(name) <= 100
+
+
+@pytest.mark.asyncio
+async def test_names_are_stable_so_a_rerun_creates_nothing():
+    """recover_draft_channels re-runs this against a rebuilt channel. Names must
+    be reproducible or the skip check won't recognise what it already made."""
+    sign_ups = {"b1": "Dave", "b2": "Dave"}
+    first = make_channel()
+    await spawn_opponent_threads(first, "Red-Team", ["a1"], ["b1", "b2"], sign_ups)
+    made = thread_names(first)
+
+    second = make_channel(existing_thread_names=made)
+    created = await spawn_opponent_threads(
+        second, "Red-Team", ["a1"], ["b1", "b2"], sign_ups
+    )
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_blank_display_name_falls_back_to_a_usable_label():
+    """Discord rejects an empty thread name; a whitespace-only nickname must not
+    become one."""
+    channel = make_channel()
+    await spawn_opponent_threads(channel, "Red-Team", ["a1"], ["b1"], {"b1": "   "})
+    (name,) = thread_names(channel)
+    assert name.strip(), f"blank thread name: {name!r}"
+
+
+@pytest.mark.asyncio
+async def test_never_raises_when_the_channel_itself_misbehaves():
+    """views.py create_team_channel calls this with no guard of its own, on the
+    draft's critical path -- a raise here would strand the session at the
+    channel-creation step."""
+    class Hostile:
+        create_thread = AsyncMock()
+
+        @property
+        def threads(self):
+            raise RuntimeError("channel state unavailable")
+
+    created = await spawn_opponent_threads(
+        Hostile(), "Red-Team", ["a1"], ["b1"], SIGN_UPS
+    )
+    assert created == 0
+
+
+@pytest.mark.asyncio
+async def test_thread_counts_even_if_its_starter_message_fails():
+    """The thread exists the moment create_thread returns. Treating a failed
+    starter as a failed creation loses track of a thread that is really there."""
+    channel = make_channel(starter_fails=True)
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1"], SIGN_UPS
+    )
+    assert created == 1
+    assert thread_names(channel) == ["Dave"]
+
+
+@pytest.mark.asyncio
+async def test_skips_opponents_whose_thread_has_been_archived():
+    """channel.threads holds only ACTIVE threads. After the 3-day auto-archive,
+    a rerun that consulted it alone would create a duplicate."""
+    channel = make_channel(archived_thread_names=["Dave"])
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], SIGN_UPS
+    )
+    assert created == 1
+    assert thread_names(channel) == ["Erin"]
+
+
+@pytest.mark.asyncio
+async def test_archived_lookup_failure_degrades_to_the_active_thread_list():
+    """The archived fetch is an API call and may fail; it must not cost us the
+    threads we can still create."""
+    channel = make_channel(existing_thread_names=["Dave"])
+
+    def boom(**kwargs):
+        raise RuntimeError("missing read_message_history")
+
+    channel.archived_threads = boom
+    created = await spawn_opponent_threads(
+        channel, "Red-Team", ["a1"], ["b1", "b2"], SIGN_UPS
+    )
+    assert created == 1
+    assert thread_names(channel) == ["Erin"]

--- a/tests/test_opponent_threads_wiring.py
+++ b/tests/test_opponent_threads_wiring.py
@@ -1,0 +1,142 @@
+"""create_team_channel must actually call the scouting-thread helper, with the
+right rosters, after the channel row is committed.
+
+tests/test_opponent_threads.py covers the helper in isolation -- every one of
+those tests still passes if the call site is deleted, the rosters are swapped,
+or the call is moved ahead of the commit that persists channel_ids and the
+'pairings' stage. This file is what notices.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+
+import views
+
+
+class _ACM:
+    """Minimal async context manager returning `value`."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeDB:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def begin(self):
+        return _ACM(self)
+
+    async def execute(self, *args, **kwargs):
+        self.calls.append("db-execute")
+
+    async def commit(self):
+        self.calls.append("db-commit")
+
+
+class FakeRole:
+    """Hashable stand-in -- overwrites is a dict keyed by role/member objects,
+    and SimpleNamespace defines __eq__ so it can't be a key."""
+
+    def __init__(self, name):
+        self.name = name
+        self.tags = None
+
+
+class FakeGuild:
+    id = 4242
+    name = "Test Guild"
+    categories: list = []
+    roles: list = []
+
+    def __init__(self, channel):
+        self.me = FakeRole("bot")
+        self.default_role = FakeRole("everyone")
+        self._channel = channel
+
+    async def create_text_channel(self, **kwargs):
+        return self._channel
+
+
+@pytest_asyncio.fixture
+async def wired(monkeypatch):
+    """create_team_channel with its config/DB/Discord edges faked out.
+
+    Returns (view, guild, calls, spawn) -- `calls` records the ordering of the
+    DB commit against the helper call.
+    """
+    calls: list = []
+    channel = SimpleNamespace(id=999, name="Red-Team-Chat-abc1", threads=[])
+
+    monkeypatch.setattr("config.get_config", lambda gid: {
+        "categories": {"draft": "Drafts"}, "roles": {"admin": "Admin"},
+    })
+    monkeypatch.setattr("config.is_special_guild", lambda gid: False)
+    monkeypatch.setattr("config.get_bots_with_draft_access", lambda gid: [])
+
+    session = SimpleNamespace(
+        friendly_id="abc1",
+        premade_match_id=None,
+        session_type="team",
+        sign_ups={"a1": "Alice", "b1": "Dave", "b2": "Erin"},
+        team_a=["a1"],
+        team_b=["b1", "b2"],
+    )
+    monkeypatch.setattr(views, "get_draft_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(views, "AsyncSessionLocal", lambda: _ACM(FakeDB(calls)))
+
+    async def spawn(*args, **kwargs):
+        calls.append("spawn")
+        spawn.args = args
+        return 0
+
+    spawn.args = None
+    monkeypatch.setattr(views, "spawn_opponent_threads", spawn)
+
+    view = views.PersistentView(bot=None, draft_session_id="s1", session_type="team")
+    # Set by the "Draft" channel pass, which both call sites run first.
+    view.draft_chat_channel = None
+    return view, FakeGuild(channel), calls, spawn
+
+
+@pytest.mark.asyncio
+async def test_red_team_channel_spawns_threads_for_team_b(wired):
+    view, guild, _calls, spawn = wired
+    await view.create_team_channel(guild, "Red-Team", [], ["a1"], ["b1", "b2"])
+
+    channel, team_name, team_a, team_b, sign_ups = spawn.args
+    assert team_name == "Red-Team"
+    assert team_a == ["a1"]
+    assert team_b == ["b1", "b2"]
+    assert sign_ups == {"a1": "Alice", "b1": "Dave", "b2": "Erin"}
+    assert channel.name == "Red-Team-Chat-abc1"
+
+
+@pytest.mark.asyncio
+async def test_threads_are_spawned_after_the_channel_row_is_committed(wired):
+    """channel_ids and session_stage='pairings' are the draft's critical path;
+    the threads are a nice-to-have that must not precede them."""
+    view, guild, calls, _spawn = wired
+    await view.create_team_channel(guild, "Red-Team", [], ["a1"], ["b1", "b2"])
+
+    assert "spawn" in calls, "create_team_channel never called spawn_opponent_threads"
+    assert calls.index("db-commit") < calls.index("spawn")
+
+
+@pytest.mark.asyncio
+async def test_shared_draft_channel_still_calls_the_helper_to_no_op(wired):
+    """The 'Draft' channel is filtered inside the helper (opponent_ids returns
+    []), not at the call site -- keep that contract explicit."""
+    view, guild, _calls, spawn = wired
+    await view.create_team_channel(guild, "Draft", [], ["a1"], ["b1", "b2"])
+
+    assert spawn.args is not None
+    assert spawn.args[1] == "Draft"

--- a/views.py
+++ b/views.py
@@ -19,6 +19,7 @@ from helpers.money_gate import wallet_howto
 from helpers.display_names import get_display_name, get_display_name_by_id
 from helpers.debt_warning import format_staked_sign_ups, DEBT_WARNING_AGE_DAYS
 from helpers.draft_footer import apply_draft_footer_from_session
+from helpers.opponent_threads import spawn_opponent_threads
 from helpers.permissions import bot_manager_button
 from utils import (
     calculate_pairings,
@@ -1403,6 +1404,16 @@ class PersistentView(discord.ui.View):
                                         .where(DraftSession.session_id == self.draft_session_id)
                                         .values(**update_values))
                 await db_session.commit()
+
+        # One scouting thread per opposing player, so each team has a dedicated
+        # place to pool reads on that opponent. Deliberately after the commit
+        # above: channel_ids and the 'pairings' stage are the draft's critical
+        # path, and threads are a nice-to-have. spawn_opponent_threads owns the
+        # guard (it never raises) and no-ops for the shared "Draft" channel --
+        # and so for swiss, whose only channel is "Draft".
+        await spawn_opponent_threads(
+            channel, team_name, team_a, team_b, session.sign_ups
+        )
 
         return channel.id
 


### PR DESCRIPTION
When the private `Red-Team-Chat` / `Blue-Team-Chat` channels are created, each team now gets one thread per player on the **opposing** team — a dedicated place to pool reads and matchup notes on that specific opponent.

```
#blue-team-chat-alpine-guide-90
  🧵 [TEST] _Italic_Name   — "Scouting thread for **…** (Red Team). Share reads, matchup notes, and what you saw them pick."
  🧵 [TEST] ~Strike~User   — same
  🧵 [TEST] Bot_User_One   — same
```

### Heads-up for review

**This diff touches `helpers/quiz_threads.py`, which is unrelated to scouting threads.** `THREAD_ARCHIVE_MINUTES` was previously defined there; rather than duplicate it or import it out of the quiz feature, it moves to `helpers/utils.py` (the shared helper module) and both features import it from there. That's the one-line change in `quiz_threads.py` and the six-line addition in `helpers/utils.py`.

### Where it hooks in

`create_team_channel` — the only place holding the live `TextChannel`. That covers both entry points (`create_rooms_pairings` and `recover_draft_channels`) without touching either call site, and it activates the `team_a` / `team_b` parameters, which every call site already passed and nothing had ever read.

It no-ops for the shared `"Draft"` channel, which is what structurally keeps swiss drafts (whose only channel is `"Draft"`) out of the feature — no `session_type` check to keep in sync.

### The parts worth a careful look

- **Thread names are a pure function of `(discord_id, sign_ups)`.** The skip-if-it-exists check is name-based, so a name that varied with roster order or with what's already in the channel would make a re-run duplicate everything.
- **Display names are not unique** (`sign_ups` stores `member.display_name`), so an id fragment is appended when two sign-ups collide — otherwise the second player silently gets no thread at all. `helpers/seating.py` already defends the same case on the Draftmancer side. Never observed in 3134 recorded drafts, but structurally possible.
- **Existing threads are read from the active cache *and* `archived_threads()`.** These auto-archive after 3 days, so the cache alone wouldn't see the helper's own earlier work. If that API call fails we degrade to the cached names rather than lose the run.
- **A thread counts the moment `create_thread` returns.** Treating a failed starter message as a failed creation would lose track of a thread that really exists, and re-create it next run.
- **The helper owns the never-raises guard**, not the call site — `create_team_channel` persists `channel_ids` and flips the session to the `'pairings'` stage, so nothing here may raise into that path. There's a test that fails if the guard is removed.

### Verification

- Full suite: **1274 passed, 9 skipped**
- `pipenv run pyrefly check`: **0 errors** (new module opted into `project-includes`)
- 28 thread tests, including a wiring test that fails if the call site is deleted or the rosters are swapped
- Driven end-to-end on the test server: threads appeared in the correct team channel, named for the opposing side, with the starter message — confirming the bot holds `create_public_threads`

### Known and deliberately deferred

The starter message interpolates the opponent's display name into plain message content, so it is unescaped and carries no `allowed_mentions` guard. A nickname containing markdown renders formatted, and `@everyone` as a nickname could ping. Deferred by design — it's part of a broader display-name rendering cleanup being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
