### PR TITLE
Stop a paid stake debt reading as a pre-existing one

### DIFF
--- a/services/debt_service.py
+++ b/services/debt_service.py
@@ -219,6 +219,64 @@ async def get_balance_with(
         return balance
 
 
+async def get_pair_position_around_draft(
+    guild_id: str,
+    session_id: str,
+    player_id: str,
+    counterparty_id: str,
+) -> tuple[int, int]:
+    """What this pair owed BEFORE this draft's stake debt, and what has been paid since.
+
+    Returns ``(pre_existing, settled_since)`` from ``player_id``'s perspective:
+    pre_existing negative means they already owed the counterparty; settled_since is
+    positive for tix they have paid off since this draft booked its debt.
+
+    The split is by row id, not by source: debt_ledger is append-only and its id is
+    monotonic, so "before this draft" is exactly "rows with a lower id than this draft's
+    own row for this pair". That is what makes the pre-existing figure honest.
+
+    The older ``get_balance_with(exclude_session_id=...)`` could not do this. It dropped
+    rows whose source_type was 'draft' AND source_id was this session — but an
+    auto-settlement paying that very debt is source_type 'settlement' with a uuid, so it
+    survived the filter and read back as a pre-existing counter-debt. The embed then
+    announced "Pre-existing: 60 tix ... Net total: 0 tix (debts canceled!)" when nobody
+    had owed anything beforehand and the loser had simply been debited.
+    """
+    async with db_session() as session:
+        pair = [
+            DebtLedger.guild_id == guild_id,
+            DebtLedger.player_id == player_id,
+            DebtLedger.counterparty_id == counterparty_id,
+            TIX_ONLY,
+        ]
+        cutoff = (await session.execute(
+            select(func.min(DebtLedger.id)).where(
+                *pair,
+                DebtLedger.source_type == 'draft',
+                DebtLedger.source_id == session_id,
+            ))).scalar()
+
+        if cutoff is None:
+            # The stake debt has not been written yet — this embed renders before
+            # create_debt_entries_from_stakes on the first pass. Everything on the
+            # books is therefore pre-existing, and nothing can have been paid against
+            # a debt that does not exist.
+            total = (await session.execute(
+                select(func.coalesce(func.sum(DebtLedger.amount), 0)).where(*pair))).scalar()
+            return int(total or 0), 0
+
+        pre_existing = (await session.execute(
+            select(func.coalesce(func.sum(DebtLedger.amount), 0)).where(
+                *pair, DebtLedger.id < cutoff))).scalar()
+        settled_since = (await session.execute(
+            select(func.coalesce(func.sum(DebtLedger.amount), 0)).where(
+                *pair,
+                DebtLedger.id > cutoff,
+                DebtLedger.source_type == 'settlement',
+            ))).scalar()
+        return int(pre_existing or 0), int(settled_since or 0)
+
+
 async def get_all_balances_for(
     guild_id: str,
     player_id: str

--- a/tests/test_bet_outcomes.py
+++ b/tests/test_bet_outcomes.py
@@ -465,3 +465,95 @@ class TestBetOutcomesDisplay:
         assert "Net total: 30 tix" in outcome
 
         # This would fail with the bug: "Pre-existing: 30 tix" and "Net total: 60 tix"
+
+
+class TestBetOutcomesAfterWalletSettlement:
+    """A stake debt paid out of the loser's wallet must not read as a pre-existing debt.
+
+    Auto-settlement writes its rows moments after the stake debt, in the same flow that
+    renders this embed. The old pre-existing figure excluded only the draft rows for this
+    session, so the settlement survived the filter and came back as a counter-debt: the
+    embed announced "Pre-existing: 30 tix ... Net total: 0 tix (debts canceled!)" when
+    nobody had owed anything beforehand and the loser had in fact just paid.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_debt_paid_from_the_wallet_is_not_reported_as_pre_existing(self, test_db):
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(
+                    session_id="settled_session", guild_id="test_guild",
+                    team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="settled_session",
+                                            player_a_id="alice", player_b_id="bob", amount=30))
+                await db_session.commit()
+
+        # the draft's stake debt: alice owes bob 30
+        await create_ledger_entries(
+            guild_id="test_guild", debtor_id="alice", creditor_id="bob", amount=30,
+            source_type="draft", source_id="settled_session")
+        # auto-settlement pays it straight back out of alice's wallet
+        await create_ledger_entries(
+            guild_id="test_guild", debtor_id="bob", creditor_id="alice", amount=30,
+            source_type="settlement", source_id="some-uuid")
+
+        outcome_lines, _ = await get_formatted_bet_outcomes(
+            "settled_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        outcome = outcome_lines[0]
+        assert "Pre-existing: 30" not in outcome, "nobody owed anything before this draft"
+        assert "canceled" not in outcome.lower(), (
+            "'canceled' means two debts offset each other; this one was PAID")
+        assert "This draft: 30 tix" in outcome
+        assert "aid" in outcome, "the line must say the money moved"
+        assert "Nothing left to settle" in outcome
+
+    @pytest.mark.asyncio
+    async def test_a_partly_paid_debt_shows_what_is_still_owed(self, test_db):
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(
+                    session_id="partial_session", guild_id="test_guild",
+                    team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="partial_session",
+                                            player_a_id="alice", player_b_id="bob", amount=100))
+                await db_session.commit()
+
+        await create_ledger_entries(
+            guild_id="test_guild", debtor_id="alice", creditor_id="bob", amount=100,
+            source_type="draft", source_id="partial_session")
+        await create_ledger_entries(   # alice's wallet only covered 60
+            guild_id="test_guild", debtor_id="bob", creditor_id="alice", amount=60,
+            source_type="settlement", source_id="some-uuid")
+
+        outcome_lines, _ = await get_formatted_bet_outcomes(
+            "partial_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        outcome = outcome_lines[0]
+        assert "This draft: 100 tix" in outcome
+        assert "60" in outcome, "the amount already paid must be visible"
+        assert "40" in outcome, "and what is still owed"
+        assert "Pre-existing: 60" not in outcome, "the payment is not a pre-existing debt"
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_mutual_offset_still_reads_as_cancelled(self, test_db):
+        """The word 'canceled' keeps its real meaning: two debts offsetting, no payment."""
+        await create_ledger_entries(
+            guild_id="test_guild", debtor_id="bob", creditor_id="alice", amount=30,
+            source_type="draft", source_id="older_session")
+
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(
+                    session_id="offset_session", guild_id="test_guild",
+                    team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="offset_session",
+                                            player_a_id="alice", player_b_id="bob", amount=30))
+                await db_session.commit()
+
+        outcome_lines, _ = await get_formatted_bet_outcomes(
+            "offset_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        outcome = outcome_lines[0]
+        assert "Pre-existing" in outcome, "this one really is a pre-existing debt"
+        assert "30" in outcome

--- a/utils.py
+++ b/utils.py
@@ -20,8 +20,8 @@ from cogs.leaderboard import create_leaderboard_embed, TimeframeView
 from draft_organization.tournament import Tournament
 from services.debt_service import (
     create_debt_entries_from_stakes,
-    get_balance_with,
     get_draft_debtors,
+    get_pair_position_around_draft,
 )
 from services.mtgo_resolution_service import settle_new_debts
 from debt_views import SettleDebtsView
@@ -2886,25 +2886,28 @@ async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
                 winner_name = sign_ups.get(winner_id, "Unknown")
                 loser_name = sign_ups.get(loser_id, "Unknown")
 
-                # Get pre-draft balance from loser's perspective
-                # Exclude entries from THIS session to get the true pre-existing balance
-                pre_draft_balance = await get_balance_with(
+                # Split the pair's history at this draft's own stake debt: what they
+                # owed BEFORE it, and what has been paid off since. Auto-settlement
+                # writes its rows moments later in this same flow, so anything that
+                # merely excludes the draft rows counts the payment as a pre-existing
+                # counter-debt (see get_pair_position_around_draft).
+                pre_draft_balance, settled_since = await get_pair_position_around_draft(
                     guild_id=draft_session.guild_id,
+                    session_id=session_id,
                     player_id=loser_id,
                     counterparty_id=winner_id,
-                    exclude_session_id=session_id
                 )
 
-                # Calculate new balance after this draft
-                # From loser's perspective: negative = loser owes winner
-                new_balance = pre_draft_balance - amount
+                # Where the pair stands now. From loser's perspective: negative = owes.
+                new_balance = pre_draft_balance - amount + settled_since
 
                 # Convert to absolute values for display
                 previous_debt = abs(pre_draft_balance)
                 new_debt = abs(new_balance)
 
                 # Add to unique outcomes list with balances
-                unique_pairs.append((loser_name, winner_name, amount, loser_id, winner_id, pre_draft_balance, new_balance))
+                unique_pairs.append((loser_name, winner_name, amount, loser_id, winner_id,
+                                     pre_draft_balance, new_balance, settled_since))
 
                 # Add to total stake
                 total_stake += amount
@@ -2914,12 +2917,33 @@ async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
 
             # Format for display with pre-existing debt, this draft, and net total
             formatted_lines = []
-            for loser_name, winner_name, amount, loser_id, winner_id, pre_draft_balance, new_balance in unique_pairs:
+            for (loser_name, winner_name, amount, loser_id, winner_id,
+                 pre_draft_balance, new_balance, settled_since) in unique_pairs:
                 previous_debt = abs(pre_draft_balance)
                 new_debt = abs(new_balance)
 
+                # Paid out of the loser's wallet. This has to come first: the
+                # net-based branches below would otherwise describe a debt that was
+                # PAID as one that was "canceled", which means something else entirely
+                # (two debts offsetting) and tells the player nothing moved.
+                if settled_since > 0:
+                    still_owed = abs(new_balance) if new_balance < 0 else 0
+                    lines = [
+                        (f"{loser_name} \u2192 {winner_name}: {amount} tix"
+                         if still_owed == 0 else f"{loser_name} owes {winner_name}:"),
+                        f"  This draft: {amount} tix",
+                    ]
+                    if previous_debt:
+                        lines.append(f"  Pre-existing: {previous_debt} tix")
+                    if still_owed == 0:
+                        lines.append(f"  Paid automatically from {loser_name}'s wallet")
+                        lines.append("  Nothing left to settle")
+                    else:
+                        lines.append(f"  Paid from wallet: {settled_since} tix")
+                        lines.append(f"  Still owed: {still_owed} tix")
+
                 # Determine net debtor/creditor based on new_balance sign
-                if new_balance < 0:
+                elif new_balance < 0:
                     # NET: Loser owes Winner (most common)
                     net_debtor = loser_name
                     net_creditor = winner_name


### PR DESCRIPTION
## The bug

Auto-settlement (shipped in #424) debits a losing player's wallet moments after the stake debt is written — in the same flow that renders the bet-outcomes embed. The embed's "pre-existing" figure came from `get_balance_with(exclude_session_id=...)`, which drops rows whose `source_type` is `'draft'` **and** `source_id` is this session. A settlement is `source_type='settlement'` with a uuid, so it survived the filter and came back as a pre-existing counter-debt:

```
Debt between Alice and Bob:
  This draft: 60 tix
  Pre-existing: 60 tix
  Net total: 0 tix (debts canceled!)
```

Every clause is false. Nobody owed anything beforehand, and the debt was not *canceled* — it was **paid**. Worse, it tells a player who has just been debited that they're square by coincidence, rather than that money moved.

This is live for any staked draft where a loser had wallet funds.

## Why the old filter couldn't work

It was filtering on the wrong axis. **Provenance** can't separate "a settlement that paid *this* debt" from "a settlement that paid an older one" — both are `settlement` with a uuid.

**Position in the log** can. `debt_ledger` is append-only with a monotonic id, so "before this draft" is exactly *"rows with a lower id than this draft's own row for this pair"*. `get_pair_position_around_draft` splits there and returns `(pre_existing, settled_since)` — no new column, and no plumbing through the settlement path.

## Wording

`Paid` vs `Pre-existing` is the distinction that matters: money moved, versus debts offsetting. **"Canceled" now means only the latter.**

| case | rendering |
|---|---|
| Fully paid | `Alice → Bob: 30 tix` · This draft: 30 · **Paid automatically from Alice's wallet** · **Nothing left to settle** |
| Partly paid | `Alice owes Bob:` · This draft: 100 · **Paid from wallet: 60** · **Still owed: 40** |
| Paid + real prior debt | This draft: 100 · Pre-existing: 20 · Paid from wallet: 60 · Still owed: 60 |
| Unpaid | unchanged |
| Genuine mutual offset | unchanged — still *"debts canceled!"* |

*"Nothing left to settle"* is the line that stops someone paying twice, which is the actual harm today.

The paid branch is checked **before** every net-based branch: a fully paid debt nets to zero and would otherwise fall straight into "canceled" — the same bug by another route.

## Verification

- 3 tests written RED first; the 7 existing bet-outcome tests pass unchanged
- Every case rendered and read end-to-end, not just asserted on fragments
- Full suite: **1277 passed**, 9 skipped, pytest exit code 0
- `pipenv run pyrefly check`: **0 errors**

## Scope

This is the bug-fix half of the embed work. The polish — reordering so settlement runs before the embed's closing fields, a "settled straight from wallets" summary field, and showing the how-to only when someone still owes — remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLERVw2GEcW92iWRuwWk3k