### PR TITLE
Only explain how to pay when somebody still has to

### DIFF
--- a/tests/test_bet_outcomes.py
+++ b/tests/test_bet_outcomes.py
@@ -75,7 +75,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Bob's team wins, so Alice loses)
         sign_ups = {"alice": "Alice", "bob": "Bob"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_1",
             sign_ups,
             ["bob"]  # winning_team_ids
@@ -133,7 +133,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Bob wins again, Alice loses again)
         sign_ups = {"alice": "Alice", "bob": "Bob"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_2",
             sign_ups,
             ["bob"]
@@ -191,7 +191,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Alice wins, Bob loses)
         sign_ups = {"alice": "Alice", "bob": "Bob"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_3",
             sign_ups,
             ["alice"]  # Alice's team wins
@@ -250,7 +250,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Alice wins, Bob loses)
         sign_ups = {"alice": "Alice", "bob": "Bob"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_4",
             sign_ups,
             ["alice"]  # Alice's team wins
@@ -309,7 +309,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Alice wins, Bob loses 30)
         sign_ups = {"alice": "Alice", "bob": "Bob"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_5",
             sign_ups,
             ["alice"]  # Alice's team wins
@@ -376,7 +376,7 @@ class TestBetOutcomesDisplay:
 
         # Call the function (Bob and Dave win)
         sign_ups = {"alice": "Alice", "bob": "Bob", "charlie": "Charlie", "dave": "Dave"}
-        outcome_lines, total = await get_formatted_bet_outcomes(
+        outcome_lines, total, _owes = await get_formatted_bet_outcomes(
             "test_session_6",
             sign_ups,
             ["bob", "dave"]  # Team B wins
@@ -432,7 +432,7 @@ class TestBetOutcomesDisplay:
         winning_team = ["bob"]
 
         # Call 1: Before debt entries are created
-        outcome_lines_1, total_1 = await get_formatted_bet_outcomes(
+        outcome_lines_1, total_1, _o1 = await get_formatted_bet_outcomes(
             "test_session_idempotent",
             sign_ups,
             winning_team
@@ -446,7 +446,7 @@ class TestBetOutcomesDisplay:
         )
 
         # Call 2: After debt entries are created
-        outcome_lines_2, total_2 = await get_formatted_bet_outcomes(
+        outcome_lines_2, total_2, _o2 = await get_formatted_bet_outcomes(
             "test_session_idempotent",
             sign_ups,
             winning_team
@@ -497,7 +497,7 @@ class TestBetOutcomesAfterWalletSettlement:
             guild_id="test_guild", debtor_id="bob", creditor_id="alice", amount=30,
             source_type="settlement", source_id="some-uuid")
 
-        outcome_lines, _ = await get_formatted_bet_outcomes(
+        outcome_lines, _, _owes = await get_formatted_bet_outcomes(
             "settled_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
 
         outcome = outcome_lines[0]
@@ -526,7 +526,7 @@ class TestBetOutcomesAfterWalletSettlement:
             guild_id="test_guild", debtor_id="bob", creditor_id="alice", amount=60,
             source_type="settlement", source_id="some-uuid")
 
-        outcome_lines, _ = await get_formatted_bet_outcomes(
+        outcome_lines, _, _owes = await get_formatted_bet_outcomes(
             "partial_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
 
         outcome = outcome_lines[0]
@@ -551,9 +551,78 @@ class TestBetOutcomesAfterWalletSettlement:
                                             player_a_id="alice", player_b_id="bob", amount=30))
                 await db_session.commit()
 
-        outcome_lines, _ = await get_formatted_bet_outcomes(
+        outcome_lines, _, _owes = await get_formatted_bet_outcomes(
             "offset_session", {"alice": "Alice", "bob": "Bob"}, ["bob"])
 
         outcome = outcome_lines[0]
         assert "Pre-existing" in outcome, "this one really is a pre-existing debt"
         assert "30" in outcome
+
+
+class TestOutcomesReportWhetherAnyoneStillOwes:
+    """The how-to-pay panel is driven by the same computation that writes the lines.
+
+    Deriving it separately (a second balance query, or a check run before this render's
+    settlement) lets the two disagree: the embed can say "Nothing left to settle" while
+    still printing instructions for paying, or hide the instructions from someone who
+    genuinely owes. One computation, one answer.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nobody_owes_once_the_wallet_covered_it(self, test_db):
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(session_id="paid_s", guild_id="test_guild",
+                                            team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="paid_s", player_a_id="alice",
+                                            player_b_id="bob", amount=30))
+                await db_session.commit()
+        await create_ledger_entries(guild_id="test_guild", debtor_id="alice",
+                                    creditor_id="bob", amount=30,
+                                    source_type="draft", source_id="paid_s")
+        await create_ledger_entries(guild_id="test_guild", debtor_id="bob",
+                                    creditor_id="alice", amount=30,
+                                    source_type="settlement", source_id="u1")
+
+        lines, _total, still_owed = await get_formatted_bet_outcomes(
+            "paid_s", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        assert still_owed is False, "the wallet covered it; nothing left to pay"
+        assert "Nothing left to settle" in lines[0], "and the line must agree"
+
+    @pytest.mark.asyncio
+    async def test_someone_still_owes_when_the_wallet_fell_short(self, test_db):
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(session_id="part_s", guild_id="test_guild",
+                                            team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="part_s", player_a_id="alice",
+                                            player_b_id="bob", amount=100))
+                await db_session.commit()
+        await create_ledger_entries(guild_id="test_guild", debtor_id="alice",
+                                    creditor_id="bob", amount=100,
+                                    source_type="draft", source_id="part_s")
+        await create_ledger_entries(guild_id="test_guild", debtor_id="bob",
+                                    creditor_id="alice", amount=60,
+                                    source_type="settlement", source_id="u1")
+
+        lines, _total, still_owed = await get_formatted_bet_outcomes(
+            "part_s", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        assert still_owed is True, "40 tix are still owed"
+        assert "Still owed: 40 tix" in lines[0]
+
+    @pytest.mark.asyncio
+    async def test_an_unsettled_draft_still_owes(self, test_db):
+        async with AsyncSessionLocal() as db_session:
+            async with db_session.begin():
+                db_session.add(DraftSession(session_id="raw_s", guild_id="test_guild",
+                                            team_a=["alice"], team_b=["bob"]))
+                db_session.add(StakePairing(session_id="raw_s", player_a_id="alice",
+                                            player_b_id="bob", amount=30))
+                await db_session.commit()
+
+        _lines, _total, still_owed = await get_formatted_bet_outcomes(
+            "raw_s", {"alice": "Alice", "bob": "Bob"}, ["bob"])
+
+        assert still_owed is True

--- a/utils.py
+++ b/utils.py
@@ -604,7 +604,7 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                         winning_team = draft_session.team_a if team_a_wins > team_b_wins else draft_session.team_b
 
                         # Get bet outcome lines
-                        outcome_lines, outcome_total = await get_formatted_bet_outcomes(
+                        outcome_lines, outcome_total, anyone_still_owes = await get_formatted_bet_outcomes(
                             draft_session_id,
                             draft_session.sign_ups,
                             winning_team
@@ -621,9 +621,13 @@ async def generate_draft_summary_embed(bot, draft_session_id):
                                 color=discord_color  # Match main embed color
                             )
                             bet_embed.set_footer(text=f"Total bets settled: {outcome_total} tix")
-                            # These outcomes become debt ledger entries just below, so
-                            # this is where a loser first learns they owe someone.
-                            add_wallet_howto(bet_embed, draft_session.guild_id)
+                            # Only explain how to pay if somebody still has to. A loser
+                            # whose wallet already covered it has nothing left to do, and
+                            # the panel would contradict both the line above it and the
+                            # DM they are about to get. The flag comes from the same pass
+                            # that wrote those lines, so the two cannot disagree.
+                            if anyone_still_owes:
+                                add_wallet_howto(bet_embed, draft_session.guild_id)
 
                             # Create the debt ledger entries these outcomes imply, then
                             # draw them against the losers' wallets: a debt landing on
@@ -2851,7 +2855,7 @@ async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
             draft_session = draft_result.scalars().first()
             
             if not draft_session:
-                return [], 0
+                return [], 0, False
 
             # Get all stake pairings for this session
             pairing_stmt = select(StakePairing).where(StakePairing.session_id == session_id)
@@ -2915,12 +2919,19 @@ async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
             # Sort by amount (highest first)
             unique_pairs.sort(key=lambda x: x[2], reverse=True)
 
-            # Format for display with pre-existing debt, this draft, and net total
+            # Format for display with pre-existing debt, this draft, and net total.
+            # anyone_still_owes rides along with the lines deliberately: the caller
+            # uses it to decide whether to print the how-to-pay panel, and deriving
+            # that separately is how the panel and the lines come to contradict each
+            # other -- "Nothing left to settle" printed above instructions for paying.
             formatted_lines = []
+            anyone_still_owes = False
             for (loser_name, winner_name, amount, loser_id, winner_id,
                  pre_draft_balance, new_balance, settled_since) in unique_pairs:
                 previous_debt = abs(pre_draft_balance)
                 new_debt = abs(new_balance)
+                if new_balance != 0:
+                    anyone_still_owes = True
 
                 # Paid out of the loser's wallet. This has to come first: the
                 # net-based branches below would otherwise describe a debt that was
@@ -2999,7 +3010,7 @@ async def get_formatted_bet_outcomes(session_id, sign_ups, winning_team_ids):
                 # Join the 4 lines into a single multi-line string
                 formatted_lines.append("\n".join(lines))
 
-            return formatted_lines, total_stake
+            return formatted_lines, total_stake, anyone_still_owes
 
 
 async def check_inactive_players_task(bot):


### PR DESCRIPTION
> Stacked on #428 — review that one first.

## The problem

The bet-outcomes embed appended the "💡 Paying with tix" panel unconditionally. After #424 shipped auto-debit, a loser whose wallet had just been emptied read instructions for paying a debt that was already settled — contradicting both the line directly above it (*"Nothing left to settle"*) and the DM arriving moments later.

## The fix

Gate the panel on whether anyone still owes:

```python
if anyone_still_owes:
    add_wallet_howto(bet_embed, draft_session.guild_id)
```

The flag comes out of **the same pass that writes the lines** — `get_formatted_bet_outcomes` already computes each pair's net position, so it returns it rather than the caller asking a second time. That's what makes the panel and the lines structurally incapable of disagreeing.

It's also scoped to *this draft's* pairs rather than the player's whole book, which is the more accurate question: the panel sits under this draft's outcomes.

## Two alternatives, tried and rejected

**Gating on `get_draft_debtors` + a balance read.** That reads the ledger *before* this render's settlement, so on the first render it finds no debtors yet and hides the panel from people who genuinely owe.

**Reordering settlement above the outcome computation** to make the above work. That's compensating for a flag taken from the wrong place — and it moves money earlier in a render path for a display reason, which is the wrong trade.

## Not included

The original plan had a "💸 Settled straight from wallets" summary field. Left out deliberately: the per-pair lines from #428 already say *"Paid automatically from Alice's wallet"*, so a summary would restate it. Easy to add later if an at-a-glance total turns out to be wanted.

## Verification

- 3 tests written RED first (`not enough values to unpack`); the 10 existing bet-outcome tests pass unchanged
- Full suite: **1280 passed**, 9 skipped, pytest exit code 0
- `pipenv run pyrefly check`: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLERVw2GEcW92iWRuwWk3k