### PR TITLE
DraftBot: stop a finished draft being re-seated and ready-checked

### DIFF
--- a/services/draft_setup_manager.py
+++ b/services/draft_setup_manager.py
@@ -244,6 +244,11 @@ class DraftSetupManager:
         self.post_timeout_ready_users = set()
         self.draft_channel_id = None  # Will be populated from database
         self.drafting = False
+        # `drafting` is False both before a draft starts and after it ends, so it
+        # cannot answer "is this session still on its way to a draft". This says so
+        # explicitly: set when Draftmancer reports the draft over, cleared if one
+        # starts again, and consulted anywhere the answer must not be "not yet".
+        self.draft_finished = False
         self.draftPaused = False
         self.draft_cancelled = False
         self.removing_unexpected_user = False
@@ -297,6 +302,7 @@ class DraftSetupManager:
     async def _on_end_draft(self, data=None):
         logger.info(f"Draft ended event received: {data}")
         self.drafting = False
+        self.draft_finished = True
         self.draftPaused = False
         # A draft can end with someone still disconnected — /scrap, or the rest of the
         # table replacing them with bots and playing on. "Please reconnect" after that
@@ -470,10 +476,14 @@ class DraftSetupManager:
         # remaining move was /mutiny. Seen in prod 2026-08-14 22:54.
         #
         # Two limits on it. Only for someone we actually seated, so an unseated extra
-        # wandering off cannot throw away a good seating. And only before the draft is
-        # under way — check_session_stage_and_organize refuses to seat a live draft,
-        # but the record of who we seated is still worth keeping accurate rather than
-        # discarding the moment a mid-draft connection wobbles.
+        # wandering off cannot throw away a good seating. And only while the session is
+        # still on its way to a draft: not once one is under way, and not once one has
+        # FINISHED. The table emptying after a draft is the normal end of every draft,
+        # and reading it as a stale seating restarted a dead lobby — cleared the flag,
+        # re-sent setSeating to the finished session, then ready-checked and DM'd
+        # everyone (prod 2026-08-19 10:51, eight seconds after "Draft completed
+        # naturally"). `drafting` alone cannot see that: it is False before the draft
+        # and False after it.
         #
         # Asks "is anyone we seated missing" rather than "did the count drop". The two
         # are not the same: one seated player leaving while a newcomer arrives in the
@@ -482,6 +492,7 @@ class DraftSetupManager:
         # table's size, so computing it on every event costs nothing worth guarding.
         if (self.seating_order_set
                 and not self.drafting
+                and not self.draft_finished
                 and not self.draftPaused
                 and not self._should_disconnect):
             present_ids = {user.get('userID') for user in non_bot_users}
@@ -1901,6 +1912,7 @@ class DraftSetupManager:
                             await channel.send(f"Error starting draft: {response['error']}")
                 else:
                     self.drafting = True
+                    self.draft_finished = False
                     self.logger.info("Draft started successfully")
             except asyncio.TimeoutError:
                 self.logger.warning("Timeout waiting for draft start response")
@@ -1919,9 +1931,10 @@ class DraftSetupManager:
         """
         if self.seating_order_set or self.seating_attempts >= 4:
             return  # Already set or max attempts reached
-        if self.drafting or self.draftPaused or self._should_disconnect:
+        if self.drafting or self.draft_finished or self.draftPaused or self._should_disconnect:
             self.logger.info(
-                "Not organizing seating: the draft is already under way or shutting down"
+                "Not organizing seating: the draft is already under way, finished, "
+                "or shutting down"
             )
             return
 

--- a/tests/test_reseat_after_leave.py
+++ b/tests/test_reseat_after_leave.py
@@ -272,3 +272,81 @@ async def test_flapping_cannot_reseat_without_limit():
         await mgr._on_session_users(_users([n for n in SEATS if n != "gregg"]))
 
     assert mgr.seating_attempts == 3, "the attempt cap must survive a departure"
+
+
+@pytest.mark.asyncio
+async def test_a_finished_draft_is_not_reseated_when_the_table_empties():
+    """From a live incident (2026-08-19 10:51, session 316309465618055170-1787146235).
+
+    The draft ended at 10:51:50. Eight seconds later a seated player closed
+    Draftmancer — which is simply what finishing looks like — and the bot cleared
+    the seating, re-sent setSeating to the finished session, started a ready check
+    and DM'd five people. It timed out 90 seconds later in front of everyone.
+
+    `drafting` is False both before a draft starts and after it ends, so the guard
+    added with this block could not tell "not yet" from "all over"; the whole table
+    leaving after a draft is the one case guaranteed to hit it.
+    """
+    mgr = _manager(SEATS)
+    _already_seated(mgr)
+    mgr.guild_id = "123"
+    mgr.draft_channel_id = "456"
+
+    attempts = []
+
+    async def fake_attempt(desired_seating_order):
+        attempts.append(list(desired_seating_order))
+
+    mgr.attempt_seating_order = fake_attempt
+
+    bot = MagicMock()
+    bot.get_guild.return_value = None      # take the cheap branch; rooms aren't the point
+    bot.get_channel.return_value = None
+
+    with patch("services.draft_setup_manager.get_bot", return_value=bot), \
+         patch("services.draft_setup_manager.DRAFT_LOG_WAIT_ATTEMPTS", 0), \
+         patch("services.draft_setup_manager.DraftSession.get_by_session_id",
+               new=AsyncMock(return_value=_db_session(SEATS))):
+        await mgr._on_end_draft()
+        assert mgr.drafting is False, "the draft is over; this is the state that misleads"
+
+        # everyone drifts out of the finished session, one payload at a time
+        await mgr._on_session_users(_users([n for n in SEATS if n != "gregg"]))
+        await mgr._on_session_users(_users(SEATS[:2]))
+
+    assert not attempts, "a finished draft must never be re-seated"
+    assert mgr.seating_order_set is True, (
+        "the seating of a finished draft is history, not something to invalidate"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_seating_machinery_itself_refuses_to_seat_a_finished_draft():
+    """The invariant belongs to check_session_stage_and_organize, the only route to
+    emit('setSeating') — a future caller must not be able to re-derive it wrongly.
+
+    Mirrors the live-draft test above: the second half is what stops the first half
+    being vacuous.
+    """
+    mgr = _manager(SEATS)
+    _already_seated(mgr)
+    mgr.seating_order_set = False   # something invalidated the seating
+    mgr.draft_finished = True       # ...but the draft is already over
+    mgr._get_draft_channel = AsyncMock(return_value=None)
+
+    attempts = []
+
+    async def fake_attempt(desired_seating_order):
+        attempts.append(list(desired_seating_order))
+
+    mgr.attempt_seating_order = fake_attempt
+
+    with patch("services.draft_setup_manager.DraftSession.get_by_session_id",
+               new=AsyncMock(return_value=_db_session(SEATS))):
+        await mgr.check_session_stage_and_organize()
+        assert not attempts, "seating a draft that has finished restarts a dead lobby"
+
+        mgr.draft_finished = False
+        await mgr.check_session_stage_and_organize()
+
+    assert attempts, "with the draft not finished the same call must seat"


### PR DESCRIPTION
Fixes a live regression: a **finished** draft gets re-seated and ready-checked, roughly eight seconds after it ends.

Reported from prod this morning — the table saw a ready check fire, time out in front of everyone, restart itself, and keep going four minutes after the draft was already over. Five players got DM'd about a draft that no longer existed.

## What happened

Session `316309465618055170-1787146235`, from the production log:

| Time | Event |
|---|---|
| 10:51:50 | `_on_end_draft` — **"Draft completed naturally"**, sets `drafting = False` |
| 10:51:58 | A seated player closes Draftmancer → seating treated as stale → `seating_order_set = False` |
| 10:51:59 | `check_session_stage_and_organize` proceeds — same blind spot |
| 10:52:14 | **Re-sends `setSeating`** to the finished session |
| 10:52:15 | Starts a ready check |
| 10:52:16 | DMs five players |
| 10:53:48 | Times out |
| 10:55:47 | Auto-restarts, invalidated at 10:55:51 when someone leaves |

## Root cause

`self.drafting` is `False` in two different situations the code treats as one: **before** a draft starts, and **after** `_on_end_draft` sets it back.

The re-seat-on-leave path added in 099cdbd guards on `not self.drafting`. Its own comment says what it meant —

> "And only before the draft is under way"

— but a finished draft is also "not under way". The trigger is the most ordinary thing there is: someone closing Draftmancer once the draft is done, which is what the end of every draft looks like.

## The fix

Records the state that was missing: `draft_finished`, set when Draftmancer reports the draft over and cleared if one starts again (so it cannot latch). Both guards consult it — the re-seat path, and `check_session_stage_and_organize` itself, since that is the only route to `emit('setSeating')` and a future caller must not be able to re-derive the rule wrongly.

## Verification

**Unit** — two failing-first tests from the incident, alongside the nine existing ones in that file (which still pass, so the original 099cdbd fix is intact):
- `test_a_finished_draft_is_not_reseated_when_the_table_empties` drives the real `_on_end_draft`, then empties the table
- `test_the_seating_machinery_itself_refuses_to_seat_a_finished_draft` mirrors the existing live-draft guard test, with a second half so the first is not vacuous

**End-to-end** — real manager, real DB, real Discord test channel, with only the Draftmancer socket stubbed and the two events handed to the manager directly. Run both ways, because a green E2E that cannot fail proves nothing:

| | `setSeating` / `readyCheck` emits | New Discord messages |
|---|---|---|
| With the fix | none | 1 — "Rooms and Pairings have been created!" |
| Guards reverted | `['setSeating', 'setSeating', 'readyCheck']` | 4 — status update, "Readycheck in progress: 0/6", timeout notice |

Reverted, it reproduced the incident exactly, DMs included. Note the reverted run emits `setSeating` **twice** — the re-seat, then `verify_seating_order`'s reset — so a finished session was being reordered twice before anyone was pinged.

**1310 passed, 9 skipped** on the full suite, rebased onto current main.

## Not a bug, for the record

The accompanying "Readycheck will timeout 11 minutes ago" is not a defect. `draft_setup_manager.py:1570` renders `<t:{ts}:R>`, which Discord resolves relative to *view* time — a message posted with a 90-second deadline naturally reads "11 minutes ago" when you scroll past it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfvS8bPfbohC1btuvjGJm7
